### PR TITLE
chore(lint): zero 19 errors + gate npm run lint in CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Build package
         run: npm run build
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,19 @@ export default ts.config(
     js.configs.recommended,
     ...ts.configs.recommended,
     {
+        // Arquivos de configuracao em CommonJS (.cjs) — Storybook, PostCSS.
+        // Permite require/module/__dirname/process e desliga a regra
+        // typescript-eslint que so faz sentido em modulos ESM.
+        files: ["**/*.cjs"],
+        languageOptions: {
+            sourceType: "commonjs",
+            globals: { ...globals.node },
+        },
+        rules: {
+            "@typescript-eslint/no-require-imports": "off",
+        },
+    },
+    {
         files: ["ui_kit/**/*.{ts,tsx}", ".storybook/**/*.{ts,tsx}"],
         languageOptions: {
             ecmaVersion: "latest",

--- a/ui_kit/components/alert/index.tsx
+++ b/ui_kit/components/alert/index.tsx
@@ -35,12 +35,14 @@ Alert.displayName = "Alert"
 const AlertTitle = React.forwardRef<
     HTMLParagraphElement,
     React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
     <h5
         ref={ref}
         className={cn("mb-1 font-medium leading-none tracking-tight", className)}
         {...props}
-    />
+    >
+        {children}
+    </h5>
 ))
 AlertTitle.displayName = "AlertTitle"
 

--- a/ui_kit/components/avatar/index.tsx
+++ b/ui_kit/components/avatar/index.tsx
@@ -59,8 +59,7 @@ Avatar.displayName = "Avatar";
 
 /* ───────── Image ───────── */
 
-export interface AvatarImageProps
-  extends React.ImgHTMLAttributes<HTMLImageElement> {}
+export type AvatarImageProps = React.ImgHTMLAttributes<HTMLImageElement>;
 
 /**
  * AvatarImage — imagem do avatar com error state.

--- a/ui_kit/components/chip/Chip.stories.tsx
+++ b/ui_kit/components/chip/Chip.stories.tsx
@@ -50,7 +50,8 @@ export const FilterGroup: Story = {
     const toggle = (id: string) =>
       setActive((prev) => {
         const next = new Set(prev);
-        next.has(id) ? next.delete(id) : next.add(id);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
         return next;
       });
     const items = [

--- a/ui_kit/components/combobox/index.tsx
+++ b/ui_kit/components/combobox/index.tsx
@@ -269,6 +269,12 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
                 tabIndex={-1}
                 aria-label="Limpar seleção"
                 onClick={clear}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    clear(e as unknown as React.MouseEvent);
+                  }
+                }}
                 onMouseDown={(e) => e.preventDefault()}
                 className="inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded-full text-fg-muted hover:bg-muted hover:text-fg"
               >

--- a/ui_kit/components/date-picker/DatePicker.stories.tsx
+++ b/ui_kit/components/date-picker/DatePicker.stories.tsx
@@ -42,7 +42,7 @@ export const WithDefaultValue: Story = {
 };
 
 export const Controlled: Story = {
-  render: () => {
+  render: function ControlledStory() {
     const [date, setDate] = useState<Date | null>(new Date(2025, 0, 7));
     return (
       <div className="flex flex-col gap-2">

--- a/ui_kit/components/date-picker/date-picker.test.tsx
+++ b/ui_kit/components/date-picker/date-picker.test.tsx
@@ -91,11 +91,15 @@ describe("DatePicker", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("invalid aplica aria-invalid", () => {
+  it("invalid aplica data-invalid", () => {
+    // Lex jsx-a11y/role-supports-aria-props proíbe aria-invalid em role=button
+    // (implícito em <button>); o trigger usa data-invalid como hook de estilo
+    // e o aviso a11y para invalid fica no Field/Form layer (aria-describedby
+    // apontando para a mensagem de erro).
     render(<DatePicker invalid />);
     expect(
       screen.getByRole("button", { name: "Selecionar data" }),
-    ).toHaveAttribute("aria-invalid", "true");
+    ).toHaveAttribute("data-invalid", "true");
   });
 
   it("name renderiza input hidden em formato ISO", () => {

--- a/ui_kit/components/date-picker/index.tsx
+++ b/ui_kit/components/date-picker/index.tsx
@@ -185,7 +185,7 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
             type="button"
             aria-haspopup="dialog"
             aria-label={ariaLabel}
-            aria-invalid={invalid || undefined}
+            data-invalid={invalid || undefined}
             disabled={disabled}
             className={cn(triggerVariants({ size }), className)}
           >
@@ -209,6 +209,12 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
                 tabIndex={-1}
                 aria-label="Limpar data"
                 onClick={clear}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    clear(e as unknown as React.MouseEvent);
+                  }
+                }}
                 onMouseDown={(e) => e.preventDefault()}
                 className="inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded-full text-fg-muted hover:bg-muted hover:text-fg"
               >

--- a/ui_kit/components/file-upload/FileUpload.stories.tsx
+++ b/ui_kit/components/file-upload/FileUpload.stories.tsx
@@ -207,7 +207,7 @@ export const ButtonWithUploader: Story = {
  * onReject custom: receba as rejeições e mostre fora da lista interna.
  */
 export const RejectCallback: Story = {
-  render: () => {
+  render: function RejectCallbackStory() {
     const [rejections, setRejections] = useState<FileRejection[]>([]);
     return (
       <div className="flex flex-col gap-3">

--- a/ui_kit/components/form-layout/form-layout.test.tsx
+++ b/ui_kit/components/form-layout/form-layout.test.tsx
@@ -123,7 +123,7 @@ describe("FormLayout.Section", () => {
   it("aside aparece no canto da seção", () => {
     render(
       <FormLayout>
-        <FormLayout.Section title="X" aside={<a href="#">link</a>}>
+        <FormLayout.Section title="X" aside={<a href="/aside-link">link</a>}>
           <div>y</div>
         </FormLayout.Section>
       </FormLayout>,

--- a/ui_kit/components/navbar/navbar.tsx
+++ b/ui_kit/components/navbar/navbar.tsx
@@ -236,7 +236,7 @@ function NavbarInternal({
                                 className="min-h-8 min-w-8 h-8 w-8 rounded-full object-cover"
                             />
                         </When>
-                        <When condition={!Boolean(settings.user?.avatar)}>
+                        <When condition={!settings.user?.avatar}>
                             <div className="min-h-8 min-w-8 h-8 w-8 flex items-center justify-center rounded-full bg-brand-fgLight/20 text-brand-fgLight text-sm font-semibold">
                                 {settings.user?.initials || settings.user?.name?.split(' ').map(n => n[0]).join('').toUpperCase()}
                             </div>

--- a/ui_kit/components/pagination/index.tsx
+++ b/ui_kit/components/pagination/index.tsx
@@ -47,11 +47,18 @@ const PaginationLink = ({
   size = "default",
   children,
   onClick,
+  href,
   ...props
 }: PaginationLinkProps) => (
   <a
     aria-current={isActive ? "page" : undefined}
     aria-disabled={disabled}
+    href={href}
+    /* role="button" quando o consumidor nao passa href — o componente vira
+       interativo apenas via onClick. Quando ha href, <a> e interativo
+       nativamente. */
+    role={!href ? "button" : undefined}
+    tabIndex={disabled ? -1 : 0}
     className={cn(
       buttonVariants({
         variant: isActive ? "outline" : "ghost",
@@ -64,6 +71,12 @@ const PaginationLink = ({
       className
     )}
     onClick={disabled ? (e) => e.preventDefault() : onClick}
+    onKeyDown={(e) => {
+      if ((e.key === "Enter" || e.key === " ") && !disabled && onClick) {
+        e.preventDefault();
+        onClick(e as unknown as React.MouseEvent<HTMLAnchorElement>);
+      }
+    }}
     {...props}
   >
     {children}

--- a/ui_kit/components/typography/index.tsx
+++ b/ui_kit/components/typography/index.tsx
@@ -258,7 +258,7 @@ interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 }
 
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-    ({ className, variant = "default", ...props }, ref) => (
+    ({ className, variant = "default", children, ...props }, ref) => (
         <a
             ref={ref}
             className={cn(
@@ -267,7 +267,9 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
                 className
             )}
             {...props}
-        />
+        >
+            {children}
+        </a>
     )
 );
 Link.displayName = "Link";


### PR DESCRIPTION
## Sumário

Fecha Plan #123 (sub-issue de Tech Task #120). Zera os **19 erros de ESLint** pré-existentes no repositório e tranca o gate no CI, fazendo a checkbox "lint verde" da DoD passar honestamente em todos os reviews v0.1.0 daqui pra frente.

Closes #123

## Mudanças (1 commit, 14 arquivos)

### Batch 1 — Config files (6 erros)

| Arquivo | Erros |
|---|---:|
| `.storybook/main.cjs` | 5 |
| `postcss.config.cjs` | 1 |

Override em `eslint.config.mjs` para `*.cjs` permitindo CommonJS globals (`require`, `module`, `process`, `__dirname`) e desligando `@typescript-eslint/no-require-imports` no escopo.

### Batch 2 — Component code (13 erros, 11 arquivos)

| Arquivo | Regra | Fix |
|---|---|---|
| `alert/index.tsx` | `heading-has-content` | h5 renderiza `{children}` explicito |
| `avatar/index.tsx` | `no-empty-object-type` | `interface AvatarImageProps extends X {}` → `type AvatarImageProps = X` |
| `chip/Chip.stories.tsx` | `no-unused-expressions` | ternary como statement → if/else |
| `combobox/index.tsx` | `click-events-have-key-events` | `<span onClick>` ganha `onKeyDown` (Enter/Space) |
| `date-picker/DatePicker.stories.tsx` | `rules-of-hooks` | `render: () => ...` → `render: function ControlledStory() ...` |
| `date-picker/index.tsx` | `role-supports-aria-props` | `aria-invalid` no trigger button (não suportado em role=button) → `data-invalid` + test atualizado |
| `date-picker/index.tsx` | `click-events-have-key-events` | clear button ganha `onKeyDown` |
| `file-upload/FileUpload.stories.tsx` | `rules-of-hooks` | render → named function `RejectCallbackStory` |
| `form-layout/form-layout.test.tsx` | `anchor-is-valid` | `href="#"` → `href="/aside-link"` |
| `navbar/navbar.tsx` | `no-extra-boolean-cast` | `!Boolean(x)` → `!x` |
| `pagination/index.tsx` | `click-events` + `no-static-element-interactions` | mantém `<a>` (preserva API com href), adiciona `role` condicional, `tabIndex`, `onKeyDown` |
| `typography/index.tsx` | `anchor-has-content` | `<a>` renderiza `{children}` explicito |

### Batch 3 — CI gate

`.github/workflows/pull-request.yml`: adiciona step `Lint` entre Install e Build. **Regressão de lint passa a bloquear merge.**

## DoD do Plan #123

- [x] `npm run lint` reporta **0 erros**
- [x] `npm run typecheck` verde
- [x] `npm run test` 385/385 verde
- [x] `npm run build` verde (329.3 kB / 84.9 kB gzipped)
- [x] `npm run docs:build` 19 páginas verde
- [x] CI roda `npm run lint` em todo PR
- [x] PR fecha esta issue via `Closes #123`
- [x] Warnings remanescentes (27) catalogados — todos `no-explicit-any`, `exhaustive-deps`, `no-unused-vars`. Ficam para Tech Task futura de tipagem estrita.

## Test plan

- [ ] CI verde (Build and Test Package — agora inclui `npm run lint`)
- [ ] Storybook do DatePicker continua funcionando — note: `data-invalid` substitui `aria-invalid` no trigger; anúncio acessível de "invalid" agora é responsabilidade do FormLayout (via `aria-describedby` apontando para a mensagem de erro)
- [ ] Pagination: `<a>` ainda aceita `href`; quando consumidor não passa, vira `role="button"` interativo via teclado

## Notas

**DatePicker `aria-invalid` → `data-invalid`**: per `lex-frontend-accessibility`, o trigger button do DatePicker (com role=button implícito) não suporta `aria-invalid`. O atributo virou `data-invalid` (hook de CSS apenas). A semântica de "campo inválido" deve ser comunicada via `aria-describedby` apontando para a mensagem de erro no FormLayout — fica como referência arquitetural para Field/Form composition.

**Pagination**: API preservada (`<a>` com `href` opcional). Quando há `href` é link nativo; quando não há, role muda para "button" com `tabIndex` + `onKeyDown` para acessibilidade via teclado.