### PR TITLE
ci(workflows): update master → main references after branch rename

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,7 +7,7 @@ name: Deploy docs to GitHub Pages
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -2,7 +2,7 @@ name: Deploy Storybook to GitHub Pages
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Build and Publish Package
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - 'v*'
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ name: Build and Test
 on:
   pull_request:
     branches:
-      - master
+      - main
     types: [opened, synchronize, reopened, labeled]
 
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ npm run init:env    # configura git hooks locais
 ## Fluxo de PR
 
 1. Crie a issue (templates em `.github/ISSUE_TEMPLATE/`).
-2. Branch `{type}/{N}-{slug}` a partir de `master`.
+2. Branch `{type}/{N}-{slug}` a partir de `main`.
 3. Implemente, mantendo commits atômicos com Conventional Commits.
 4. Antes do push: `npm run lint && npm run test && npm run typecheck && npm run build`.
 5. Abra o PR referenciando a issue via `Closes #N` ou `Refs #N`.

--- a/README.md
+++ b/README.md
@@ -204,14 +204,14 @@ Fluxo completo de visual regression e how-to em [CONTRIBUTING.md](./CONTRIBUTING
 A publicação é feita pelo workflow `publish.yml`:
 
 1. Bump de versão em um PR.
-2. Ao mergear em `master`, o CI publica `@guardiafinance/design-system@x.y.z`
+2. Ao mergear em `main`, o CI publica `@guardiafinance/design-system@x.y.z`
    no GitHub Packages.
 
 ## 🤝 Contribuição
 
 Consulte [CONTRIBUTING.md](./CONTRIBUTING.md) — resumo:
 
-- Branch de feature a partir de `master`.
+- Branch de feature a partir de `main`.
 - `npm run lint && npm run test && npm run typecheck` antes do push.
 - PR com descrição; baselines visuais atualizadas via `npm run test-storybook:update` quando a mudança altera UI.
 - Patches que afetam a API pública precisam de nota no `CHANGELOG.md`.


### PR DESCRIPTION
## Resumo

Branch principal renomeada de `master` → `main` in-place via `POST /repos/{owner}/{repo}/branches/master/rename`. A API preservou:
- Protection rules
- PRs abertos (auto re-targetados — havia 0)
- Default branch (auto-atualizada)

Restavam **6 referências hardcoded** que a API não toca. Este PR fecha o gap.

## Mudanças

| Arquivo | Antes | Depois |
|---|---|---|
| `.github/workflows/deploy-docs.yml` | `branches: ["main", "master"]` | `branches: ["main"]` |
| `.github/workflows/deploy-storybook.yml` | `branches: ["main", "master"]` | `branches: ["main"]` |
| `.github/workflows/pull-request.yml` | `- master` | `- main` |
| `.github/workflows/publish.yml` | `- master` | `- main` |
| `README.md` (×2) | "em `master`" / "a partir de `master`" | "em `main`" / "a partir de `main`" |
| `CONTRIBUTING.md` | "a partir de `master`" | "a partir de `main`" |

Sem este fix:
- `pull-request.yml` escuta `master` (não existe) → CI não dispara em novos PRs
- `publish.yml` não publica em merges no `main`
- Docs orientam contributors errado

## Verificação

```bash
grep -rln "\bmaster\b" .github/workflows/ README.md CONTRIBUTING.md
# (empty — 0 references)
```

CI deste PR já valida o trigger novo: `pull-request.yml` dispara apontando pra `main`.

## Out of scope

- Referências em `.ahrena/framework/**` e `.claude/{docs,rules,skills,agents,commands}/**` — mirror do framework upstream, atualizado em sync separado
- Provider cache local em `.claude/plans/` (gitignored)

Closes #146