### PR TITLE
feat(icon-button): migrate to brand-aware tokens + a11y coverage (#137)

### DIFF
--- a/ui_kit/components/icon-button/icon-button.test.tsx
+++ b/ui_kit/components/icon-button/icon-button.test.tsx
@@ -222,7 +222,7 @@ describe("<IconButton />", () => {
   });
 
   describe("a11y", () => {
-    it("no viola WCAG 2.1 AA em light + dark (ghost — default)", async () => {
+    it("has no WCAG 2.1 AA violations in light + dark (ghost — default)", async () => {
       const { container } = render(
         <IconButton aria-label="Salvar">
           <Icon />
@@ -231,7 +231,7 @@ describe("<IconButton />", () => {
       await axeInThemes(container);
     });
 
-    it("no viola WCAG 2.1 AA em light + dark (variantes interativas)", async () => {
+    it("has no WCAG 2.1 AA violations in light + dark (interactive variants)", async () => {
       const { container } = render(
         <div>
           <IconButton aria-label="default" variant="default">
@@ -254,7 +254,7 @@ describe("<IconButton />", () => {
       await axeInThemes(container);
     });
 
-    it("no viola WCAG 2.1 AA em light + dark quando disabled/loading", async () => {
+    it("has no WCAG 2.1 AA violations in light + dark when disabled/loading", async () => {
       const { container } = render(
         <div>
           <IconButton aria-label="desabilitado" disabled>

--- a/ui_kit/components/icon-button/icon-button.test.tsx
+++ b/ui_kit/components/icon-button/icon-button.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 
+import { axeInThemes } from "@/test-utils/a11y";
 import { IconButton } from "./index";
 
 const Icon = () => (
@@ -192,5 +193,79 @@ describe("<IconButton />", () => {
     );
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  describe("brand-aware hover tokens (per #125)", () => {
+    it("outline variant uses bg-bg-hover + border-action on hover", () => {
+      render(
+        <IconButton aria-label="x" variant="outline" data-testid="b">
+          <Icon />
+        </IconButton>,
+      );
+      const b = screen.getByTestId("b");
+      expect(b.className).toMatch(/hover:bg-bg-hover/);
+      expect(b.className).toMatch(/hover:border-action/);
+      expect(b.className).not.toMatch(/guardia-violet-(100|500|700)/);
+    });
+
+    it("ghost variant uses bg-bg-hover + text-action-hover on hover", () => {
+      render(
+        <IconButton aria-label="x" variant="ghost" data-testid="b">
+          <Icon />
+        </IconButton>,
+      );
+      const b = screen.getByTestId("b");
+      expect(b.className).toMatch(/hover:bg-bg-hover/);
+      expect(b.className).toMatch(/hover:text-action-hover/);
+      expect(b.className).not.toMatch(/guardia-violet-(100|500|700)/);
+    });
+  });
+
+  describe("a11y", () => {
+    it("no viola WCAG 2.1 AA em light + dark (ghost — default)", async () => {
+      const { container } = render(
+        <IconButton aria-label="Salvar">
+          <Icon />
+        </IconButton>,
+      );
+      await axeInThemes(container);
+    });
+
+    it("no viola WCAG 2.1 AA em light + dark (variantes interativas)", async () => {
+      const { container } = render(
+        <div>
+          <IconButton aria-label="default" variant="default">
+            <Icon />
+          </IconButton>
+          <IconButton aria-label="secondary" variant="secondary">
+            <Icon />
+          </IconButton>
+          <IconButton aria-label="destructive" variant="destructive">
+            <Icon />
+          </IconButton>
+          <IconButton aria-label="outline" variant="outline">
+            <Icon />
+          </IconButton>
+          <IconButton aria-label="ghost" variant="ghost">
+            <Icon />
+          </IconButton>
+        </div>,
+      );
+      await axeInThemes(container);
+    });
+
+    it("no viola WCAG 2.1 AA em light + dark quando disabled/loading", async () => {
+      const { container } = render(
+        <div>
+          <IconButton aria-label="desabilitado" disabled>
+            <Icon />
+          </IconButton>
+          <IconButton aria-label="carregando" loading>
+            <Icon />
+          </IconButton>
+        </div>,
+      );
+      await axeInThemes(container);
+    });
   });
 });

--- a/ui_kit/components/icon-button/index.tsx
+++ b/ui_kit/components/icon-button/index.tsx
@@ -44,9 +44,9 @@ const iconButtonVariants = cva(
         destructive:
           "bg-transparent text-destructive hover:bg-destructive/10",
         outline:
-          "bg-background text-foreground border-border-strong hover:bg-guardia-violet-100 hover:border-guardia-violet-500",
+          "bg-background text-foreground border-border-strong hover:bg-bg-hover hover:border-action",
         ghost:
-          "bg-transparent text-foreground hover:bg-guardia-violet-100 hover:text-guardia-violet-700",
+          "bg-transparent text-foreground hover:bg-bg-hover hover:text-action-hover",
       },
       size: {
         sm: "h-7 w-7 [&_svg]:size-3.5",

--- a/ui_kit/styles/index.css
+++ b/ui_kit/styles/index.css
@@ -221,7 +221,7 @@
   --accent-brand: var(--guardia-violet-200);    /* Violeta sobre dark: 200 (#AF97BD) */
   --accent-brand-hover: var(--guardia-violet-100);
 
-  /* Surface hover em dark: Surface 2 (gray-700) — discreto e legível */
+  /* Surface hover in dark: Surface 2 (gray-700) — subtle and legible */
   --bg-hover: var(--guardia-gray-700);
 
   /* Skeleton (loading placeholders) — dark variants alinhados a Cinza */

--- a/ui_kit/styles/index.css
+++ b/ui_kit/styles/index.css
@@ -121,6 +121,9 @@
   --accent-brand: var(--guardia-orange-500);
   --accent-brand-hover: var(--guardia-orange-700);
 
+  /* Surface hover for ghost/outline interactive elements — soft brand tint */
+  --bg-hover: var(--guardia-violet-100);
+
   /* State */
   --success: var(--signal-green);
   --success-soft: #D6F5E6;
@@ -217,6 +220,9 @@
   --action-hover: var(--guardia-orange-700);
   --accent-brand: var(--guardia-violet-200);    /* Violeta sobre dark: 200 (#AF97BD) */
   --accent-brand-hover: var(--guardia-violet-100);
+
+  /* Surface hover em dark: Surface 2 (gray-700) — discreto e legível */
+  --bg-hover: var(--guardia-gray-700);
 
   /* Skeleton (loading placeholders) — dark variants alinhados a Cinza */
   --skeleton-base: var(--guardia-gray-700);
@@ -393,6 +399,10 @@
    * Token semantics: violet-500 (light) / orange-500 (dark) — see #125. */
   --color-action: var(--action);
   --color-action-hover: var(--action-hover);
+
+  /* Soft brand-tinted hover surface for ghost/outline interactive variants.
+   * Pairs with `bg-bg-hover` utility (violet-100 light / gray-700 dark). */
+  --color-bg-hover: var(--bg-hover);
 
   /* ─── Brand palette exposed as utilities (bg-guardia-orange-500 etc.) ─── */
   --color-guardia-yellow-100: var(--guardia-yellow-100);


### PR DESCRIPTION
## Summary

- Add shared `--bg-hover` semantic token (light: violet-100 / dark: gray-700) + `bg-bg-hover` utility — amortizes future Chip/DatePicker/FileUpload migrations
- Migrate IconButton `outline` + `ghost` variants from hardcoded `guardia-violet-{100,500,700}` to `bg-bg-hover` / `border-action` / `text-action-hover`
- Add jest-axe coverage in light + dark for default + all interactive variants + disabled/loading

## Why

Plan #137 of Tech Task #125 — IconButton was using hardcoded palette in 2 hover states, breaking brand-aware theming. Migration introduces a reusable `--bg-hover` token so 3 future siblings reuse the work.

## Test plan

- [x] `npx vitest run` — 393 tests pass (21 in icon-button, was 16)
- [x] `npx tsc -p tsconfig.test.json --noEmit` — clean
- [x] `npx eslint ui_kit/components/icon-button` — 0 errors
- [x] `grep -rE "guardia-(violet|orange|pink|yellow)-[0-9]+" ui_kit/components/icon-button/` — 0 results in interactive states

Closes #137
Refs #125