### PR TITLE
chore(ci): publish only on tag push + revert orphan 0.1.0 bump (#150)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,6 @@ name: Build and Publish Package
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardiafinance/design-system",
-  "version": "0.1.0",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardiafinance/design-system",
-      "version": "0.1.0",
+      "version": "0.0.11",
       "workspaces": [
         "docs"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardiafinance/design-system",
-  "version": "0.1.0",
+  "version": "0.0.11",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- Drop `push.branches: [main]` from `.github/workflows/publish.yml` trigger — workflow now fires only on `push.tags: ['v*']`
- Revert `package.json` + `package-lock.json` version from `0.1.0` → `0.0.11` (orphan bump from [6759a16](https://github.com/guardiatechnology/design-system/commit/6759a16), never tagged/released)

## Why

The `publish` job was already gated by `startsWith(github.ref, 'refs/tags/v')` and correctly skipped on main pushes. But the `build` job ran on every merge to main (~40s/merge), generating an artifact that nobody consumed. Wasted CI minutes; misleading green-tick on commits that aren't releases. The version bump to 0.1.0 was orphan (no tag, no GitHub release, no publish history for that version) — reverting to the last real tagged version makes the next release follow the canonical flow.

## Test plan

- [x] `publish.yml` trigger contains only `push.tags: ['v*']`
- [x] `package.json` + `package-lock.json` version = `0.0.11`
- [ ] After merge: verify no run kicks off automatically (sanity check)
- [ ] Next release: bump version → push annotated signed tag `v0.0.12` → workflow fires → publish job runs

Closes #150