### PR TITLE
feat(checkbox): migrate to brand-aware tokens + a11y coverage (#139)

### DIFF
--- a/ui_kit/components/checkbox/checkbox.test.tsx
+++ b/ui_kit/components/checkbox/checkbox.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { axeInThemes } from "@/test-utils/a11y";
 import { Checkbox } from "./index";
 
 describe("Checkbox", () => {
@@ -100,12 +101,29 @@ describe("Checkbox", () => {
     expect(screen.getByRole("checkbox")).toHaveAttribute("id", "my-cb");
   });
 
-  it("classes do indicator: violet-500 fill em checked", () => {
+  it("brand-aware classes: bg-action + text-button-fg em checked", () => {
     render(<Checkbox checked />);
     const cb = screen.getByRole("checkbox");
-    expect(cb.className).toMatch(
-      /data-\[state=checked\]:bg-guardia-violet-500/,
-    );
+    expect(cb.className).toMatch(/data-\[state=checked\]:bg-action/);
+    expect(cb.className).toMatch(/data-\[state=checked\]:border-action/);
+    expect(cb.className).toMatch(/data-\[state=checked\]:text-button-fg/);
+    expect(cb.className).not.toMatch(/guardia-violet-(100|500|700)/);
+    expect(cb.className).not.toMatch(/\btext-white\b/);
+  });
+
+  it("brand-aware classes: bg-action + text-button-fg em indeterminate", () => {
+    render(<Checkbox indeterminate />);
+    const cb = screen.getByRole("checkbox");
+    expect(cb.className).toMatch(/data-\[state=indeterminate\]:bg-action/);
+    expect(cb.className).toMatch(/data-\[state=indeterminate\]:border-action/);
+    expect(cb.className).toMatch(/data-\[state=indeterminate\]:text-button-fg/);
+  });
+
+  it("brand-aware hover: border-action (sem guardia-violet hardcoded)", () => {
+    render(<Checkbox />);
+    const cb = screen.getByRole("checkbox");
+    expect(cb.className).toMatch(/hover:border-action/);
+    expect(cb.className).not.toMatch(/hover:border-guardia-violet-500/);
   });
 
   it("focus-visible:ring laranja com offset", () => {
@@ -139,5 +157,52 @@ describe("Checkbox", () => {
     );
     const wrapper = screen.getByRole("checkbox").closest("label");
     expect(wrapper).toHaveClass("my-wrap");
+  });
+
+  describe("a11y", () => {
+    it("has no WCAG 2.1 AA violations in light + dark (unchecked + label)", async () => {
+      const { container } = render(
+        <Checkbox label="Aceito os termos" />,
+      );
+      await axeInThemes(container);
+    });
+
+    it("has no WCAG 2.1 AA violations in light + dark (checked + label)", async () => {
+      const { container } = render(
+        <Checkbox checked label="Notificações por email" />,
+      );
+      await axeInThemes(container);
+    });
+
+    it("has no WCAG 2.1 AA violations in light + dark (indeterminate + label)", async () => {
+      const { container } = render(
+        <Checkbox indeterminate label="Selecionar todos" />,
+      );
+      await axeInThemes(container);
+    });
+
+    it("has no WCAG 2.1 AA violations in light + dark (label + description)", async () => {
+      const { container } = render(
+        <Checkbox
+          label="Email diário"
+          description="Receba um resumo das atividades"
+        />,
+      );
+      await axeInThemes(container);
+    });
+
+    it("has no WCAG 2.1 AA violations in light + dark (invalid)", async () => {
+      const { container } = render(
+        <Checkbox invalid label="Campo obrigatório" />,
+      );
+      await axeInThemes(container);
+    });
+
+    it("has no WCAG 2.1 AA violations in light + dark (disabled)", async () => {
+      const { container } = render(
+        <Checkbox disabled label="Indisponível" />,
+      );
+      await axeInThemes(container);
+    });
   });
 });

--- a/ui_kit/components/checkbox/index.tsx
+++ b/ui_kit/components/checkbox/index.tsx
@@ -42,11 +42,11 @@ const boxVariants = cva(
     "rounded-sm border-[1.5px] bg-background text-transparent",
     "border-border-strong",
     "transition-[background-color,border-color,color,box-shadow] duration-150",
-    /* Hover (não disabled): border violet-500 */
-    "hover:border-guardia-violet-500",
-    /* Checked / Indeterminate: violet-500 fill + check branco */
-    "data-[state=checked]:bg-guardia-violet-500 data-[state=checked]:border-guardia-violet-500 data-[state=checked]:text-white",
-    "data-[state=indeterminate]:bg-guardia-violet-500 data-[state=indeterminate]:border-guardia-violet-500 data-[state=indeterminate]:text-white",
+    /* Hover (não disabled): border action (violet light / orange dark) */
+    "hover:border-action",
+    /* Checked / Indeterminate: action fill + button-fg icon (white light / mono-black dark, AA-safe) */
+    "data-[state=checked]:bg-action data-[state=checked]:border-action data-[state=checked]:text-button-fg",
+    "data-[state=indeterminate]:bg-action data-[state=indeterminate]:border-action data-[state=indeterminate]:text-button-fg",
     /* Focus-visible: ring laranja com offset */
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
     /* Invalid: border red (override hover) */


### PR DESCRIPTION
## Summary

- Migrate Checkbox hover + checked + indeterminate variants from `guardia-violet-500` + `text-white` to `border-action` / `bg-action` / `text-button-fg`
- Auto-fix dark-mode WCAG AA: `text-white` over `bg-action` (orange-500) = ~3.13:1 → fails AA; `text-button-fg` resolves to mono-black in dark = ~6.2:1 → passes AA
- Update existing class assertion + add 3 brand-token guards + 6 a11y tests (unchecked/checked/indeterminate/label+desc/invalid/disabled, light + dark)

## Why

Plan #139 of Tech Task #125. Reuses tokens `--color-action` (from #136) and `--color-button-fg` (from #138) — no new tokens introduced; pure migration.

## Test plan

- [x] `npx vitest run` — 409/409 pass (27 in checkbox, was 19)
- [x] `npx tsc -p tsconfig.test.json --noEmit` — clean
- [x] `npx eslint ui_kit/components/checkbox` — 0 errors
- [x] `grep -rE "guardia-(violet|orange|pink|yellow)-[0-9]+|text-white" ui_kit/components/checkbox/index.tsx` — 0 results

Closes #139
Refs #125