### PR TITLE
feat(radio): migrate to brand-aware tokens + a11y coverage (#140)

### DIFF
--- a/ui_kit/components/radio/index.tsx
+++ b/ui_kit/components/radio/index.tsx
@@ -70,8 +70,8 @@ const markVariants = cva(
     "rounded-full border-[1.5px] bg-background",
     "border-border-strong",
     "transition-[background-color,border-color,box-shadow] duration-150",
-    "hover:border-guardia-violet-500",
-    "data-[state=checked]:border-guardia-violet-500",
+    "hover:border-action",
+    "data-[state=checked]:border-action",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
     "aria-[invalid=true]:border-destructive aria-[invalid=true]:hover:border-destructive",
     "disabled:cursor-not-allowed disabled:opacity-55",
@@ -161,7 +161,7 @@ const Radio = React.forwardRef<
           <span
             aria-hidden="true"
             style={{ width: dotPx, height: dotPx }}
-            className="block rounded-full bg-guardia-violet-500"
+            className="block rounded-full bg-action"
           />
         </RadioGroupPrimitive.Indicator>
       </RadioGroupPrimitive.Item>

--- a/ui_kit/components/radio/radio.test.tsx
+++ b/ui_kit/components/radio/radio.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { axeInThemes } from "@/test-utils/a11y";
 import { Radio, RadioGroup } from "./index";
 
 function setup(props: Partial<React.ComponentProps<typeof RadioGroup>> = {}) {
@@ -239,5 +240,74 @@ describe("Radio", () => {
       </RadioGroup>,
     );
     expect(screen.getByRole("radio").closest("label")).toHaveClass("my-wrap");
+  });
+
+  describe("brand-aware tokens (per #125)", () => {
+    it("mark uses border-action on hover + checked (no guardia-violet hardcoded)", () => {
+      render(
+        <RadioGroup>
+          <Radio value="x" />
+        </RadioGroup>,
+      );
+      const r = screen.getByRole("radio");
+      expect(r.className).toMatch(/hover:border-action/);
+      expect(r.className).toMatch(/data-\[state=checked\]:border-action/);
+      expect(r.className).not.toMatch(/guardia-violet-(100|500|700)/);
+    });
+
+    it("indicator dot uses bg-action (themed: violet light / orange dark)", () => {
+      const { container } = render(
+        <RadioGroup defaultValue="x">
+          <Radio value="x" />
+        </RadioGroup>,
+      );
+      // Indicator only renders inside Radix Indicator when checked
+      const dot = container.querySelector('[role="radio"] span[aria-hidden="true"]');
+      expect(dot).not.toBeNull();
+      expect(dot!.className).toMatch(/\bbg-action\b/);
+      expect(dot!.className).not.toMatch(/bg-guardia-violet-500/);
+    });
+  });
+
+  describe("a11y", () => {
+    it("has no WCAG 2.1 AA violations in light + dark (group, no selection)", async () => {
+      const { container } = render(
+        <RadioGroup aria-label="Frequência">
+          <Radio value="now" label="Imediato" description="Agora" />
+          <Radio value="daily" label="Diário" description="Uma vez por dia" />
+          <Radio value="weekly" label="Semanal" />
+        </RadioGroup>,
+      );
+      await axeInThemes(container);
+    });
+
+    it("has no WCAG 2.1 AA violations in light + dark (group with default selection)", async () => {
+      const { container } = render(
+        <RadioGroup aria-label="Frequência" defaultValue="daily">
+          <Radio value="now" label="Imediato" />
+          <Radio value="daily" label="Diário" />
+          <Radio value="weekly" label="Semanal" />
+        </RadioGroup>,
+      );
+      await axeInThemes(container);
+    });
+
+    it("has no WCAG 2.1 AA violations in light + dark (invalid)", async () => {
+      const { container } = render(
+        <RadioGroup aria-label="Opção">
+          <Radio value="x" invalid label="Campo obrigatório" />
+        </RadioGroup>,
+      );
+      await axeInThemes(container);
+    });
+
+    it("has no WCAG 2.1 AA violations in light + dark (disabled)", async () => {
+      const { container } = render(
+        <RadioGroup aria-label="Opção">
+          <Radio value="x" disabled label="Indisponível" />
+        </RadioGroup>,
+      );
+      await axeInThemes(container);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Migrate Radio mark from hardcoded `guardia-violet-500` to `border-action` / `bg-action` (3 occurrences: hover border, checked-state border, indicator dot)
- Indicator dot now themes in dark (orange-500 instead of static violet)
- Add 2 brand-token guards + 4 a11y tests (no selection, default selection, invalid, disabled) — light + dark

## Why

Plan #140 of Tech Task #125. Pure migration — reuses `--color-action` from #136, no new tokens. Unlike Chip/Checkbox, Radio has no `text-white` over `bg-action` — the indicator dot has no text/icon contrast concern.

## Test plan

- [x] `npx vitest run` — 415/415 pass (29 in radio, was 23)
- [x] `npx tsc -p tsconfig.test.json --noEmit` — clean
- [x] `npx eslint ui_kit/components/radio` — 0 errors
- [x] `grep -rE "guardia-(violet|orange|pink|yellow)-[0-9]+" ui_kit/components/radio/index.tsx` — 0 results

Closes #140
Refs #125