### PR TITLE
feat(date-picker): migrate to brand-aware tokens + a11y coverage (#143)

### DIFF
--- a/ui_kit/components/date-picker/date-picker.test.tsx
+++ b/ui_kit/components/date-picker/date-picker.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { axeInThemes } from "@/test-utils/a11y";
 import { DatePicker, formatDateBR } from "./index";
 
 describe("formatDateBR", () => {
@@ -202,6 +203,101 @@ describe("DatePicker", () => {
     await user.keyboard("{Escape}");
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("brand-aware tokens", () => {
+    it("trigger usa border-action no hover + estado aberto (sem guardia-violet hardcoded)", () => {
+      render(<DatePicker />);
+      const trigger = screen.getByRole("button", { name: "Selecionar data" });
+      expect(trigger.className).toMatch(/hover:border-action/);
+      expect(trigger.className).toMatch(/data-\[state=open\]:border-action/);
+      expect(trigger.className).not.toMatch(/guardia-violet-(100|500|700)/);
+    });
+
+    it("dia selecionado renderiza com bg-action + text-button-fg", async () => {
+      const user = userEvent.setup();
+      render(<DatePicker defaultValue={new Date(2025, 5, 15)} />);
+      await user.click(
+        screen.getByRole("button", { name: "Selecionar data" }),
+      );
+      await screen.findByRole("dialog");
+      /* DayPicker aplica a classe `selected` no <td> (gridcell), que carrega
+         `bg-action` + `text-button-fg` via [&_button] selector. Asserts no
+         próprio gridcell. */
+      const day15Button = screen
+        .getAllByRole("button")
+        .find((b) => b.textContent?.trim() === "15");
+      expect(day15Button).toBeDefined();
+      const gridcell = day15Button!.closest("td");
+      expect(gridcell?.className ?? "").toMatch(/bg-action/);
+      expect(gridcell?.className ?? "").toMatch(/text-button-fg/);
+      expect(gridcell?.className ?? "").not.toMatch(/guardia-violet-500/);
+      expect(gridcell?.className ?? "").not.toMatch(/\btext-white\b/);
+    });
+
+    it("botão 'Hoje' usa text-action + hover:bg-bg-hover (sem guardia-violet hardcoded)", async () => {
+      render(<DatePicker />);
+      await userEvent.click(
+        screen.getByRole("button", { name: "Selecionar data" }),
+      );
+      const today = await screen.findByRole("button", { name: "Hoje" });
+      expect(today.className).toMatch(/text-action/);
+      expect(today.className).toMatch(/hover:bg-bg-hover/);
+      expect(today.className).not.toMatch(/guardia-violet-(100|500|700)/);
+    });
+  });
+
+  describe("a11y", () => {
+    it("não tem violações WCAG 2.1 AA em light + dark (trigger vazio)", async () => {
+      const { container } = render(<DatePicker />);
+      await axeInThemes(container);
+    });
+
+    it("não tem violações WCAG 2.1 AA em light + dark (com valor + clear)", async () => {
+      const { container } = render(
+        <DatePicker
+          defaultValue={new Date(2025, 5, 15)}
+          aria-label="Data de vencimento"
+        />,
+      );
+      await axeInThemes(container);
+    });
+
+    it("não tem violações WCAG 2.1 AA em light + dark (invalid)", async () => {
+      const { container } = render(
+        <DatePicker invalid aria-label="Data de vencimento" />,
+      );
+      await axeInThemes(container);
+    });
+
+    it("não tem violações WCAG 2.1 AA em light + dark (disabled)", async () => {
+      const { container } = render(
+        <DatePicker disabled aria-label="Data de vencimento" />,
+      );
+      await axeInThemes(container);
+    });
+
+    it("não tem violações WCAG 2.1 AA em light + dark (dialog aberto com dia selecionado)", async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <DatePicker defaultValue={new Date(2025, 5, 15)} />,
+      );
+      await user.click(
+        screen.getByRole("button", { name: "Selecionar data" }),
+      );
+      await screen.findByRole("dialog");
+      await axeInThemes(container);
+    });
+
+    it("não tem violações WCAG 2.1 AA em light + dark (dialog aberto sem valor)", async () => {
+      const user = userEvent.setup();
+      const { container } = render(<DatePicker />);
+      await user.click(
+        screen.getByRole("button", { name: "Selecionar data" }),
+      );
+      await screen.findByRole("dialog");
+      await axeInThemes(container);
     });
   });
 });

--- a/ui_kit/components/date-picker/date-picker.test.tsx
+++ b/ui_kit/components/date-picker/date-picker.test.tsx
@@ -228,8 +228,9 @@ describe("DatePicker", () => {
       const day15Button = screen
         .getAllByRole("button")
         .find((b) => b.textContent?.trim() === "15");
-      expect(day15Button).toBeDefined();
-      const gridcell = day15Button!.closest("td");
+      expect(day15Button).not.toBeUndefined();
+      const gridcell = day15Button?.closest("td");
+      expect(gridcell).not.toBeNull();
       expect(gridcell?.className ?? "").toMatch(/bg-action/);
       expect(gridcell?.className ?? "").toMatch(/text-button-fg/);
       expect(gridcell?.className ?? "").not.toMatch(/guardia-violet-500/);

--- a/ui_kit/components/date-picker/index.tsx
+++ b/ui_kit/components/date-picker/index.tsx
@@ -50,9 +50,10 @@ const triggerVariants = cva(
     "border border-border-strong rounded-md",
     "text-left cursor-pointer",
     "transition-[border-color,box-shadow] duration-150",
-    "hover:border-guardia-violet-500 disabled:hover:border-border-strong",
+    /* Hover + open: border action (violet light / orange dark) */
+    "hover:border-action disabled:hover:border-border-strong",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-    "data-[state=open]:border-guardia-violet-500 data-[state=open]:ring-2 data-[state=open]:ring-ring data-[state=open]:ring-offset-2",
+    "data-[state=open]:border-action data-[state=open]:ring-2 data-[state=open]:ring-ring data-[state=open]:ring-offset-2",
     "aria-[invalid=true]:border-destructive aria-[invalid=true]:hover:border-destructive",
     "aria-[invalid=true]:focus-visible:ring-destructive aria-[invalid=true]:data-[state=open]:ring-destructive",
     "disabled:cursor-not-allowed disabled:opacity-70 disabled:bg-muted",
@@ -277,9 +278,9 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
                 caption_label: "select-none",
                 nav: "flex items-center justify-between absolute left-0 right-0 px-1",
                 button_previous:
-                  "inline-flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-fg hover:bg-guardia-violet-100/50 hover:text-guardia-violet-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "inline-flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-fg hover:bg-bg-hover/50 hover:text-action focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 button_next:
-                  "inline-flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-fg hover:bg-guardia-violet-100/50 hover:text-guardia-violet-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "inline-flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-fg hover:bg-bg-hover/50 hover:text-action focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 month_grid: "border-collapse",
                 weekdays: "flex",
                 weekday:
@@ -289,14 +290,13 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
                 day_button: cn(
                   "h-8 w-8 inline-flex items-center justify-center rounded-md border-0 bg-transparent text-fg",
                   "transition-colors duration-100",
-                  "hover:bg-guardia-violet-100/50 hover:text-guardia-violet-700",
+                  "hover:bg-bg-hover/50 hover:text-action",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   "disabled:cursor-not-allowed disabled:opacity-35",
                 ),
-                today:
-                  "[&_button]:font-bold [&_button]:text-guardia-violet-700",
+                today: "[&_button]:font-bold [&_button]:text-action",
                 selected:
-                  "[&_button]:bg-guardia-violet-500 [&_button]:text-white [&_button]:hover:bg-guardia-violet-500 [&_button]:hover:text-white [&_button]:font-semibold",
+                  "[&_button]:bg-action [&_button]:text-button-fg [&_button]:hover:bg-action [&_button]:hover:text-button-fg [&_button]:font-semibold",
                 outside: "[&_button]:text-fg-muted [&_button]:opacity-60",
                 disabled: "[&_button]:cursor-not-allowed [&_button]:opacity-35",
                 hidden: "invisible",
@@ -316,7 +316,7 @@ const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
                 <button
                   type="button"
                   onClick={pickToday}
-                  className="rounded-sm border-0 bg-transparent px-2 py-1 text-[12px] font-semibold text-guardia-violet-700 hover:bg-guardia-violet-100/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="rounded-sm border-0 bg-transparent px-2 py-1 text-[12px] font-semibold text-action hover:bg-bg-hover/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   Hoje
                 </button>


### PR DESCRIPTION
## Summary

- Migrate DatePicker hardcoded palette in interactive states (`hover:border-`, `data-[state=open]:border-`, day hover, selected, today, "Hoje") from `guardia-violet-*` + `text-white` → `border-action` / `bg-action` / `text-action` / `text-button-fg` / `bg-bg-hover`
- Auto-fixes dark-mode WCAG AA: `text-white` over `bg-action` (orange-500) ≈ 3.13:1 → fails AA; `text-button-fg` = mono-black in dark = 6.2:1 → passes AA
- Add 3 brand-token guards (trigger, selected day, Hoje button) + 6 jest-axe checks (light + dark) covering trigger empty, trigger with value + clear, invalid, disabled, dialog open with selected day, dialog open without value

## Why

Plan #143 of Tech Task #125. Reuses tokens `--color-action`, `--color-button-fg`, `--color-bg-hover` — no new tokens introduced; pure migration.

## Test plan

- [x] `npx vitest run ui_kit/components/date-picker` — 32/32 pass (was 23)
- [x] `npx tsc -p tsconfig.test.json --noEmit` — clean
- [x] `npx eslint ui_kit/components/date-picker` — 0 errors
- [x] `grep -rE "guardia-(violet\|orange\|pink\|yellow)-[0-9]+\|text-white" ui_kit/components/date-picker/index.tsx` — 0 results

Closes #143
Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)