### PR TITLE
fix(theme): make ThemeProvider SSR-safe + bump 0.0.12 (#160)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardiafinance/design-system",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardiafinance/design-system",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "workspaces": [
         "docs"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardiafinance/design-system",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "exports": {
     ".": {

--- a/ui_kit/theme/theme-provider.test.tsx
+++ b/ui_kit/theme/theme-provider.test.tsx
@@ -83,4 +83,41 @@ describe("<ThemeProvider />", () => {
     expect(screen.getByTestId("current-theme")).toHaveTextContent("dark");
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
   });
+
+  it("falls back to defaultTheme when localStorage access throws (private browsing, strict CSP)", () => {
+    const originalGetItem = Storage.prototype.getItem;
+    Storage.prototype.getItem = vi.fn(() => {
+      throw new Error("SecurityError: localStorage blocked");
+    });
+    try {
+      render(
+        <ThemeProvider defaultTheme="dark">
+          <Consumer />
+        </ThemeProvider>,
+      );
+      expect(screen.getByTestId("current-theme")).toHaveTextContent("dark");
+      expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    } finally {
+      Storage.prototype.getItem = originalGetItem;
+    }
+  });
+
+  it("keeps the in-memory theme even when localStorage.setItem throws (QuotaExceededError)", () => {
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = vi.fn(() => {
+      throw new Error("QuotaExceededError");
+    });
+    try {
+      render(
+        <ThemeProvider defaultTheme="light">
+          <Consumer />
+        </ThemeProvider>,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /go-dark/i }));
+      expect(screen.getByTestId("current-theme")).toHaveTextContent("dark");
+      expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    } finally {
+      Storage.prototype.setItem = originalSetItem;
+    }
+  });
 });

--- a/ui_kit/theme/theme-provider.test.tsx
+++ b/ui_kit/theme/theme-provider.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+
+import { ThemeProvider, useTheme } from "./theme-provider";
+
+function Consumer() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="current-theme">{theme}</span>
+      <button type="button" onClick={() => setTheme("dark")}>
+        go-dark
+      </button>
+    </div>
+  );
+}
+
+describe("<ThemeProvider />", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("renders during server-side rendering without reading localStorage (#153 regression)", () => {
+    // WHY: useState initializer ran during static prerender (Next.js
+    // `output: "export"`, RSC) crashed with `ReferenceError: localStorage
+    // is not defined`. Trap any read on Storage.prototype during
+    // renderToString — the deferred useEffect read MUST NOT fire on the
+    // server, so the trap stays untouched and the render succeeds.
+    const trap = vi.fn(() => {
+      throw new Error("localStorage MUST NOT be accessed during render");
+    });
+    const originalGetItem = Storage.prototype.getItem;
+    Storage.prototype.getItem = trap;
+    try {
+      const html = renderToString(
+        <ThemeProvider defaultTheme="light">
+          <Consumer />
+        </ThemeProvider>,
+      );
+      expect(trap).not.toHaveBeenCalled();
+      expect(html).toContain("light");
+    } finally {
+      Storage.prototype.getItem = originalGetItem;
+    }
+  });
+
+  it("uses defaultTheme on first client render", () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <Consumer />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("current-theme")).toHaveTextContent("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("hydrates the persisted theme from localStorage after mount", () => {
+    window.localStorage.setItem("ui-theme", "dark");
+    render(
+      <ThemeProvider defaultTheme="light">
+        <Consumer />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("current-theme")).toHaveTextContent("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("persists the new theme to localStorage when setTheme is called", () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <Consumer />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /go-dark/i }));
+    expect(window.localStorage.getItem("ui-theme")).toBe("dark");
+    expect(screen.getByTestId("current-theme")).toHaveTextContent("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+});

--- a/ui_kit/theme/theme-provider.tsx
+++ b/ui_kit/theme/theme-provider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from "react"
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react"
 
 type Theme = "light" | "dark" | "system"
 
@@ -33,9 +33,16 @@ export function ThemeProvider({
     const [theme, setTheme] = useState<Theme>(defaultTheme)
 
     useEffect(() => {
-        const stored = window.localStorage.getItem(storageKey) as Theme | null
-        if (stored) setTheme(stored)
-    }, [storageKey])
+        try {
+            const stored = window.localStorage.getItem(storageKey) as Theme | null
+            setTheme(stored || defaultTheme)
+        } catch {
+            // WHY: localStorage can throw under Safari "Block all cookies",
+            // strict CSP, or private browsing — fall back to defaultTheme
+            // instead of leaving the consumer stuck in an inconsistent state.
+            setTheme(defaultTheme)
+        }
+    }, [storageKey, defaultTheme])
 
     useEffect(() => {
         const root = window.document.documentElement
@@ -55,13 +62,25 @@ export function ThemeProvider({
         root.setAttribute("data-theme", theme)
     }, [theme])
 
-    const value = {
-        theme,
-        setTheme: (theme: Theme) => {
-            window.localStorage.setItem(storageKey, theme)
-            setTheme(theme)
-        },
-    }
+    // WHY: memoized so context consumers do not re-render when the provider's
+    // parent re-renders but `theme` is unchanged. The inner setTheme catches
+    // QuotaExceededError + private-browsing throws (same rationale as the
+    // hydration effect) so the in-memory state still updates even when the
+    // persistence write fails.
+    const value = useMemo<ThemeProviderState>(
+        () => ({
+            theme,
+            setTheme: (next: Theme) => {
+                try {
+                    window.localStorage.setItem(storageKey, next)
+                } catch {
+                    // ignore: storage unavailable; keep in-memory update
+                }
+                setTheme(next)
+            },
+        }),
+        [theme, storageKey],
+    )
 
     return (
         <ThemeProviderContext.Provider {...props} value={value}>

--- a/ui_kit/theme/theme-provider.tsx
+++ b/ui_kit/theme/theme-provider.tsx
@@ -26,9 +26,16 @@ export function ThemeProvider({
     storageKey = "ui-theme",
     ...props
 }: ThemeProviderProps) {
-    const [theme, setTheme] = useState<Theme>(
-        () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
-    )
+    // WHY: localStorage is read in useEffect (post-mount), never in the useState
+    // initializer, so SSR / static prerender (Next.js `output: "export"`, RSC)
+    // never touches a browser-only global. First paint shows `defaultTheme`; the
+    // persisted value applies after hydration.
+    const [theme, setTheme] = useState<Theme>(defaultTheme)
+
+    useEffect(() => {
+        const stored = window.localStorage.getItem(storageKey) as Theme | null
+        if (stored) setTheme(stored)
+    }, [storageKey])
 
     useEffect(() => {
         const root = window.document.documentElement
@@ -51,7 +58,7 @@ export function ThemeProvider({
     const value = {
         theme,
         setTheme: (theme: Theme) => {
-            localStorage.setItem(storageKey, theme)
+            window.localStorage.setItem(storageKey, theme)
             setTheme(theme)
         },
     }


### PR DESCRIPTION
## Summary

- Make `ThemeProvider` safe on the server: the `localStorage` read moves from the `useState` initializer to a `useEffect`, so Next.js static prerender (`output: "export"`, RSC, Turbopack) no longer crashes with `ReferenceError: localStorage is not defined`.
- Bump the package to **`0.0.12`**. The `./styles.css` subpath export was already declared in `package.json` but absent from the published `0.0.11` tarball — the next tag publish materializes it for Turbopack-strict consumers.

Together these unblock the documented happy path for Next.js 16 App Router consumers (see #153 for repro from `guardiatechnology/bounded-context-template`). After publish, the consumer can drop both the postinstall CSS copy hack and the `mounted` wrapper around `<ThemeProvider>`.

## Trade-off

First paint shows `defaultTheme`; the persisted value applies after hydration. This is the documented `next-themes` pattern. Consumers that want zero-flash can mitigate via an inline `<script>` in `<head>` that sets `data-theme` before React hydrates — not part of this PR.

## Test plan

- [x] `vitest run` — 449 passed (4 new in `ui_kit/theme/theme-provider.test.tsx`)
- [x] `npx eslint ui_kit/theme/theme-provider.{tsx,test.tsx}` — 0 errors, 0 warnings
- [x] `npm run typecheck` (tsc strict) — clean
- [x] `npm run build` (rslib) — `dist/styles/index.css` ships; `dist/theme/theme-provider.js` uses `useState(defaultTheme)` + deferred `useEffect` for localStorage
- [x] Storybook smoke (Theme story): toggle Light ↔ Dark still works
- [ ] Post-merge: maintainer creates signed `v0.0.12` tag → `publish.yml` publishes to GitHub Packages → consumer drops both workarounds

Test coverage added (4 cases in `theme-provider.test.tsx`):

1. **SSR safety** — traps `Storage.prototype.getItem` to throw if called; `renderToString` must not invoke it (regression guard for the reported `ReferenceError`).
2. **Default behavior** — `defaultTheme="light"` produces `data-theme="light"` on first client render.
3. **Hydration** — `localStorage["ui-theme"]="dark"` populated before mount surfaces in the consumer after the deferred `useEffect`.
4. **Persistence** — `setTheme("dark")` writes to `localStorage` and updates the DOM attribute.

Closes #160
Refs #153
