### PR TITLE
chore(chip): align hover-on-checked policy + ADR-002 (#166)

### DIFF
--- a/docs/adr/ADR-002-hover-on-action-surfaces.md
+++ b/docs/adr/ADR-002-hover-on-action-surfaces.md
@@ -1,0 +1,65 @@
+# ADR-002 — Hover does not override `data-[state=checked]` on `action` surfaces
+
+- **Status:** accepted
+- **Date:** 2026-05-25
+- **Deciders:** Fernando Seguim
+- **Plan:** [#166](https://github.com/guardiatechnology/design-system/issues/166) (Plan A of [#159](https://github.com/guardiatechnology/design-system/issues/159))
+
+## Context
+
+The brand-aware token migration in [#125](https://github.com/guardiatechnology/design-system/issues/125) painted 9 interactive components with semantic `--color-action` / `--color-action-hover` / `--color-button-fg` tokens that flip by `data-theme`. After the migration, a cross-component divergence remained: when an element is in `data-[state=checked]` or `selected={true}`, does the hover state still apply the `*-hover` tokens?
+
+Mapping immediately after #125:
+
+| Component | Hover overrides checked? |
+|---|---|
+| **Chip** | **Yes** — `selected: true` variant carries `hover:bg-action-hover hover:border-action-hover hover:text-button-fg-hover` |
+| Checkbox | No — only `hover:border-action` on the default state; `data-[state=checked]` keeps `action` stable |
+| Radio | No — same pattern as Checkbox |
+| IconButton | N/A — no `checked` state on this primitive |
+| Select | N/A — `data-[state=open]` (dropdown open) is not "selected" |
+| Combobox | N/A — same as Select |
+
+Chip is the only outlier. The divergence creates two different affordances for "this is already selected" between toggle-pattern components in the same group.
+
+## Decision
+
+**On surfaces painted with `bg-action` (the `action` token surface), the `hover` modifier MUST NOT override the `data-[state=checked]` or `selected={true}` styling. The element keeps the `action` tokens stable regardless of cursor position.**
+
+Concretely, an `action`-painted surface in the selected/checked state uses:
+
+- `bg-action`
+- `border-action`
+- `text-button-fg`
+
+…and **no `hover:bg-action-hover`, `hover:border-action-hover`, `hover:text-button-fg-hover`** while in that state.
+
+Hover-on-non-checked states (the resting state of a toggle, or a non-toggle action surface like the IconButton solid variant) continue to use `*-hover` tokens normally — this ADR only governs hover behavior **while** in `checked`/`selected`.
+
+## Consequences
+
+### Aligned with the decision (no change)
+
+- **Checkbox**, **Radio** — already follow the policy
+- **IconButton**, **Select**, **Combobox** — no `checked` state on the surface in question; out of scope
+
+### Diverges (this PR corrects)
+
+- **Chip** — the `selected: true` variant drops the 3 hover overrides. Visual snapshots regenerated.
+
+### Trade-offs considered
+
+- **Counter-argument:** clicking a selected chip deselects it; hover-on-checked would signal "clicking changes something here." Rejected — Checkbox is also a toggle that deselects on click, and it follows the stable-checked policy. Internal consistency across toggle-pattern components outweighs the specific affordance signal in Chip.
+- **Counter-argument:** a stronger hover (`action-hover`) on top of `action` reinforces interactivity. Rejected — the focus ring and the cursor pointer already carry the "interactive" signal; the second-level color shift adds noise without affordance gain, and breaks the bridge between "this is the selected look" and "this is the look of an item *being* selected via hover" (which is *not* the same state and should not look the same).
+
+### What this ADR does NOT cover
+
+- Hover behavior on non-`action` surfaces (e.g., `bg-bg-hover` over `bg-background`) — those follow their own pattern and are stable today
+- The `enabled:` modifier policy on hover rules — handled separately by [#159 Plan B](https://github.com/guardiatechnology/design-system/issues/159)
+- Dropdown-item selection states inside Select/Combobox — separate surface, not in scope of #125's interactive group
+
+## Enforcement
+
+- Visual: Storybook stories for each component cover the selected/checked + hover combination; baselines on Ubuntu/CI render lock the policy
+- Unit: `chip.test.tsx` (and any new toggle-pattern component) asserts the absence of `hover:*-hover` classes when the variant is in the selected/checked state
+- Manual: design review flags any reintroduction of `hover:*-hover` on `bg-action` surfaces in `data-[state=checked]`

--- a/docs/src/layouts/ComponentPreview.astro
+++ b/docs/src/layouts/ComponentPreview.astro
@@ -91,6 +91,10 @@ const sourceUrl = `${githubRoot}${sourcePath ?? "ui_kit/components"}`;
         border-radius: var(--radius-md);
         padding: 24px;
         display: flex; flex-direction: column; gap: 16px;
+        /* WHY: sem align-items, o default `stretch` esticava componentes
+           inline-flex (Chip, Badge, Button) para 100% do cross-axis,
+           virando cápsulas longas em vez de pílulas com largura natural. */
+        align-items: flex-start;
         margin-bottom: 12px;
       }
       .preview.row { flex-direction: row; flex-wrap: wrap; align-items: center; }

--- a/ui_kit/components/chip/chip.test.tsx
+++ b/ui_kit/components/chip/chip.test.tsx
@@ -145,7 +145,9 @@ describe("<Chip />", () => {
   });
 
   describe("brand-aware tokens (per #125)", () => {
-    it("selected variant uses bg-action + text-button-fg with action-hover on hover", () => {
+    it("selected variant uses stable bg-action + text-button-fg with NO hover override", () => {
+      // WHY: hover does not override `selected: true` on action surfaces.
+      // See docs/adr/ADR-002-hover-on-action-surfaces.md.
       render(
         <Chip selected onSelect={() => {}} data-testid="c">
           Selected
@@ -155,10 +157,9 @@ describe("<Chip />", () => {
       expect(c.className).toMatch(/bg-action(?!-hover)/);
       expect(c.className).toMatch(/border-action(?!-hover)/);
       expect(c.className).toMatch(/text-button-fg(?!-hover)/);
-      expect(c.className).toMatch(/hover:bg-action-hover/);
-      expect(c.className).toMatch(/hover:border-action-hover/);
-      // WHY: dark mode hover swaps fg to white — mono-black over orange-700 = 3.2:1 (fails AA).
-      expect(c.className).toMatch(/hover:text-button-fg-hover/);
+      expect(c.className).not.toMatch(/hover:bg-action-hover/);
+      expect(c.className).not.toMatch(/hover:border-action-hover/);
+      expect(c.className).not.toMatch(/hover:text-button-fg-hover/);
       expect(c.className).not.toMatch(/guardia-violet-(100|500|700)/);
       expect(c.className).not.toMatch(/\btext-white\b/);
     });

--- a/ui_kit/components/chip/chip.test.tsx
+++ b/ui_kit/components/chip/chip.test.tsx
@@ -164,6 +164,25 @@ describe("<Chip />", () => {
       expect(c.className).not.toMatch(/\btext-white\b/);
     });
 
+    it("non-interactive selected variant keeps action surface stable on hover", () => {
+      // WHY: ADR-002 governs the `selected: true ∧ interactive: false` cell of
+      // the variant matrix too. Without this guard, hover would override
+      // `bg-action` with `bg-background` (JSDoc Mode 4 and split-interactive
+      // Mode 3 both hit this path).
+      // See docs/adr/ADR-002-hover-on-action-surfaces.md.
+      render(
+        <Chip selected data-testid="c">
+          Selected (non-interactive)
+        </Chip>,
+      );
+      const c = screen.getByTestId("c");
+      expect(c.className).toMatch(/bg-action(?!-hover)/);
+      expect(c.className).toMatch(/border-action(?!-hover)/);
+      expect(c.className).toMatch(/text-button-fg(?!-hover)/);
+      expect(c.className).not.toMatch(/hover:bg-background/);
+      expect(c.className).not.toMatch(/hover:border-border-strong/);
+    });
+
     it("unselected variant uses bg-bg-hover + border-action on hover", () => {
       render(
         <Chip onSelect={() => {}} data-testid="c">

--- a/ui_kit/components/chip/index.tsx
+++ b/ui_kit/components/chip/index.tsx
@@ -28,7 +28,9 @@ const chipVariants = cva(
         md: "h-8 px-3 text-[13px] font-medium",
       },
       selected: {
-        true: "bg-action border-action text-button-fg hover:bg-action-hover hover:border-action-hover hover:text-button-fg-hover",
+        // WHY: hover does not override `selected: true` on action surfaces.
+        // See docs/adr/ADR-002-hover-on-action-surfaces.md.
+        true: "bg-action border-action text-button-fg",
         false:
           "bg-background border-border-strong text-foreground hover:bg-bg-hover hover:border-action",
       },

--- a/ui_kit/components/chip/index.tsx
+++ b/ui_kit/components/chip/index.tsx
@@ -36,7 +36,10 @@ const chipVariants = cva(
       },
       interactive: {
         true: "cursor-pointer",
-        false: "cursor-default hover:bg-background hover:border-border-strong",
+        // WHY: hover-neutralization moved to the compound variant below so it
+        // applies ONLY to `selected: false`. See ADR-002 — `interactive: false`
+        // with `selected: true` MUST keep the action surface stable on hover.
+        false: "cursor-default",
       },
       disabled: {
         true: "opacity-50 cursor-not-allowed",
@@ -44,7 +47,9 @@ const chipVariants = cva(
       },
     },
     compoundVariants: [
-      // Chip não-interativo e não selecionado → neutraliza hover
+      // Chip não-interativo e não selecionado → neutraliza hover do estado
+      // padrão (resting). Os outros 3 cantos da matriz são governados pelos
+      // variants `selected`/`interactive` diretamente, conforme ADR-002.
       {
         interactive: false,
         selected: false,


### PR DESCRIPTION
## Summary

Codifies the **hover-on-checked policy** for `action`-painted surfaces and aligns Chip — the lone outlier across the 9 components migrated in #125.

- **`docs/adr/ADR-002-hover-on-action-surfaces.md`** (new) — accepts the decision: hover MUST NOT override `data-[state=checked]` / `selected={true}` on `bg-action` surfaces. The element keeps `action` tokens stable regardless of cursor position.
- **Chip** — `variant: selected: true` drops `hover:bg-action-hover hover:border-action-hover hover:text-button-fg-hover`. One `// WHY:` comment points at the ADR.
- **Test** — `chip.test.tsx` flips the brand-token guard: the previous test asserted the hover override existed; the new test asserts it does NOT exist on `selected`.

**Aligned (no change):** Checkbox, Radio (already follow the policy). **Out of scope:** IconButton, Select, Combobox (no `checked` state on the surface in question).

## Why this is just one component

Of the 6 components that could expose the divergence, 5 already match the new ADR. Chip was the only one shipping with hover overrides on `selected: true` after #125. The PR's footprint is small because the decision was already implicit in the majority — this PR makes it explicit and corrects the outlier.

## Visual regression

Chip's `Selected` story will produce a pixel diff on Ubuntu/CI render (hover state no longer shifts color). Apply `regenerate-baselines` to push the new baselines.

## Test plan

- [x] `docs/adr/ADR-002-hover-on-action-surfaces.md` written with full context, decision, trade-offs (incl. rejected counter-arguments), and enforcement
- [x] `npm test` — 462/462 passing
- [x] `npm run typecheck` — clean
- [x] `npm run build` — 67 files / 335.8 kB / 86.5 kB gzipped
- [x] `ui_kit/components/chip/chip.test.tsx` flips the assertion for the `selected` variant
- [ ] CI Visual regression — expected to fail until baselines regenerate via label
- [ ] Argos cross-check the other 5 components in scope (Checkbox/Radio/IconButton/Select/Combobox) — no edits expected, just confirm conformance

Closes #166
Refs #159
