### PR TITLE
chore(form-triggers): use enabled:hover: in 4 composites (#169)

### DIFF
--- a/ui_kit/components/combobox/combobox.test.tsx
+++ b/ui_kit/components/combobox/combobox.test.tsx
@@ -265,6 +265,15 @@ describe("Combobox", () => {
       expect(cls).not.toContain("guardia-violet");
     });
 
+    it("trigger gates hover via `enabled:` modifier (no `disabled:hover:` override, per #169)", () => {
+      // WHY: enabled:hover:border-action substitui o par verboso
+      // hover:border-action + disabled:hover:border-border-strong. Ver #169.
+      render(<Combobox options={PLANOS} />);
+      const trigger = screen.getByRole("combobox");
+      expect(trigger.className).toMatch(/enabled:hover:border-action/);
+      expect(trigger.className).not.toMatch(/disabled:hover:/);
+    });
+
     it("AC-3: selected option uses bg-action + text-button-fg", async () => {
       render(<Combobox options={PLANOS} defaultValue="pro" />);
       await userEvent.click(screen.getByRole("combobox"));

--- a/ui_kit/components/combobox/index.tsx
+++ b/ui_kit/components/combobox/index.tsx
@@ -62,7 +62,7 @@ const triggerVariants = cva(
     "text-left cursor-pointer",
     "transition-[border-color,box-shadow] duration-150",
     /* Hover (não disabled): border action (violet-500 light / orange-500 dark) */
-    "hover:border-action disabled:hover:border-border-strong",
+    "enabled:hover:border-action",
     /* Focus / open: ring laranja */
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
     "data-[state=open]:border-action data-[state=open]:ring-2 data-[state=open]:ring-ring data-[state=open]:ring-offset-2",

--- a/ui_kit/components/date-picker/date-picker.test.tsx
+++ b/ui_kit/components/date-picker/date-picker.test.tsx
@@ -215,6 +215,15 @@ describe("DatePicker", () => {
       expect(trigger.className).not.toMatch(/guardia-violet-(100|500|700)/);
     });
 
+    it("trigger gates hover via `enabled:` modifier (no `disabled:hover:` override, per #169)", () => {
+      // WHY: enabled:hover:border-action substitui o par verboso
+      // hover:border-action + disabled:hover:border-border-strong. Ver #169.
+      render(<DatePicker />);
+      const trigger = screen.getByRole("button", { name: "Selecionar data" });
+      expect(trigger.className).toMatch(/enabled:hover:border-action/);
+      expect(trigger.className).not.toMatch(/disabled:hover:/);
+    });
+
     it("dia selecionado renderiza com bg-action + text-button-fg", async () => {
       const user = userEvent.setup();
       render(<DatePicker defaultValue={new Date(2025, 5, 15)} />);

--- a/ui_kit/components/date-picker/index.tsx
+++ b/ui_kit/components/date-picker/index.tsx
@@ -51,7 +51,7 @@ const triggerVariants = cva(
     "text-left cursor-pointer",
     "transition-[border-color,box-shadow] duration-150",
     /* Hover + open: border action (violet light / orange dark) */
-    "hover:border-action disabled:hover:border-border-strong",
+    "enabled:hover:border-action",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
     "data-[state=open]:border-action data-[state=open]:ring-2 data-[state=open]:ring-ring data-[state=open]:ring-offset-2",
     "aria-[invalid=true]:border-destructive aria-[invalid=true]:hover:border-destructive",

--- a/ui_kit/components/file-upload/file-upload.test.tsx
+++ b/ui_kit/components/file-upload/file-upload.test.tsx
@@ -157,6 +157,17 @@ describe("FileUpload — brand-aware tokens", () => {
     expect(button.className).not.toMatch(/hover:border-guardia-violet-500/);
   });
 
+  it("variant=button gates hover via `enabled:` modifier (no `disabled:hover:` override, per #169)", () => {
+    // WHY: enabled:hover:* substitui o par verboso
+    // hover:* + disabled:hover:* no botão (form element nativo). Ver #169.
+    // O dropzone (variant=default) usa pointer-events-none e fica fora deste guard.
+    render(<FileUpload variant="button" />);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/enabled:hover:bg-bg-hover/);
+    expect(button.className).toMatch(/enabled:hover:border-action/);
+    expect(button.className).not.toMatch(/disabled:hover:/);
+  });
+
   it("variant=button icon usa text-action (sem guardia-violet hardcoded)", () => {
     render(<FileUpload variant="button" />);
     const icon = screen.getByRole("button").querySelector("span[aria-hidden]")!;

--- a/ui_kit/components/file-upload/index.tsx
+++ b/ui_kit/components/file-upload/index.tsx
@@ -508,10 +508,10 @@ const FileUpload = React.forwardRef<HTMLInputElement, FileUploadProps>(
                 "inline-flex w-fit items-center",
                 "rounded-md border border-border-strong bg-background text-fg",
                 "transition-[background-color,border-color,box-shadow] duration-150",
-                /* Hover: brand-aware soft tint + action border (violet light / orange dark) */
-                "hover:bg-bg-hover hover:border-action",
+                /* Hover (não disabled): brand-aware soft tint + action border (violet light / orange dark) */
+                "enabled:hover:bg-bg-hover enabled:hover:border-action",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                "disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:bg-background disabled:hover:border-border-strong",
+                "disabled:cursor-not-allowed disabled:opacity-55",
                 buttonClasses[buttonSize],
               )}
             >

--- a/ui_kit/components/select/index.tsx
+++ b/ui_kit/components/select/index.tsx
@@ -52,7 +52,7 @@ const triggerVariants = cva(
     "border border-border-strong rounded-md",
     "text-left cursor-pointer",
     "transition-[border-color,box-shadow] duration-150",
-    "hover:border-action disabled:hover:border-border-strong",
+    "enabled:hover:border-action",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
     "data-[state=open]:border-action data-[state=open]:ring-2 data-[state=open]:ring-ring data-[state=open]:ring-offset-2",
     "aria-[invalid=true]:border-destructive aria-[invalid=true]:hover:border-destructive",

--- a/ui_kit/components/select/select.test.tsx
+++ b/ui_kit/components/select/select.test.tsx
@@ -262,6 +262,15 @@ describe("Select", () => {
       expect(trigger.className).not.toMatch(/hover:border-guardia-violet-500/);
     });
 
+    it("trigger gates hover via `enabled:` modifier (no `disabled:hover:` override, per #169)", () => {
+      // WHY: enabled:hover:border-action substitui o par verboso
+      // hover:border-action + disabled:hover:border-border-strong. Ver #169.
+      render(<Select options={PLANOS} />);
+      const trigger = screen.getByRole("combobox");
+      expect(trigger.className).toMatch(/enabled:hover:border-action/);
+      expect(trigger.className).not.toMatch(/disabled:hover:/);
+    });
+
     it("trigger usa border-action quando aberto (data-state=open)", () => {
       render(<Select options={PLANOS} />);
       const trigger = screen.getByRole("combobox");


### PR DESCRIPTION
## Summary

Replaces the verbose `hover:X disabled:hover:Y` pattern with `enabled:hover:X` in the 4 form-trigger composites that used the override style (Select, Combobox, DatePicker, FileUpload variant=button). The other 5 components from #125 already handle disabled correctly via different mechanics and stay untouched.

Plan B of #159 (parent Tech Task). Plan A (#166) landed in PR #167.

## Why only 4 of the 9 components

Survey concrete done before opening the Plan:

| Category | Components | Why no change needed |
|---|---|---|
| **Form-trigger composites with explicit override** | Select, Combobox, DatePicker, FileUpload | **← this PR** |
| **Bare hover on native form element** | Input, IconButton | `<input>`/`<button>` natively respect `:disabled` |
| **Bare hover on wrapper** | Checkbox, Radio, Chip | `<span>` + `pointer-events-none` OR Radix root state |

The original #159 body said "all 9 components" but the survey showed the pattern only diverged in those 4. Plan B body (#169) was reshaped accordingly.

## Diff at a glance

| File | Before | After |
|---|---|---|
| `select/index.tsx:55` | `hover:border-action disabled:hover:border-border-strong` | `enabled:hover:border-action` |
| `combobox/index.tsx:65` | same | `enabled:hover:border-action` |
| `date-picker/index.tsx:54` | same | `enabled:hover:border-action` |
| `file-upload/index.tsx:512-514` | `hover:bg-bg-hover hover:border-action` + `disabled:hover:bg-background disabled:hover:border-border-strong` | `enabled:hover:bg-bg-hover enabled:hover:border-action` (kept `disabled:cursor-not-allowed disabled:opacity-55`) |

Plus +1 brand-token guard test per component (4 total) asserting `enabled:hover:` presence + `disabled:hover:` absence.

## Test plan

- [x] `npm test` — 467/467 (+4 new)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — 67 files / 335.7 kB / 86.5 kB gzipped (unchanged)
- [x] No new visual story (the resting state of these triggers is byte-identical; visual regression baselines should not budge)
- [ ] Argos cross-check that the 5 out-of-scope components remain unchanged
- [ ] Manual smoke: hover a disabled `<Select>` / `<Combobox>` / `<DatePicker>` / `<FileUpload variant="button">` and confirm no border-color flash

Closes #169
Refs #159
