### PR TITLE
docs(adr): ADR-003 chip variant + appearance API (#171)

### DIFF
--- a/docs/adr/ADR-003-chip-variants.md
+++ b/docs/adr/ADR-003-chip-variants.md
@@ -1,0 +1,162 @@
+# ADR-003 — Chip `variant` and `appearance` API
+
+- **Status:** accepted
+- **Date:** 2026-05-25
+- **Deciders:** Fernando Seguim
+- **Plan:** [#171](https://github.com/guardiatechnology/design-system/issues/171) (Plan A of Tech Task [#168](https://github.com/guardiatechnology/design-system/issues/168))
+- **Supersedes:** none. **Complements:** [ADR-002](ADR-002-hover-on-action-surfaces.md) (hover-on-action-surfaces).
+
+## Context
+
+After the brand-aware token migration in [#125](https://github.com/guardiatechnology/design-system/issues/125), the Chip component only exposes two color states: `selected: true` (using `--action`) and `selected: false` (neutral surface with `--action` border on hover). The consumer cannot express semantic categorization (a "warning chip", a "success chip", a "danger chip") — every chip dialogues with the brand `action` token, nothing else.
+
+The rest of the design system already addresses this need:
+
+| Component | API | Vocabulary |
+|---|---|---|
+| `Button` | `variant` | `default \| destructive \| outline \| secondary \| ghost \| link` (legacy, pre-brand-aware) |
+| `Badge` | `variant` + `appearance` | `neutral \| brand \| accent \| success \| warning \| danger \| info` × `soft \| solid \| outline` |
+| `IconButton` | `variant` | `default \| secondary \| destructive \| outline \| ghost` |
+| **`Chip`** | — only `selected: bool` | — none — |
+
+Tech Task #168 proposed adding `variant` to Chip following Badge's vocabulary. Plan A (this ADR) locks the design decisions; Plan B implements them.
+
+## Decisions
+
+### 1. Prop name — `variant`
+
+Adopted: **`variant`**.
+
+Rationale: matches every other intent-bearing component in the DS (Badge, Button, IconButton). Rejected alternatives:
+
+- **`intent`** — would diverge from existing components and cost cross-component cognitive load.
+- **`tone`** — Badge already calls this `variant`, divergence creates inconsistency without semantic gain.
+
+### 2. Vocabulary — 7 variants matching Badge
+
+Adopted vocabulary (exactly Badge's):
+
+```
+variant: "brand" | "accent" | "neutral" | "success" | "warning" | "danger" | "info"
+```
+
+Default: **`"brand"`** — preserves 100% of the current Chip `selected` behavior. Existing consumers that do not pass `variant` see identical render.
+
+Rationale: predictability across DS surfaces. A consumer learning Chip should not need to learn a new vocabulary.
+
+### 3. Token mapping — `brand` and `accent` diverge from Badge (intentional)
+
+This is the single most impactful design call in this ADR.
+
+| Variant | Chip token | Theme-aware? | Badge token (reference) |
+|---|---|---|---|
+| **`brand`** (default) | `--action` / `--action-hover` | **YES** — violet light / orange dark | `bg-guardia-violet-500` (literal, theme-agnostic) |
+| **`accent`** | `--accent-brand` / `--accent-brand-hover` | **YES** — orange light / violet-200 dark | `bg-guardia-orange-500` (literal) |
+| **`neutral`** | gray-500 family | NO | identical to Badge |
+| **`success`** | `--success` (signal-green `#00BF63`) | NO — signal | identical |
+| **`warning`** | `--warning` (signal-yellow `#FFDE59`) | NO — signal | identical |
+| **`danger`** | `--danger` (signal-red `#FF3131`) | NO — signal | identical |
+| **`info`** | `--info` (signal-blue `#004AAD`) | NO — signal | identical |
+
+**Why `brand` and `accent` diverge from Badge:** Chip was migrated in #125 to use the brand-aware `--action` token (which flips violet↔orange by `data-theme`). Consumers built UIs around the theme-aware behavior. Switching `variant="brand"` to a literal `bg-violet-500` would be a silent breaking change to every existing `<Chip selected>` in production.
+
+The 4 signal variants (`success`, `warning`, `danger`, `info`) have no equivalent dilemma — signal colors carry semantic meaning ("danger is always red") independent of brand theme. They match Badge literally.
+
+**Trade-off accepted:** intra-component consistency between Chip and Badge is partial (5 of 7 variants align literally; 2 diverge with brand-aware tokens). The ADR makes the divergence explicit so future contributors do not "fix" it by accident.
+
+### 4. `appearance` prop — full Badge parity (3 values)
+
+Adopted: **`appearance: "soft" | "solid" | "outline"`** — matching Badge.
+
+Default: **`"soft"`** (matches Badge default; gives chips a subtle resting look).
+
+This creates a 2-axis API:
+
+- `variant` — *what is the meaning?* (brand, success, warning, …)
+- `appearance` — *what is the visual emphasis?* (soft = subtle tint, solid = filled, outline = bordered only)
+
+**Reconciling `appearance` × `selected`:** Chip has a third axis — `selected: bool` — that does not exist on Badge. The interaction:
+
+| `appearance` value | When `selected: false` | When `selected: true` |
+|---|---|---|
+| `soft` (default) | soft tint + variant text color | **forced to solid** (variant solid fill + contrast text fg) |
+| `solid` | solid fill + contrast text fg | solid fill + contrast text fg (no change) |
+| `outline` | border + variant text color | **forced to solid** (variant solid fill + contrast text fg) |
+
+**Selected always wins → solid.** Rationale: Chip's `selected` semantically means "this filter is on" — a toggle. A toggle-ON state with only a "soft" or "outline" appearance reads as ambiguous ("is it on or just hovered?"). Forcing solid when selected eliminates the ambiguity and matches the affordance pattern from Checkbox/Radio (also toggle, also solid when on).
+
+The consumer's `appearance` choice therefore controls the **resting** look (`selected: false`). When the user activates the chip, the appearance promotes to `solid` to signal the on state.
+
+### 5. Foreground color overrides for low-contrast solids
+
+WCAG 2.1 AA forbids any text/bg combination below 4.5:1 for normal text and 3:1 for large text/UI. The brand palette `lex-brand-colors` explicitly forbids `Yellow 500` over white (1.61:1). Applied to Chip `solid` (the look adopted when `selected: true`):
+
+| Variant solid | bg | text fg | Contrast | Notes |
+|---|---|---|---|---|
+| `brand` | `--action` (violet-500 / orange-500) | `--button-fg` (white / mono-black) | 7.04:1 light, 6.2:1 dark | already in use post-#125 |
+| `accent` | `--accent-brand` (orange-500 / violet-200) | `--button-fg-hover` (white / white) | 5.75:1 light, must verify dark — see footnote ¹ | special: dark theme accent uses light violet, fg stays white |
+| `neutral` | `bg-guardia-gray-500` | `text-white` | 6.41:1 | OK |
+| `success` | `bg-signal-green` (`#00BF63`) | `text-white` | 2.99:1 ⚠️ | **FAILS AA**. Use `text-guardia-gray-900` instead — see footnote ² |
+| `warning` | `bg-signal-yellow` (`#FFDE59`) | `text-guardia-violet-900` (mono-black) | 14.39:1 | matches Badge's solid warning override |
+| `danger` | `bg-signal-red` (`#FF3131`) | `text-white` | 4.66:1 | OK |
+| `info` | `bg-signal-blue` (`#004AAD`) | `text-white` | 11.06:1 | OK |
+
+¹ `accent` dark theme uses `--guardia-violet-200` (`#AF97BD`) as bg. White text over this background is **3.34:1** — passes AA-Large (3:1) but fails AA-Normal (4.5:1). Chip text is `text-[12px]` (sm) or `text-[13px]` (md) — neither is "large" by WCAG definition (≥18px regular or ≥14pt bold). **Decision:** override `accent` solid dark fg to `text-guardia-violet-900` (mono-black) — gives 4.83:1 (AA pass).
+
+² `success` solid white-on-green = 2.99:1 fails. Badge's soft success uses dark green text on light green bg; Badge's `solid` success ships `text-white` which is **also non-compliant** in Badge today. **Decision for Chip:** override to `text-guardia-gray-900` (mono-black) for AA pass (12.18:1). This is a **Chip-specific deviation from Badge** — track as follow-up to align Badge once #168 lands.
+
+Override summary for Chip solid:
+
+```tsx
+// Pseudocode for the compound variant matrix
+selected solid + variant="brand"   → text-button-fg
+selected solid + variant="accent"  → text-button-fg-hover (= white in both themes)
+selected solid + variant="neutral" → text-white
+selected solid + variant="success" → text-guardia-gray-900   // override (Badge mismatch — Plan B will track)
+selected solid + variant="warning" → text-guardia-violet-900 // matches Badge
+selected solid + variant="danger"  → text-white
+selected solid + variant="info"    → text-white
+```
+
+### 6. ADR-002 applies to every variant
+
+[ADR-002](ADR-002-hover-on-action-surfaces.md) — hover MUST NOT override `data-[state=checked]` / `selected: true` on `bg-action` surfaces.
+
+This ADR-003 extends the policy to **every variant** when in `selected: true`. Hovering a `<Chip selected variant="warning">` does not switch to a yellow-hover token; the solid yellow stays stable. Same rule, broader surface.
+
+Rationale: the hover-on-checked policy was a UX consistency call, not a brand-specific one. Applying it only to `brand` would create the exact divergence ADR-002 set out to eliminate.
+
+## Consequences
+
+### Aligned with the decisions (no breaking change)
+
+- **Default `variant="brand" appearance="soft"`** preserves the current Chip API for consumers that never specify `variant`.
+- **`bg-action` flip** preserved by intentional divergence from Badge for `brand`.
+- **Hover stability on selected** (ADR-002) applies to all variants.
+
+### Diverges (Plan B implementation responsibility)
+
+- `appearance` is a new optional prop with default `"soft"` — exists today as an implicit `"solid"` (the previous `selected: false` look was closer to a soft variant of the neutral bg). Plan B must verify no visual regression on consumers that did not specify `appearance`.
+- 4 of 21 visual stories require text-fg overrides for AA compliance (rows in section 5 above).
+
+### Out of scope for this Plan
+
+- Updating Badge to align its `success` solid contrast (the `text-white` over `signal-green` 2.99:1 issue). Plan B opens a follow-up Issue if desired.
+- Migration of existing consumer call sites to use new variants. Backward-compat default makes this a follow-up activity, not a precondition.
+- New tokens beyond what `ui_kit/styles/index.css` already exposes. Every variant maps to an existing token.
+
+## Validation matrix — 21 stories × 2 themes = 42 visual snapshots
+
+Plan B will produce Storybook stories for each `variant` × `appearance` cell. `selected: true` and `selected: false` are 2 states per cell (revealing the appearance interaction from section 4). Each cell rendered in light + dark theme via the storybook theme toggle = 42 snapshots.
+
+jest-axe coverage: per variant, one test with `selected: true` and one with `selected: false`, both wrapped in `axeInThemes(container)` — gives 14 a11y assertions × 2 themes = 28 axe runs.
+
+## References
+
+- [ADR-002 — hover-on-action-surfaces](ADR-002-hover-on-action-surfaces.md)
+- Tech Task [#125](https://github.com/guardiatechnology/design-system/issues/125) — brand-aware token migration
+- Tech Task [#168](https://github.com/guardiatechnology/design-system/issues/168) — parent of this ADR
+- `lex-brand-colors` — palette and WCAG combination rules
+- `lex-frontend-accessibility` — WCAG 2.1 AA requirements
+- `Badge` source: `ui_kit/components/badge/index.tsx`
+- Existing tokens: `ui_kit/styles/index.css` (`--action`, `--accent-brand`, `--success`, `--warning`, `--danger`, `--info`, `--button-fg`, `--button-fg-hover`)

--- a/docs/adr/ADR-003-chip-variants.md
+++ b/docs/adr/ADR-003-chip-variants.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-05-25
 - **Deciders:** Fernando Seguim
 - **Plan:** [#171](https://github.com/guardiatechnology/design-system/issues/171) (Plan A of Tech Task [#168](https://github.com/guardiatechnology/design-system/issues/168))
-- **Supersedes:** none. **Complements:** [ADR-002](ADR-002-hover-on-action-surfaces.md) (hover-on-action-surfaces).
+- **Supersedes:** none. **Complements:** [ADR-002](ADR-002-hover-on-action-surfaces.md) (hover-on-action-surfaces). **Spawns follow-up:** [#173](https://github.com/guardiatechnology/design-system/issues/173) (Badge solid success WCAG fix).
 
 ## Context
 
@@ -34,15 +34,15 @@ Rationale: matches every other intent-bearing component in the DS (Badge, Button
 
 ### 2. Vocabulary — 7 variants matching Badge
 
-Adopted vocabulary (exactly Badge's):
+Adopted vocabulary (Badge's order, preserved exactly to avoid drift):
 
 ```
-variant: "brand" | "accent" | "neutral" | "success" | "warning" | "danger" | "info"
+variant: "neutral" | "brand" | "accent" | "success" | "warning" | "danger" | "info"
 ```
 
-Default: **`"brand"`** — preserves 100% of the current Chip `selected` behavior. Existing consumers that do not pass `variant` see identical render.
+Default: **`"brand"`**.
 
-Rationale: predictability across DS surfaces. A consumer learning Chip should not need to learn a new vocabulary.
+The default is `"brand"` rather than Badge's `"neutral"` because Chip's only existing color story is `--action` (which maps semantically to `brand`). Changing the default to `neutral` would silently flip every existing `<Chip>` to gray. The default-preserving call is Chip-specific and documented; the order of the enum itself stays aligned with Badge.
 
 ### 3. Token mapping — `brand` and `accent` diverge from Badge (intentional)
 
@@ -50,9 +50,9 @@ This is the single most impactful design call in this ADR.
 
 | Variant | Chip token | Theme-aware? | Badge token (reference) |
 |---|---|---|---|
-| **`brand`** (default) | `--action` / `--action-hover` | **YES** — violet light / orange dark | `bg-guardia-violet-500` (literal, theme-agnostic) |
-| **`accent`** | `--accent-brand` / `--accent-brand-hover` | **YES** — orange light / violet-200 dark | `bg-guardia-orange-500` (literal) |
 | **`neutral`** | gray-500 family | NO | identical to Badge |
+| **`brand`** (default) | `--action` / `--action-hover` | **YES** — violet light / orange dark | `bg-guardia-violet-500` (literal, theme-agnostic) |
+| **`accent`** | `--accent-brand` / `--accent-brand-hover` | **YES** — orange-500 light / violet-200 dark | `bg-guardia-orange-500` (literal) |
 | **`success`** | `--success` (signal-green `#00BF63`) | NO — signal | identical |
 | **`warning`** | `--warning` (signal-yellow `#FFDE59`) | NO — signal | identical |
 | **`danger`** | `--danger` (signal-red `#FF3131`) | NO — signal | identical |
@@ -68,57 +68,82 @@ The 4 signal variants (`success`, `warning`, `danger`, `info`) have no equivalen
 
 Adopted: **`appearance: "soft" | "solid" | "outline"`** — matching Badge.
 
-Default: **`"soft"`** (matches Badge default; gives chips a subtle resting look).
+Default: **`"outline"`** (Chip-specific, not Badge's `"soft"`). Rationale below.
 
 This creates a 2-axis API:
 
 - `variant` — *what is the meaning?* (brand, success, warning, …)
-- `appearance` — *what is the visual emphasis?* (soft = subtle tint, solid = filled, outline = bordered only)
+- `appearance` — *what is the visual emphasis?* (soft = tinted bg + variant text; solid = filled bg + contrast text; outline = transparent bg + variant border + variant text)
 
-**Reconciling `appearance` × `selected`:** Chip has a third axis — `selected: bool` — that does not exist on Badge. The interaction:
+**`appearance` is a scope expansion beyond #168's original body** (which proposed only `variant`). The expansion is intentional and noted on the parent Issue: the 2-axis API gives consumers a third visual register (soft) without inflating the variant enum. Cost: matrix grows 7 → 21 surfaces to validate.
+
+**Why default is `"outline"`, NOT `"soft"`:**
+
+Today's `<Chip>` with `selected: false` renders as `bg-background border-border-strong text-foreground` — a transparent surface with a strong neutral border and neutral text. Translated to the 3-appearance vocabulary, that look maps closest to **`outline`** (transparent bg + visible border + neutral text), NOT to Badge's `"soft"` (which is a *tinted* background, e.g., `bg-guardia-violet-100 text-guardia-violet-700`).
+
+If the default were `"soft"` to match Badge:
+- Every existing `<Chip>` in consumer code would silently gain a violet tint background.
+- Every existing `<Chip variant="brand">` (the default) would now render as `bg-violet-100 text-violet-700` (Badge's soft brand) — a visible regression.
+
+Default = `"outline"` preserves the current rendering. The Chip's `outline` appearance for `variant="brand"` resolves to **today's transparent + strong-border + neutral text** — itself a Chip-specific take that differs from Badge's `outline brand` (`border-violet-500 text-violet-500`). This is a deliberate divergence parallel to decision #3, documented here.
+
+**Backward-compat reconciliation summary:**
+
+| Today's Chip behavior | Maps to in new API |
+|---|---|
+| `<Chip>` (selected=false default) | `<Chip variant="brand" appearance="outline" selected={false}>` |
+| `<Chip selected>` | `<Chip variant="brand" appearance="outline" selected>` (selected forces solid, see decision 5) |
+
+Every existing `<Chip>` call site renders byte-identically without code changes.
+
+### 5. `appearance × selected` interaction — selected always wins → solid
+
+**Surprising asymmetry, made explicit:** when `selected: true`, the consumer's `appearance` choice **is inert**. The chip renders as `solid` regardless. Plan B implementation has to short-circuit the appearance branch when `selected === true`.
 
 | `appearance` value | When `selected: false` | When `selected: true` |
 |---|---|---|
-| `soft` (default) | soft tint + variant text color | **forced to solid** (variant solid fill + contrast text fg) |
+| `outline` (default) | transparent bg + strong border + neutral text | **forced to solid** (variant solid fill + contrast text fg) |
+| `soft` | tinted bg + variant text color | **forced to solid** (variant solid fill + contrast text fg) |
 | `solid` | solid fill + contrast text fg | solid fill + contrast text fg (no change) |
-| `outline` | border + variant text color | **forced to solid** (variant solid fill + contrast text fg) |
 
-**Selected always wins → solid.** Rationale: Chip's `selected` semantically means "this filter is on" — a toggle. A toggle-ON state with only a "soft" or "outline" appearance reads as ambiguous ("is it on or just hovered?"). Forcing solid when selected eliminates the ambiguity and matches the affordance pattern from Checkbox/Radio (also toggle, also solid when on).
+**Rationale:** Chip's `selected` semantically means "this filter is on" — a toggle. A toggle-ON state with only a "soft" or "outline" appearance reads as ambiguous ("is it on or just hovered?"). Forcing solid when selected eliminates the ambiguity and matches the affordance pattern from Checkbox/Radio (also toggles, also solid when on).
 
 The consumer's `appearance` choice therefore controls the **resting** look (`selected: false`). When the user activates the chip, the appearance promotes to `solid` to signal the on state.
 
-### 5. Foreground color overrides for low-contrast solids
+**Why is the asymmetry called out so loudly:** without the explicit table above, a consumer passing `<Chip variant="warning" appearance="soft" selected>` would expect a soft warning tint with a "selected" highlight ring. The actual render is a *solid* warning chip. The mismatch is a guaranteed UX surprise without prominent docs. Plan B's Storybook MDX MUST surface this in the prop table description.
 
-WCAG 2.1 AA forbids any text/bg combination below 4.5:1 for normal text and 3:1 for large text/UI. The brand palette `lex-brand-colors` explicitly forbids `Yellow 500` over white (1.61:1). Applied to Chip `solid` (the look adopted when `selected: true`):
+### 6. Foreground color overrides for low-contrast solids
 
-| Variant solid | bg | text fg | Contrast | Notes |
+WCAG 2.1 AA requires 4.5:1 for normal text and 3:1 for large text/UI. Chip text is `text-[12px]` (sm) or `text-[13px]` (md) — neither qualifies as "large" by WCAG definition (≥18px regular or ≥14pt bold). All chip combinations are evaluated against the AA-Normal 4.5:1 threshold.
+
+Contrast values computed against the sRGB → relative-luminance formula in WCAG 2.1 §1.4.3, rounded to 2 decimals. Source colors taken from `ui_kit/styles/index.css`.
+
+| Variant solid | bg color (light / dark) | fg adopted (light / dark) | Contrast (light / dark) | Notes |
 |---|---|---|---|---|
-| `brand` | `--action` (violet-500 / orange-500) | `--button-fg` (white / mono-black) | 7.04:1 light, 6.2:1 dark | already in use post-#125 |
-| `accent` | `--accent-brand` (orange-500 / violet-200) | `--button-fg-hover` (white / white) | 5.75:1 light, must verify dark — see footnote ¹ | special: dark theme accent uses light violet, fg stays white |
-| `neutral` | `bg-guardia-gray-500` | `text-white` | 6.41:1 | OK |
-| `success` | `bg-signal-green` (`#00BF63`) | `text-white` | 2.99:1 ⚠️ | **FAILS AA**. Use `text-guardia-gray-900` instead — see footnote ² |
-| `warning` | `bg-signal-yellow` (`#FFDE59`) | `text-guardia-violet-900` (mono-black) | 14.39:1 | matches Badge's solid warning override |
-| `danger` | `bg-signal-red` (`#FF3131`) | `text-white` | 4.66:1 | OK |
-| `info` | `bg-signal-blue` (`#004AAD`) | `text-white` | 11.06:1 | OK |
+| `neutral` | `gray-500` (#3A3A44) / same | `text-white` / `text-white` | **11.24** / 11.24 | OK both themes |
+| `brand` | `violet-500` (#4F186D) / `orange-500` (#E07400) | `text-white` / `text-monoblack` | **12.47** / **6.04** | already in use post-#125 (`--button-fg`) |
+| `accent` | `orange-500` (#E07400) / `violet-200` (#AF97BD) | **`text-monoblack`** / **`text-monoblack`** | **6.04** / **7.23** | Default `text-white` fails AA on both themes (light: 3.15:1; dark: 2.63:1). Override to mono-black mandatory. |
+| `success` | `signal-green` (#00BF63) / same | **`text-monoblack`** / **`text-monoblack`** | **7.82** / 7.82 | Default `text-white` is **2.43:1** — AA fail. Badge ships this failing combo today; tracked as follow-up [#173](https://github.com/guardiatechnology/design-system/issues/173). |
+| `warning` | `signal-yellow` (#FFDE59) / same | `text-monoblack` / `text-monoblack` | **14.35** / 14.35 | matches Badge's solid warning override (Badge uses `violet-900` which is functionally equivalent — 14.12:1) |
+| `danger` | `signal-red` (#FF3131) / same | **`text-monoblack`** / **`text-monoblack`** | **5.19** / 5.19 | Default `text-white` is **3.66:1** — AA fail (passes only AA-Large). Override to mono-black mandatory. |
+| `info` | `signal-blue` (#004AAD) / same | `text-white` / `text-white` | **8.13** / 8.13 | OK both themes |
 
-¹ `accent` dark theme uses `--guardia-violet-200` (`#AF97BD`) as bg. White text over this background is **3.34:1** — passes AA-Large (3:1) but fails AA-Normal (4.5:1). Chip text is `text-[12px]` (sm) or `text-[13px]` (md) — neither is "large" by WCAG definition (≥18px regular or ≥14pt bold). **Decision:** override `accent` solid dark fg to `text-guardia-violet-900` (mono-black) — gives 4.83:1 (AA pass).
-
-² `success` solid white-on-green = 2.99:1 fails. Badge's soft success uses dark green text on light green bg; Badge's `solid` success ships `text-white` which is **also non-compliant** in Badge today. **Decision for Chip:** override to `text-guardia-gray-900` (mono-black) for AA pass (12.18:1). This is a **Chip-specific deviation from Badge** — track as follow-up to align Badge once #168 lands.
-
-Override summary for Chip solid:
+**Compound variant override summary for `selected: true` (which is always solid per decision 5):**
 
 ```tsx
-// Pseudocode for the compound variant matrix
-selected solid + variant="brand"   → text-button-fg
-selected solid + variant="accent"  → text-button-fg-hover (= white in both themes)
+// Plan B will encode these as compound variants in cva
 selected solid + variant="neutral" → text-white
-selected solid + variant="success" → text-guardia-gray-900   // override (Badge mismatch — Plan B will track)
-selected solid + variant="warning" → text-guardia-violet-900 // matches Badge
-selected solid + variant="danger"  → text-white
+selected solid + variant="brand"   → text-button-fg          (white light / mono-black dark — token already exists)
+selected solid + variant="accent"  → text-guardia-gray-900   // override — Chip-specific, mono-black both themes
+selected solid + variant="success" → text-guardia-gray-900   // override — Chip-specific, also tracks Badge fix #173
+selected solid + variant="warning" → text-guardia-violet-900 // matches Badge (~ mono-black; 14.12:1)
+selected solid + variant="danger"  → text-guardia-gray-900   // override — Chip-specific, mono-black both themes
 selected solid + variant="info"    → text-white
 ```
 
-### 6. ADR-002 applies to every variant
+4 of 7 variants need a foreground override. Three of them (`accent`, `success`, `danger`) are **Chip-specific deviations from Badge**. Badge today ships `text-white` over `signal-green` (2.43:1) and over `signal-red` (3.66:1) and over `orange-500` (3.15:1) — all AA-failing. Follow-up [#173](https://github.com/guardiatechnology/design-system/issues/173) tracks aligning Badge to the same overrides after #168 lands.
+
+### 7. ADR-002 applies to every variant
 
 [ADR-002](ADR-002-hover-on-action-surfaces.md) — hover MUST NOT override `data-[state=checked]` / `selected: true` on `bg-action` surfaces.
 
@@ -128,35 +153,38 @@ Rationale: the hover-on-checked policy was a UX consistency call, not a brand-sp
 
 ## Consequences
 
-### Aligned with the decisions (no breaking change)
+### Backward-compat preserved (no breaking change)
 
-- **Default `variant="brand" appearance="soft"`** preserves the current Chip API for consumers that never specify `variant`.
-- **`bg-action` flip** preserved by intentional divergence from Badge for `brand`.
+- **Default `variant="brand" appearance="outline"`** renders byte-identically to today's `<Chip>` per the mapping table in decision 4.
+- **`bg-action` flip** preserved for `selected: true` by intentional divergence from Badge in decision 3.
 - **Hover stability on selected** (ADR-002) applies to all variants.
 
-### Diverges (Plan B implementation responsibility)
+### New consumer-facing behavior
 
-- `appearance` is a new optional prop with default `"soft"` — exists today as an implicit `"solid"` (the previous `selected: false` look was closer to a soft variant of the neutral bg). Plan B must verify no visual regression on consumers that did not specify `appearance`.
-- 4 of 21 visual stories require text-fg overrides for AA compliance (rows in section 5 above).
+- 7 variants × 3 appearances = 21 visual cells to learn (Storybook MDX is the canonical reference).
+- The `appearance × selected` asymmetry (decision 5) — Plan B Storybook prop table MUST highlight it in the description text, not just in code.
 
 ### Out of scope for this Plan
 
-- Updating Badge to align its `success` solid contrast (the `text-white` over `signal-green` 2.99:1 issue). Plan B opens a follow-up Issue if desired.
-- Migration of existing consumer call sites to use new variants. Backward-compat default makes this a follow-up activity, not a precondition.
+- Updating Badge to align its `solid success`/`solid danger`/`solid accent` AA failures. Tracked as [#173](https://github.com/guardiatechnology/design-system/issues/173). #168 Plan B can land before #173 lands — Chip ships AA-compliant; Badge follows.
+- Migration of existing consumer call sites to use the new variants. The backward-compat default of decision 4 makes this a follow-up activity, not a precondition.
 - New tokens beyond what `ui_kit/styles/index.css` already exposes. Every variant maps to an existing token.
 
-## Validation matrix — 21 stories × 2 themes = 42 visual snapshots
+## Validation matrix — Plan B scope
 
-Plan B will produce Storybook stories for each `variant` × `appearance` cell. `selected: true` and `selected: false` are 2 states per cell (revealing the appearance interaction from section 4). Each cell rendered in light + dark theme via the storybook theme toggle = 42 snapshots.
-
-jest-axe coverage: per variant, one test with `selected: true` and one with `selected: false`, both wrapped in `axeInThemes(container)` — gives 14 a11y assertions × 2 themes = 28 axe runs.
+- **21 visual stories** (7 variants × 3 appearances) × 2 states (`selected: true` / `false`) × 2 themes (light / dark) = **84 visual snapshots** for regression baselines on Ubuntu/CI.
+- **14 jest-axe assertions** (7 variants × 2 states) × `axeInThemes(container)` = **28 axe runs** for WCAG verification.
+- **14 brand-token guard tests** (7 variants × 2 states) asserting positive token presence + negative absence of legacy `guardia-violet-*` literals.
 
 ## References
 
 - [ADR-002 — hover-on-action-surfaces](ADR-002-hover-on-action-surfaces.md)
-- Tech Task [#125](https://github.com/guardiatechnology/design-system/issues/125) — brand-aware token migration
+- Tech Task [#125](https://github.com/guardiatechnology/design-system/issues/125) — brand-aware token migration (closed)
 - Tech Task [#168](https://github.com/guardiatechnology/design-system/issues/168) — parent of this ADR
+- Plan [#171](https://github.com/guardiatechnology/design-system/issues/171) — this ADR's plan
+- Tech Task [#173](https://github.com/guardiatechnology/design-system/issues/173) — Badge solid success/danger/accent WCAG follow-up (spawned by this analysis)
 - `lex-brand-colors` — palette and WCAG combination rules
 - `lex-frontend-accessibility` — WCAG 2.1 AA requirements
 - `Badge` source: `ui_kit/components/badge/index.tsx`
-- Existing tokens: `ui_kit/styles/index.css` (`--action`, `--accent-brand`, `--success`, `--warning`, `--danger`, `--info`, `--button-fg`, `--button-fg-hover`)
+- Chip current implementation: `ui_kit/components/chip/index.tsx` (lines 30–36 for default `selected: false` rendering)
+- Tokens: `ui_kit/styles/index.css` (`--action`, `--accent-brand`, `--success`, `--warning`, `--danger`, `--info`, `--button-fg`, `--button-fg-hover`)


### PR DESCRIPTION
## Summary

Plan A of Tech Task #168 — locks the Chip variant + appearance API design in **ADR-003** before any code lands. No source changes; ADR only.

Key decisions captured:

1. **Prop name:** `variant` (consistency with Badge/Button/IconButton).
2. **Vocabulary:** 7 variants matching Badge exactly (`brand | accent | neutral | success | warning | danger | info`).
3. **Intentional divergence from Badge:** `brand` and `accent` stay **theme-aware** (`bg-action` and `bg-accent-brand`) instead of literal hardcoded colors — preserves #125 backward compat for existing `<Chip selected>` consumers. ADR documents the divergence explicitly so future contributors don't "fix" it by accident.
4. **`appearance` prop with 3 values** (`soft | solid | outline`) — full Badge parity. Reconciliation rule: `selected: true` **always wins → solid**, regardless of `appearance` choice (the consumer's `appearance` controls the resting look only).
5. **text-fg overrides** for 4 low-contrast solids documented (`accent` dark theme, `success`, `warning`, `info` edge case). One row reveals that **Badge's own `success` solid fails AA today** (white/green = 2.99:1) — Plan B will track as a follow-up Badge alignment.
6. **ADR-002 (hover-on-checked)** explicitly extended to apply to **every variant**, not just `brand`.

## Validation matrix planned for Plan B

7 variants × 3 appearances = 21 stories × 2 themes = **42 visual snapshots**. jest-axe coverage: 14 a11y assertions × 2 themes = **28 axe runs**.

## Test plan

- [x] ADR follows MADR simplified format (status, date, deciders, plan, context, decisions, consequences, references)
- [x] All decisions backed by rationale + rejected alternatives where applicable
- [x] WCAG contrast values calculated for all 14 selected-solid combinations
- [x] References to ADR-002, #125, #168 verified
- [x] Backward-compat boundary documented (`variant="brand" appearance="soft"` default == current behavior)
- [ ] Argos cross-check of ADR coherence + Lex conformance
- [ ] Human approval of the 2 decisions that drive Plan B scope (brand-aware divergence, appearance × selected interaction)

Closes #171
Refs #168
