### PR TITLE
fix(badge): WCAG AA fg overrides for solid accent/success/danger

### DIFF
--- a/ui_kit/components/badge/badge.test.tsx
+++ b/ui_kit/components/badge/badge.test.tsx
@@ -49,11 +49,11 @@ describe("<Badge />", () => {
   // recompute (see PR #175 / Issue #173). Locked here to detect any future
   // regression where someone reverts to the base `text-white` default.
   it.each([
-    { variant: "accent" as const,  bg: "bg-guardia-orange-500", fg: "text-guardia-gray-900",   reason: "text-white over orange-500 = 3.15:1 fails AA-Normal" },
-    { variant: "success" as const, bg: "bg-signal-green",       fg: "text-guardia-gray-900",   reason: "text-white over signal-green = 2.43:1 fails AA-Normal AND AA-Large" },
-    { variant: "danger" as const,  bg: "bg-signal-red",         fg: "text-guardia-gray-900",   reason: "text-white over signal-red = 3.66:1 fails AA-Normal" },
-    { variant: "warning" as const, bg: "bg-signal-yellow",      fg: "text-guardia-violet-900", reason: "text-white over signal-yellow = 1.33:1 fails everything" },
-  ])("solid variant=$variant uses $fg ($reason)", ({ variant, bg, fg }) => {
+    { variant: "accent",  bg: "bg-guardia-orange-500", fg: "text-guardia-gray-900",   reason: "text-white over orange-500 = 3.15:1 fails AA-Normal" },
+    { variant: "success", bg: "bg-signal-green",       fg: "text-guardia-gray-900",   reason: "text-white over signal-green = 2.43:1 fails AA-Normal AND AA-Large" },
+    { variant: "danger",  bg: "bg-signal-red",         fg: "text-guardia-gray-900",   reason: "text-white over signal-red = 3.66:1 fails AA-Normal" },
+    { variant: "warning", bg: "bg-signal-yellow",      fg: "text-guardia-violet-900", reason: "text-white over signal-yellow = 1.33:1 fails everything" },
+  ] as const)("solid variant=$variant uses $fg ($reason)", ({ variant, bg, fg }) => {
     render(<Badge appearance="solid" variant={variant} data-testid="b">X</Badge>);
     const el = screen.getByTestId("b");
     expect(el).toHaveClass(bg);

--- a/ui_kit/components/badge/badge.test.tsx
+++ b/ui_kit/components/badge/badge.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { Badge } from "./index";
+import { axeInThemes } from "@/test-utils/a11y";
 
 describe("<Badge />", () => {
   it("renders its children", () => {
@@ -36,18 +37,44 @@ describe("<Badge />", () => {
     });
   });
 
-  it("applies solid appearance with white text", () => {
+  it("applies solid appearance with white text (brand: violet-500 + white = 12.47:1 AAA)", () => {
     render(<Badge appearance="solid" variant="brand" data-testid="b">X</Badge>);
     const el = screen.getByTestId("b");
     expect(el).toHaveClass("bg-guardia-violet-500");
     expect(el).toHaveClass("text-white");
   });
 
-  it("switches yellow text to violet in solid warning (AA contrast)", () => {
-    render(<Badge appearance="solid" variant="warning" data-testid="b">!</Badge>);
+  // WCAG AA-Normal (4.5:1) fg overrides for solid variants where text-white
+  // fails the §1.4.3 contrast threshold. Numbers come from sRGB luminance
+  // recompute (see PR #175 / Issue #173). Locked here to detect any future
+  // regression where someone reverts to the base `text-white` default.
+  it.each([
+    { variant: "accent" as const,  bg: "bg-guardia-orange-500", fg: "text-guardia-gray-900",   reason: "text-white over orange-500 = 3.15:1 fails AA-Normal" },
+    { variant: "success" as const, bg: "bg-signal-green",       fg: "text-guardia-gray-900",   reason: "text-white over signal-green = 2.43:1 fails AA-Normal AND AA-Large" },
+    { variant: "danger" as const,  bg: "bg-signal-red",         fg: "text-guardia-gray-900",   reason: "text-white over signal-red = 3.66:1 fails AA-Normal" },
+    { variant: "warning" as const, bg: "bg-signal-yellow",      fg: "text-guardia-violet-900", reason: "text-white over signal-yellow = 1.33:1 fails everything" },
+  ])("solid variant=$variant uses $fg ($reason)", ({ variant, bg, fg }) => {
+    render(<Badge appearance="solid" variant={variant} data-testid="b">X</Badge>);
     const el = screen.getByTestId("b");
-    expect(el).toHaveClass("bg-signal-yellow");
-    expect(el).toHaveClass("text-guardia-violet-900");
+    expect(el).toHaveClass(bg);
+    expect(el).toHaveClass(fg);
+    // Negative guard: the failing base `text-white` MUST NOT leak through.
+    expect(el).not.toHaveClass("text-white");
+  });
+
+  it("jest-axe: solid variants are WCAG AA clean in light + dark themes", async () => {
+    const { container } = render(
+      <div>
+        <Badge appearance="solid" variant="neutral">neutral</Badge>
+        <Badge appearance="solid" variant="brand">brand</Badge>
+        <Badge appearance="solid" variant="accent">accent</Badge>
+        <Badge appearance="solid" variant="success">success</Badge>
+        <Badge appearance="solid" variant="warning">warning</Badge>
+        <Badge appearance="solid" variant="danger">danger</Badge>
+        <Badge appearance="solid" variant="info">info</Badge>
+      </div>,
+    );
+    await axeInThemes(container);
   });
 
   it("applies outline appearance with border+text color", () => {

--- a/ui_kit/components/badge/index.tsx
+++ b/ui_kit/components/badge/index.tsx
@@ -51,13 +51,22 @@ const badgeVariants = cva(
       { appearance: "soft", variant: "danger",   className: "bg-[color-mix(in_oklab,var(--signal-red)_14%,white)] text-[color-mix(in_oklab,var(--signal-red)_45%,black)]" },
       { appearance: "soft", variant: "info",     className: "bg-[color-mix(in_oklab,var(--signal-blue)_14%,white)] text-[color-mix(in_oklab,var(--signal-blue)_62%,black)]" },
 
-      /* ── SOLID ────────────────────────────────────── */
+      /* ── SOLID ──────────────────────────────────────
+       * WCAG fg overrides (per WCAG 2.1 §1.4.3 sRGB recompute, aligned with
+       * Chip ADR-003 — see docs/adr/ADR-003-chip-variants.md):
+       *   accent  → text-guardia-gray-900 (text-white over orange-500 = 3.15:1 fails AA-Normal)
+       *   success → text-guardia-gray-900 (text-white over signal-green = 2.43:1 fails AA-Normal AND AA-Large)
+       *   danger  → text-guardia-gray-900 (text-white over signal-red   = 3.66:1 fails AA-Normal)
+       *   warning → text-guardia-violet-900 (text-white over signal-yellow = 1.33:1 fails everything)
+       * neutral / brand / info keep the appearance.solid default `text-white`
+       * (all ≥ 8.13:1).
+       */
       { appearance: "solid", variant: "neutral",  className: "bg-guardia-gray-500" },
       { appearance: "solid", variant: "brand",    className: "bg-guardia-violet-500" },
-      { appearance: "solid", variant: "accent",   className: "bg-guardia-orange-500" },
-      { appearance: "solid", variant: "success",  className: "bg-signal-green" },
+      { appearance: "solid", variant: "accent",   className: "bg-guardia-orange-500 text-guardia-gray-900" },
+      { appearance: "solid", variant: "success",  className: "bg-signal-green text-guardia-gray-900" },
       { appearance: "solid", variant: "warning",  className: "bg-signal-yellow text-guardia-violet-900" },
-      { appearance: "solid", variant: "danger",   className: "bg-signal-red" },
+      { appearance: "solid", variant: "danger",   className: "bg-signal-red text-guardia-gray-900" },
       { appearance: "solid", variant: "info",     className: "bg-signal-blue" },
 
       /* ── OUTLINE ──────────────────────────────────── */


### PR DESCRIPTION
## Summary

3 Badge solid combinations were shipping with \`text-white\` over backgrounds that fail WCAG 2.1 §1.4.3 AA-Normal (success also fails AA-Large). Surfaced during the ADR-003 (Chip variants) analysis in PR #172. Override aligns Badge with the same policy Chip applies in selected-solid mode.

### WCAG recompute (sRGB luminance)

| Combination | text-white | text-guardia-gray-900 |
|---|---|---|
| \`bg-guardia-orange-500\` (accent) | **3.15:1** fails AA-Normal | **6.04:1** AA-Normal pass |
| \`bg-signal-green\` (success)      | **2.43:1** fails AA-Normal AND AA-Large | **7.82:1** AA-Normal pass |
| \`bg-signal-red\` (danger)         | **3.66:1** fails AA-Normal | **5.19:1** AA-Normal pass |

\`warning\` already used \`text-guardia-violet-900\` (13.99:1); now documented in the same compound-variants block.

### Changes

- \`ui_kit/components/badge/index.tsx\`: 3 compound variants get explicit \`text-guardia-gray-900\` override; block-level WHY comment documents the recompute table.
- \`ui_kit/components/badge/badge.test.tsx\`:
  - 4 new \`it.each\` WCAG-pinning tests (accent, success, danger, warning) with negative guard \`not.toHaveClass(\"text-white\")\`
  - 1 new jest-axe test covering all 7 solid variants in light + dark themes via \`axeInThemes\`
  - 12 badge tests total (was 9)

## Test plan

- [x] \`npm test\` — 510/510 passing (was 506; +4 new badge tests)
- [x] \`npm run typecheck\` — green
- [x] \`npm run build\` — green
- [x] Manual WCAG recompute via Python sRGB luminance
- [ ] Visual regression baselines regenerated via \`regenerate-baselines\` label (3 solid stories diff — white→dark text)
- [ ] Argos review

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)