### PR TITLE
chore(ci): add canonical status:* labels and idempotent reconciliation script

### DIFF
--- a/docs/issues/issue-211/01-brief.md
+++ b/docs/issues/issue-211/01-brief.md
@@ -1,0 +1,32 @@
+# Issue #211 — Brief
+
+- **Repo:** `guardiatechnology/design-system`
+- **Type:** Plan sub-issue (Tech Task)
+- **Parent:** #210
+- **Author:** @fernandoseguim
+- **Labels:** `ci 🏗️`, `evolvability ♻️`, `status: development`
+
+## Summary
+
+Create the 3 missing canonical `status:*` labels in `guardiatechnology/design-system` so `warrior-athena` can apply the `development → to review → done` transitions required by `lex-agent-planning` Table A on every Plan PR.
+
+## Current state (before this Plan)
+
+Only 2 of the 5 canonical status labels exist in the repo:
+
+- `status: todo` (present)
+- `status: development` (present)
+- `status: to review` (**missing**)
+- `status: done` (**missing**)
+- `status: to release` (**missing**)
+
+Symptom: PRs #205, #206, #209 (Lote 1 — IconButton, ButtonGroup, Button) opened today and are stuck at `status: development` because Athena cannot apply `status: to review`.
+
+## Desired outcome
+
+All 5 canonical status labels present in the repo with consistent color + description, and an idempotent `scripts/labels.sh` that reconciles them on fresh clones or after accidental deletion.
+
+## Out of scope
+
+- Retroactive re-tag of Lote 1 PRs (#205, #206, #209) — surfaced as tangential finding (see Phase 4 notes); 3-command chore that Fernando handles manually if desired.
+- Cross-repo propagation of the labels script to other Guardia repos — separate Plan if needed.

--- a/docs/issues/issue-211/05-security-review.md
+++ b/docs/issues/issue-211/05-security-review.md
@@ -1,0 +1,34 @@
+# Security Review — Issue #211
+
+## Scope
+
+Repo-config change (GitHub labels) + 1 shell script (`scripts/labels.sh`) that wraps `gh label create --force`.
+
+## Threat surface
+
+| Surface | Risk | Mitigation |
+|---|---|---|
+| `scripts/labels.sh` execution | Arbitrary code | Script is plain bash, `set -euo pipefail`, no `eval`, no user input interpolation beyond `--repo <slug>` flag passed straight to `gh` |
+| Label name/description content | Stored XSS in GitHub UI | GitHub sanitizes label names/descriptions; no HTML rendered in label chips |
+| GitHub token in CI | Token leakage | Script uses ambient `gh auth` — no token printed; `--force` does not require elevated scope beyond `repo` (already granted) |
+| Secret handling | None | No secrets, env vars, or credentials manipulated |
+| Dependency surface | None | Pure shell + `gh` CLI; no `npm`/`pip`/`brew` install added |
+
+## OWASP Top 10 check
+
+| Category | Applicable | Notes |
+|---|---|---|
+| A01 Broken Access Control | No | GitHub-side ACL on `gh label create` |
+| A02 Cryptographic Failures | No | No crypto |
+| A03 Injection | No | `gh label create` args are quoted; `--repo "$2"` passed as positional arg (no shell interpolation) |
+| A04 Insecure Design | No | Idempotent, declarative |
+| A05 Security Misconfiguration | No | Labels are repo metadata, not security policy |
+| A06 Vulnerable Components | No | No new dependency |
+| A07 Auth Failures | No | Relies on existing `gh auth` |
+| A08 Software/Data Integrity | No | Script is committed and reviewed; no remote execution |
+| A09 Logging Failures | No | No logging path touched |
+| A10 SSRF | No | No outbound HTTP except `gh` API to GitHub |
+
+## Verdict
+
+**PASS** — no security impact. Repo-config change with idempotent helper script. No code execution surface in production, no secret handling, no new dependencies.

--- a/docs/issues/issue-211/06-quality-report.md
+++ b/docs/issues/issue-211/06-quality-report.md
@@ -1,0 +1,37 @@
+# Quality Gate Report — Issue #211
+
+## Gate 2 — Quality (kata-quality-gate)
+
+| # | Check | Result | Notes |
+|---|---|---|---|
+| 1 | AC ↔ test traceability | N/A | Repo-config change; no code path testable via unit/integration. DoD verified via `gh label list` (see Check 7). |
+| 2 | Scope creep | PASS | Only `scripts/labels.sh` + `docs/issues/issue-211/*` touched. No component, story, or production code modified. |
+| 3 | Best practices / observability | PASS | Script uses `set -euo pipefail`, idempotent via `--force`, no secrets, no eval. |
+| 4 | Tests | N/A | No code units. |
+| 5 | Coverage | N/A | No code units. |
+| 6 | Types | N/A | No TypeScript/Python touched. |
+| 7 | DoD verification | PASS | `gh label list --repo guardiatechnology/design-system \| grep "^status:"` returns all 5 canonical labels with correct colors + descriptions. Second run of `scripts/labels.sh` produces identical output (idempotency confirmed). |
+
+## Non-applicable repo-CI checks
+
+`npm run typecheck`, `npm run lint`, `npm run test`, `npm run build`, `npm run docs:build` — not run locally for this Plan because the diff touches zero TypeScript/MDX/component files. CI on the PR will execute them anyway as a regression backstop; if any fails, the failure is pre-existing on `main` (the script + Markdown additions cannot cause a TypeScript or lint regression).
+
+## Tangential findings surfaced
+
+Per `lex-no-silent-tech-debt`:
+
+**Finding #1:** Lote 1 PRs (#205, #206, #209) are stuck at `status: development` because the labels did not exist when their Plans transitioned. Now that the labels exist, those PRs could be retroactively re-tagged to `status: to review` to align state with reality.
+
+- **(a) Expand this Plan's scope** — NO (would require touching 3 unrelated PRs)
+- **(b) New Plan sub-issue under #210** — defer; Fernando can run 3 `gh issue edit` commands manually in ~30s
+- **(c) New parent Issue** — NO (no new capability)
+
+**Decision:** Surfaced for Fernando's call; not handled in this Plan.
+
+**Finding #2:** `.ahrena/.directives` already lists `notion` in `mcp.servers` — this contradicts the brief's premise that Plan #213 must merge first. May indicate Plan #213 was effectively done out-of-band or its scope drifted.
+
+- Not handled here (out of scope, not a `status` labels concern). Suggest Fernando reconciles Plan #213's premise vs. current `.directives` state in a separate session.
+
+## Verdict
+
+**go** — ready for Phase 7 (PR open).

--- a/scripts/labels.sh
+++ b/scripts/labels.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Canonical Ahrena status:* labels for design-system
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# Source: lex-agent-planning Table A (Axis A — dev cycle)
+#
+# Idempotent: uses `gh label create --force` so repeated runs
+# update existing labels in place (color + description) and
+# create missing ones. Safe to run on a fresh clone or after
+# accidental label deletion.
+#
+# Required: gh CLI authenticated with `repo` scope.
+#
+# Usage:
+#   ./scripts/labels.sh
+#   ./scripts/labels.sh --repo guardiatechnology/design-system  # override target
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+set -euo pipefail
+
+REPO_ARG=""
+if [[ "${1:-}" == "--repo" && -n "${2:-}" ]]; then
+  REPO_ARG="$2"
+fi
+
+create() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+  if [[ -n "$REPO_ARG" ]]; then
+    gh label create "$name" --repo "$REPO_ARG" --color "$color" --description "$description" --force
+  else
+    gh label create "$name" --color "$color" --description "$description" --force
+  fi
+}
+
+list_labels() {
+  if [[ -n "$REPO_ARG" ]]; then
+    gh label list --repo "$REPO_ARG" --limit 200
+  else
+    gh label list --limit 200
+  fi
+}
+
+echo "Reconciling canonical status:* labels..."
+
+create "status: todo"        "fbca04" "Ready to be picked up"
+create "status: development" "0052cc" "Plan in active development"
+create "status: to review"   "0e8a16" "Plan in review (PR opened, awaiting human approval)"
+create "status: done"        "5319e7" "Plan complete (PR merged)"
+create "status: to release"  "fbca04" "Awaiting release (Janus)"
+
+echo "Done. Verifying..."
+list_labels | grep -E "^status:" | sort


### PR DESCRIPTION
## Summary

- Created the 3 missing canonical Ahrena `status:*` labels in this repo (`status: to review`, `status: done`, `status: to release`) via `gh label create` so `warrior-athena` can apply the `development → to review → done` transitions required by `lex-agent-planning` Table A on every Plan PR.
- Adds `scripts/labels.sh`: idempotent helper (uses `gh label create --force`) that reconciles all 5 canonical status labels on fresh clones or after accidental deletion. Macroscopic invariant: the script can be re-run any number of times and converges to the same target state.
- Adds Issue-Driven docs under `docs/issues/issue-211/` (brief, security review PASS, Gate 2 PASS).

## Why

Before this PR the repo only had `status: todo` and `status: development`. The other 3 canonical labels from `lex-agent-planning` Table A (`status: to review`, `status: done`, `status: to release`) did not exist, so Athena could not flip Plan PRs out of `status: development`. Symptom: PRs #205, #206, #209 (Lote 1 — IconButton, ButtonGroup, Button) are currently stuck at `status: development` for that reason.

## Notes for the reviewer

- **Color collision is intentional:** `status: to release` shares yellow (`#fbca04`) with `status: todo`. This matches the Ahrena convention (`ready-to-pick` ↔ `ready-to-release` semantic similarity). Documented to avoid confusion.
- **Idempotency proof:** running `bash scripts/labels.sh` twice in a row in the worktree produced identical output and zero errors.
- **No production code touched.** Only `scripts/labels.sh` (new helper) + `docs/issues/issue-211/*` (traceability).
- **Tangential findings (per `lex-no-silent-tech-debt`):** see `docs/issues/issue-211/06-quality-report.md` — Lote 1 PRs could be retroactively re-tagged, and `.directives` already lists `notion` in `mcp.servers` (Plan #213 reconciliation question). Neither handled here.

## Test plan

- [x] `gh label list --repo guardiatechnology/design-system | grep "^status:"` returns all 5 canonical labels with correct colors and descriptions
- [x] `bash scripts/labels.sh` runs without errors on macOS Bash 3.2
- [x] Second run of `bash scripts/labels.sh` is idempotent (no errors, no state change)
- [x] No TypeScript/MDX/component files modified — repo CI (`typecheck`, `lint`, `test`, `build`, `docs:build`) should be a clean pass via no-touch
- [ ] After merge: next Athena session that closes a Plan applies `status: to review` cleanly (smoke verification on next real Plan PR)

## References

- `lex-agent-planning` Table A (Axis A — dev cycle)
- `lex-pr-quality`
- `lex-no-silent-tech-debt`

Closes #211
Refs #210