### PR TITLE
docs: add ux_references snapshot as canonical visual reference for v0.1.0 DoD migrations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
 /**
  * Flat ESLint config (ESLint 9).
- * Runs against ui_kit/ and .storybook/, ignores dist, docs, wip.
+ * Runs against ui_kit/ and .storybook/, ignores dist, docs, wip, ux_references.
  */
 import js from "@eslint/js";
 import ts from "typescript-eslint";
@@ -16,6 +16,7 @@ export default ts.config(
             "dist/**",
             "docs/**",
             "wip/**",
+            "ux_references/**",
             "storybook-static/**",
             "coverage/**",
             "node_modules/**",

--- a/ux_references/ui_kits/components/Accordion/Accordion.playground.html
+++ b/ux_references/ui_kits/components/Accordion/Accordion.playground.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Accordion · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">ESTRUTURA · COLAPSÁVEIS</div>
+  <h1 class="pg-title">Accordion</h1>
+  <span class="pg-codename">import Accordion from "ui_kits/components/Accordion"</span>
+  <p class="pg-desc">Grupos expansíveis para conteúdo denso: plano de contas, filtros avançados, detalhes de lançamento, configurações. <code>type="single"</code> permite só um aberto por vez; <code>multiple</code> permite vários.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, w=620 }: any) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",maxWidth:w}}>{children}</div></div>);
+}
+
+// ─── Plano de Contas (hierárquico, padrão Brasil) ──────────────────
+const row = (code:string, nome:string, saldo:string, tipo?:string) => (
+  <div style={{display:"grid",gridTemplateColumns:"110px 1fr auto",gap:12,padding:"6px 0",fontSize:13,color:"var(--gray-700)",borderBottom:"1px dashed var(--border)"}}>
+    <span style={{fontFamily:"var(--font-mono)",color:"var(--violet-600)"}}>{code}</span>
+    <span>{nome}{tipo && <span style={{marginLeft:6,fontSize:11,color:"var(--gray-500)",textTransform:"uppercase",letterSpacing:"0.06em"}}>· {tipo}</span>}</span>
+    <strong style={{fontFamily:"var(--font-mono)",color:"var(--fg)",fontVariantNumeric:"tabular-nums"}}>{saldo}</strong>
+  </div>
+);
+
+const PLANO_CONTAS = [
+  { id:"1", title:"1. Ativo", icon:"wallet", defaultOpen:true, content: (
+    <div>
+      {row("1.1","Ativo Circulante","R$ 4.280.410,52","sintética")}
+      {row("1.1.01","Caixa e Equivalentes","R$ 128.900,00")}
+      {row("1.1.02","Bancos Conta Movimento","R$ 1.842.110,25")}
+      {row("1.1.03","Aplicações Financeiras","R$ 2.309.400,27")}
+      {row("1.2","Ativo Não Circulante","R$ 1.120.800,00","sintética")}
+    </div>
+  )},
+  { id:"2", title:"2. Passivo", icon:"layers", content: (
+    <div>
+      {row("2.1","Passivo Circulante","R$ 980.220,40","sintética")}
+      {row("2.1.01","Fornecedores","R$ 412.300,00")}
+      {row("2.1.02","Salários e Encargos","R$ 318.920,40")}
+      {row("2.1.03","Obrigações Tributárias","R$ 249.000,00")}
+    </div>
+  )},
+  { id:"3","title":"3. Despesas","icon":"trending-down", content: (
+    <div>
+      {row("3.1.4.05","Despesas com tecnologia","R$ 48.120,00")}
+      {row("3.1.4.06","Infraestrutura cloud","R$ 22.800,00")}
+      {row("3.1.5.01","Viagens e deslocamento","R$ 12.410,50")}
+    </div>
+  )},
+  { id:"4","title":"4. Receitas","icon":"trending-up", content: (
+    <div>
+      {row("4.1.01","Receita de serviços","R$ 2.840.120,00")}
+      {row("4.1.02","Receita de produtos","R$ 1.210.800,00")}
+    </div>
+  )},
+];
+
+// ─── Detalhe de lançamento (drawer-like) ──────────────────
+const LANC_DETALHE = [
+  { id:"gerais", title:"Dados do lançamento", icon:"file-text", defaultOpen:true, content: (
+    <div style={{display:"grid",gridTemplateColumns:"130px 1fr",gap:"8px 14px",fontSize:13,color:"var(--gray-700)"}}>
+      <span style={{color:"var(--gray-500)"}}>Documento</span><span>NF-e 8.421 · série 1</span>
+      <span style={{color:"var(--gray-500)"}}>Fornecedor</span><span>Papelaria Beta Ltda · 12.345.678/0001-90</span>
+      <span style={{color:"var(--gray-500)"}}>Valor total</span><strong style={{fontFamily:"var(--font-mono)"}}>R$ 12.480,00</strong>
+      <span style={{color:"var(--gray-500)"}}>Emissão</span><span>05/11/2025</span>
+    </div>
+  )},
+  { id:"fiscal", title:"Dados fiscais", icon:"receipt-text", content: (
+    <div style={{display:"grid",gridTemplateColumns:"130px 1fr",gap:"8px 14px",fontSize:13,color:"var(--gray-700)"}}>
+      <span style={{color:"var(--gray-500)"}}>CFOP</span><span>1.102 — Compra para comercialização</span>
+      <span style={{color:"var(--gray-500)"}}>CST</span><span>000 — Tributada integralmente</span>
+      <span style={{color:"var(--gray-500)"}}>ICMS</span><strong style={{fontFamily:"var(--font-mono)"}}>R$ 2.246,40</strong>
+      <span style={{color:"var(--gray-500)"}}>PIS/COFINS</span><strong style={{fontFamily:"var(--font-mono)"}}>R$ 1.154,40</strong>
+    </div>
+  )},
+  { id:"contab", title:"Classificação contábil", icon:"book-open", content: (
+    <div style={{display:"grid",gridTemplateColumns:"130px 1fr",gap:"8px 14px",fontSize:13,color:"var(--gray-700)"}}>
+      <span style={{color:"var(--gray-500)"}}>Débito</span><span><code style={{background:"var(--violet-100)",padding:"1px 6px",borderRadius: "var(--radius-sm)",color:"var(--violet-700)"}}>3.1.4.05</code> · Despesas com tecnologia</span>
+      <span style={{color:"var(--gray-500)"}}>Crédito</span><span><code style={{background:"var(--violet-100)",padding:"1px 6px",borderRadius: "var(--radius-sm)",color:"var(--violet-700)"}}>2.1.01</code> · Fornecedores</span>
+      <span style={{color:"var(--gray-500)"}}>Sugerido por</span><span>Agente Contábil · confidence 97%</span>
+    </div>
+  )},
+  { id:"historico", title:"Trilha de auditoria (4 eventos)", icon:"history", content: (
+    <ul style={{margin:0,paddingLeft:18,fontSize:13,color:"var(--gray-700)",lineHeight:1.7}}>
+      <li><b>05/11 14:32</b> · Agente Contábil classificou em <code>3.1.4.05</code></li>
+      <li><b>05/11 14:33</b> · Maria Santos aprovou a sugestão</li>
+      <li><b>05/11 14:33</b> · Lançamento conciliado com extrato Itaú</li>
+      <li><b>05/11 14:35</b> · Exportado para Domínio Sistemas</li>
+    </ul>
+  )},
+];
+
+// ─── Filtros avançados da conciliação ──────────────────
+const FILTROS_RECON = [
+  { id:"period", title:"Período e fonte", icon:"calendar", defaultOpen:true, content: (
+    <div style={{display:"flex",flexWrap:"wrap",gap:8,fontSize:13}}>
+      {["Últimos 7 dias","Mês atual","Trimestre","Personalizado"].map(x => (
+        <span key={x} style={{padding:"4px 10px",background:x==="Mês atual"?"var(--violet-500)":"var(--violet-100)",color:x==="Mês atual"?"#fff":"var(--violet-700)",borderRadius: "var(--radius-pill)",fontWeight:500}}>{x}</span>
+      ))}
+    </div>
+  )},
+  { id:"bank", title:"Contas bancárias (3 de 8)", icon:"landmark", content: (
+    <ul style={{margin:0,paddingLeft:18,fontSize:13,color:"var(--gray-700)",lineHeight:1.7}}>
+      <li>Itaú · Ag. 0478 · CC 91234-0 ✓</li>
+      <li>Bradesco · Ag. 2201 · CC 58821-2 ✓</li>
+      <li>Santander · Ag. 3102 · CC 10230-9 ✓</li>
+    </ul>
+  )},
+  { id:"status", title:"Status do par", icon:"circle-check", content: (
+    <div style={{display:"flex",gap:8,fontSize:12,flexWrap:"wrap"}}>
+      <span style={{padding:"3px 9px",borderRadius: "var(--radius-pill)",background:"var(--success-soft)",color:"color-mix(in oklab, var(--signal-green) 52%, black)",fontWeight:600}}>Conciliados 1.847</span>
+      <span style={{padding:"3px 9px",borderRadius: "var(--radius-pill)",background:"var(--warning-soft)",color:"var(--yellow-900)",fontWeight:600}}>Divergentes 23</span>
+      <span style={{padding:"3px 9px",borderRadius: "var(--radius-pill)",background:"var(--danger-soft)",color:"color-mix(in oklab, var(--signal-red) 45%, black)",fontWeight:600}}>Sem par 7</span>
+    </div>
+  )},
+];
+
+function App() {
+  return (<>
+    <Sec title="Em contexto · Plano de contas hierárquico" w={640}>
+      <Accordion items={PLANO_CONTAS} type="multiple" />
+    </Sec>
+
+    <Sec title="Em contexto · Detalhe de lançamento em drawer" w={640}>
+      <Accordion items={LANC_DETALHE} type="single" />
+    </Sec>
+
+    <Sec title="Em contexto · Filtros avançados da conciliação" w={480}>
+      <Accordion variant="plain" items={FILTROS_RECON} type="multiple" />
+    </Sec>
+
+    <Sec title="Variantes · bordered vs plain" w={540}>
+      <Accordion items={FILTROS_RECON.slice(0,2)} type="single" />
+    </Sec>
+
+    <Sec title="Com item desabilitado (módulo em breve)" w={540}>
+      <Accordion items={[
+        ...FILTROS_RECON.slice(0,2),
+        { id:"wip", title:"Folha de pagamento (em breve)", icon:"clock", content:null, disabled:true },
+      ]} type="single" />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Accordion"]) || "render(<div>Sem exemplo para Accordion</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>items</code></td><td>array</td><td>—</td><td class="desc">{`{ id, title, content, icon?, defaultOpen?, disabled? }[]`}</td></tr>
+  <tr><td><code>type</code></td><td>string</td><td>"multiple"</td><td class="desc">single · multiple</td></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"bordered"</td><td class="desc">bordered · plain</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Agrupe conteúdo longo e secundário que o usuário consulta sob demanda — FAQs, filtros avançados, detalhes de conciliação.</li>
+      <li>Mantenha o primeiro item aberto quando for o caminho mais comum.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Esconder conteúdo crítico (erros, alertas, ações primárias).</li>
+      <li>Usar em fluxos lineares onde o usuário precisa ver tudo na ordem.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Accordion/index.css
+++ b/ux_references/ui_kits/components/Accordion/index.css
@@ -1,0 +1,29 @@
+
+.grd-acc { font-family: var(--font-sans); display: flex; flex-direction: column; }
+.grd-acc-bordered { border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; background: var(--surface); }
+.grd-acc-bordered .grd-acc-item + .grd-acc-item { border-top: 1px solid var(--border); }
+.grd-acc-plain .grd-acc-item { border-bottom: 1px solid var(--border); }
+.grd-acc-plain .grd-acc-item:last-child { border-bottom: 0; }
+
+.grd-acc-trigger {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 12px 14px;
+  border: 0; background: transparent;
+  font-family: inherit; font-size: 14px; font-weight: 500;
+  color: var(--fg); cursor: pointer;
+  text-align: left;
+  transition: background 140ms;
+}
+.grd-acc-trigger:hover:not(:disabled) { background: var(--violet-50); }
+.grd-acc-item-dis .grd-acc-trigger { opacity: 0.5; cursor: not-allowed; }
+.grd-acc-title { flex: 1; }
+.grd-acc-trigger > :last-child { color: var(--fg-muted); transition: transform 180ms var(--ease-standard); }
+.grd-acc-item-open .grd-acc-trigger > :last-child { transform: rotate(180deg); color: var(--violet-600); }
+
+.grd-acc-content {
+  padding: 0 14px 14px 40px;
+  font-size: 13.5px; color: var(--fg); line-height: 1.55;
+  animation: grd-acc-in 200ms var(--ease-out);
+}
+@keyframes grd-acc-in { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }

--- a/ux_references/ui_kits/components/Accordion/index.tsx
+++ b/ux_references/ui_kits/components/Accordion/index.tsx
@@ -1,0 +1,65 @@
+
+/**
+ * Accordion — grupos de painéis colapsáveis.
+ * Props: items [{ id, title, content, defaultOpen?, icon? }], type (single|multiple).
+ */
+
+interface AccordionItem {
+  id: string;
+  title: React.ReactNode;
+  content: React.ReactNode;
+  icon?: string;
+  defaultOpen?: boolean;
+  disabled?: boolean;
+}
+interface AccordionProps {
+  items: AccordionItem[];
+  type?: "single" | "multiple";
+  variant?: "bordered" | "plain";
+  className?: string;
+}
+
+function Accordion({ items, type = "multiple", variant = "bordered", className = "" }: AccordionProps) {
+  const IconCmp = (window as any).Icon;
+  const initial = new Set(items.filter(i => i.defaultOpen).map(i => i.id));
+  const [openSet, setOpenSet] = React.useState<Set<string>>(initial);
+
+  function toggle(id: string) {
+    setOpenSet(prev => {
+      const next = new Set(prev);
+      if (type === "single") {
+        if (next.has(id)) next.clear();
+        else { next.clear(); next.add(id); }
+      } else {
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className={`grd-acc grd-acc-${variant} ${className}`}>
+      {items.map(it => {
+        const open = openSet.has(it.id);
+        return (
+          <div key={it.id} className={`grd-acc-item ${open ? "grd-acc-item-open" : ""} ${it.disabled ? "grd-acc-item-dis" : ""}`}>
+            <button
+              type="button" className="grd-acc-trigger"
+              aria-expanded={open}
+              disabled={it.disabled}
+              onClick={() => !it.disabled && toggle(it.id)}
+            >
+              {it.icon && IconCmp && <IconCmp name={it.icon} size={15} />}
+              <span className="grd-acc-title">{it.title}</span>
+              {IconCmp && <IconCmp name="chevron-down" size={15} />}
+            </button>
+            {open && <div className="grd-acc-content">{it.content}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+Accordion.displayName = "Accordion";
+(window as any).Accordion = Accordion;

--- a/ux_references/ui_kits/components/AgentCard/AgentCard.playground.html
+++ b/ux_references/ui_kits/components/AgentCard/AgentCard.playground.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>AgentCard · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="../IconButton/index.css">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">CONTEÚDO · AGENTES</div>
+  <h1 class="pg-title">AgentCard</h1>
+  <span class="pg-codename">import AgentCard from "ui_kits/components/AgentCard"</span>
+  <p class="pg-desc">Card resumo de um agente de IA no Control Center. Exibe nome, papel, status em tempo real, métricas-chave e última execução. Quatro cores de accent e quatro estados.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../IconButton/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p>
+    <div className="pg-stage" style={{display:"grid",gridTemplateColumns:"repeat(auto-fill,minmax(280px,1fr))",gap:14}}>{children}</div>
+  </div>);
+}
+
+function App() {
+  return (<>
+    <Sec title="Accents · estados">
+      <AgentCard
+        name="Bia" role="Conciliação Bancária" icon="arrow-left-right"
+        status="active" statusLabel="Conciliando"
+        accent="violet"
+        metrics={[{label:"conciliado hoje",value:"248"},{label:"taxa match",value:"97%"},{label:"pendentes",value:"3"}]}
+        lastRun="há 2 min"
+        actions={<IconButton icon="more-vertical" variant="ghost" size="sm" />}
+      />
+      <AgentCard
+        name="Theo" role="Fiscal Agent" icon="receipt-text"
+        status="idle"
+        accent="orange"
+        metrics={[{label:"NFes processadas",value:"1.2k"},{label:"erros fiscais",value:"0"},{label:"uptime",value:"99.8%"}]}
+        lastRun="há 14 min"
+      />
+      <AgentCard
+        name="Nora" role="Análise de Balanço" icon="file-chart-column"
+        status="paused" statusLabel="Aguardando dados"
+        accent="blue"
+        metrics={[{label:"relatórios",value:"12"},{label:"alertas",value:"4"},{label:"clientes",value:"8"}]}
+        lastRun="há 1h"
+      />
+      <AgentCard
+        name="Caio" role="Coleta Fiscal" icon="download"
+        status="error" statusLabel="Falha no login SEFAZ"
+        accent="green"
+        metrics={[{label:"último sucesso",value:"07/03"},{label:"tentativas",value:"3"},{label:"timeout",value:"30s"}]}
+        lastRun="há 3h"
+        actions={<Button size="sm" variant="outline" leftIcon="refresh">Tentar</Button>}
+      />
+    </Sec>
+
+    <Sec title="Mínimo · sem métricas">
+      <AgentCard name="Rita" role="Auditoria" icon="scan-search" status="active" accent="violet" lastRun="ativa agora" />
+      <AgentCard name="Léo" role="Tributário" icon="scale" status="idle" accent="orange" />
+      <AgentCard name="Miro" role="Faturamento" icon="file-text" status="active" accent="blue" />
+    </Sec>
+
+    <Sec title="Clicável (card inteiro como botão)">
+      <AgentCard name="Bia" role="Conciliação · clique para abrir" icon="arrow-left-right"
+        status="active" accent="violet"
+        metrics={[{label:"hoje",value:"248"},{label:"match",value:"97%"}]}
+        lastRun="há 2 min"
+        onClick={() => alert("Abrindo Bia...")} />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["AgentCard"]) || "render(<div>Sem exemplo para AgentCard</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>name</code></td><td>ReactNode</td><td>—</td><td class="desc">Nome do agente</td></tr>
+  <tr><td><code>role</code></td><td>ReactNode</td><td>—</td><td class="desc">Papel / especialidade</td></tr>
+  <tr><td><code>icon</code></td><td>IconName</td><td>"bot"</td><td class="desc">Glifo do avatar</td></tr>
+  <tr><td><code>status</code></td><td>string</td><td>"idle"</td><td class="desc">active · idle · paused · error</td></tr>
+  <tr><td><code>statusLabel</code></td><td>ReactNode</td><td>auto</td><td class="desc">Sobrescreve o rótulo do status</td></tr>
+  <tr><td><code>metrics</code></td><td>&#123;label,value&#125;[]</td><td>—</td><td class="desc">Até 3 KPIs em grid</td></tr>
+  <tr><td><code>lastRun</code></td><td>ReactNode</td><td>—</td><td class="desc">Timestamp humano (ex: "há 2 min")</td></tr>
+  <tr><td><code>actions</code></td><td>ReactNode</td><td>—</td><td class="desc">Slot no footer (IconButton, Button, etc)</td></tr>
+  <tr><td><code>accent</code></td><td>string</td><td>"violet"</td><td class="desc">violet · orange · blue · green</td></tr>
+  <tr><td><code>onClick</code></td><td>() =&gt; void</td><td>—</td><td class="desc">Torna o card inteiro clicável</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Laranja quando o agente está executando; violeta em idle; vermelho em erro.</li>
+      <li>Ícone <code>bot</code> + 2-3 métricas-chave (execuções, taxa de acerto, última execução).</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Humanizar o agente com foto — são sistemas, use ícone temático.</li>
+      <li>Métricas vagas ("ótimo desempenho") ou mais de 3 KPIs por card.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/AgentCard/index.css
+++ b/ux_references/ui_kits/components/AgentCard/index.css
@@ -1,0 +1,71 @@
+
+.grd-ag {
+  font-family: var(--font-sans);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 16px;
+  display: flex; flex-direction: column; gap: 12px;
+  text-align: left;
+  color: var(--fg);
+  position: relative;
+  overflow: hidden;
+}
+.grd-ag::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+  background: var(--violet-500);
+}
+.grd-ag-acc-orange::before { background: var(--orange-500); }
+.grd-ag-acc-blue::before   { background: var(--signal-blue); }
+.grd-ag-acc-green::before  { background: var(--signal-green); }
+
+.grd-ag-clickable { cursor: pointer; transition: box-shadow 160ms, border-color 160ms, transform 160ms; width: 100%; font-family: inherit; }
+.grd-ag-clickable:hover { border-color: var(--violet-300); box-shadow: var(--shadow-md); }
+
+.grd-ag-head { display: flex; align-items: center; gap: 12px; }
+.grd-ag-avatar {
+  width: 44px; height: 44px; border-radius: var(--radius-xl);
+  background: var(--violet-50); color: var(--violet-600);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.grd-ag-acc-orange .grd-ag-avatar { background: var(--orange-50); color: var(--orange-700); }
+.grd-ag-acc-blue .grd-ag-avatar   { background: var(--info-soft); color: var(--signal-blue); }
+.grd-ag-acc-green .grd-ag-avatar  { background: var(--success-soft); color: var(--signal-green); }
+
+.grd-ag-id { flex: 1; min-width: 0; }
+.grd-ag-name { font-size: 15px; font-weight: 600; color: var(--fg); line-height: 1.3; }
+.grd-ag-role { font-size: 12.5px; color: var(--fg-muted); margin-top: 1px; }
+
+.grd-ag-status {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 11.5px; font-weight: 600;
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  background: var(--gray-100); color: var(--fg-muted);
+}
+.grd-ag-status-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+.grd-ag-status-active { background: var(--success-soft); color: color-mix(in oklab, var(--signal-green) 52%, black); }
+.grd-ag-status-active .grd-ag-status-dot { background: var(--signal-green); box-shadow: 0 0 0 3px color-mix(in oklab, var(--signal-green) 28%, transparent); }
+.grd-ag-status-paused { background: var(--yellow-100); color: var(--yellow-900); }
+.grd-ag-status-error  { background: var(--danger-soft); color: color-mix(in oklab, var(--signal-red) 45%, black); }
+
+.grd-ag-metrics {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 8px;
+  padding: 10px 12px; border-radius: var(--radius-lg);
+  background: var(--gray-50);
+}
+.grd-ag-metric { text-align: center; }
+.grd-ag-metric-val {
+  font-size: 18px; font-weight: 600; color: var(--fg);
+  font-feature-settings: "tnum"; font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+.grd-ag-metric-lbl {
+  font-size: 10.5px; font-weight: 600; color: var(--fg-muted);
+  text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px;
+}
+
+.grd-ag-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.grd-ag-lastrun { display: inline-flex; align-items: center; gap: 4px; font-size: 11.5px; color: var(--fg-muted); }
+.grd-ag-actions { display: inline-flex; gap: 4px; }

--- a/ux_references/ui_kits/components/AgentCard/index.tsx
+++ b/ux_references/ui_kits/components/AgentCard/index.tsx
@@ -1,0 +1,73 @@
+
+/**
+ * AgentCard — card de agente de IA.
+ * Props: name, role, icon, status (active|idle|paused|error), metrics (label/value[]), lastRun, accent.
+ */
+
+interface AgentMetric { label: React.ReactNode; value: React.ReactNode; }
+interface AgentCardProps {
+  name: React.ReactNode;
+  role?: React.ReactNode;
+  icon?: string;
+  status?: "active" | "idle" | "paused" | "error";
+  statusLabel?: React.ReactNode;
+  metrics?: AgentMetric[];
+  lastRun?: React.ReactNode;
+  actions?: React.ReactNode;
+  accent?: "violet" | "orange" | "blue" | "green";
+  onClick?: () => void;
+  className?: string;
+}
+
+const ST_LABEL: Record<string, string> = { active: "Ativo", idle: "Ocioso", paused: "Pausado", error: "Erro" };
+
+function AgentCard({
+  name, role, icon = "bot", status = "idle", statusLabel,
+  metrics, lastRun, actions, accent = "violet", onClick, className = "",
+}: AgentCardProps) {
+  const IconCmp = (window as any).Icon;
+  const cls = ["grd-ag", `grd-ag-acc-${accent}`, onClick && "grd-ag-clickable", className].filter(Boolean).join(" ");
+  const Tag = onClick ? "button" : "div";
+  return (
+    <Tag className={cls} onClick={onClick} type={onClick ? "button" : undefined}>
+      <div className="grd-ag-head">
+        <div className="grd-ag-avatar">
+          {IconCmp && <IconCmp name={icon} size={22} />}
+        </div>
+        <div className="grd-ag-id">
+          <div className="grd-ag-name">{name}</div>
+          {role && <div className="grd-ag-role">{role}</div>}
+        </div>
+        <span className={`grd-ag-status grd-ag-status-${status}`}>
+          <span className="grd-ag-status-dot" />
+          {statusLabel ?? ST_LABEL[status]}
+        </span>
+      </div>
+
+      {metrics && metrics.length > 0 && (
+        <div className="grd-ag-metrics">
+          {metrics.map((m, i) => (
+            <div key={i} className="grd-ag-metric">
+              <div className="grd-ag-metric-val">{m.value}</div>
+              <div className="grd-ag-metric-lbl">{m.label}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {(lastRun || actions) && (
+        <div className="grd-ag-foot">
+          {lastRun && (
+            <span className="grd-ag-lastrun">
+              {IconCmp && <IconCmp name="clock" size={12} />}
+              {lastRun}
+            </span>
+          )}
+          {actions && <div className="grd-ag-actions">{actions}</div>}
+        </div>
+      )}
+    </Tag>
+  );
+}
+AgentCard.displayName = "AgentCard";
+(window as any).AgentCard = AgentCard;

--- a/ux_references/ui_kits/components/Alert/Alert.playground.html
+++ b/ux_references/ui_kits/components/Alert/Alert.playground.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Alert · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FEEDBACK · BANNER</div>
+  <h1 class="pg-title">Alert</h1>
+  <span class="pg-codename">import Alert from "ui_kits/components/Alert"</span>
+  <p class="pg-desc">Banner inline para comunicar status, aviso ou erro. Quatro tipos: <code>info</code>, <code>success</code>, <code>warning</code>, <code>danger</code>. Admite título, ação e botão fechar.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",gap:12}}>{children}</div></div>);
+}
+function App() {
+  const [shown, setShown] = React.useState(true);
+  return (<>
+    <Sec title="Tipos">
+      <Alert type="info" title="Novo agente disponível">
+        O agente de Conciliação Bancária foi atualizado com suporte a extratos em CSV.
+      </Alert>
+      <Alert type="success" title="Conciliação concluída">
+        248 lançamentos processados · 237 auto-aprovados · 11 pendentes de revisão.
+      </Alert>
+      <Alert type="warning" title="Revisão humana necessária">
+        3 lançamentos estão abaixo do limiar de confiança configurado (85%).
+      </Alert>
+      <Alert type="danger" title="Falha na integração com o banco">
+        Não foi possível autenticar com o Itaú. Reconecte a conta para retomar a coleta automática.
+      </Alert>
+    </Sec>
+
+    <Sec title="Somente mensagem (sem título)">
+      <Alert type="info">Seu plano atual permite até 5 empresas ativas.</Alert>
+      <Alert type="success">CNPJ validado na Receita Federal.</Alert>
+    </Sec>
+
+    <Sec title="Com ação à direita">
+      <Alert
+        type="warning"
+        title="Certificado A1 vence em 7 dias"
+        action={<button className="grd-btn grd-btn-secondary grd-btn-sm">Renovar agora</button>}
+      >
+        Para continuar emitindo notas fiscais, renove seu certificado digital antes do vencimento.
+      </Alert>
+      <Alert
+        type="info"
+        title="Nova funcionalidade"
+        action={<button className="grd-btn grd-btn-ghost grd-btn-sm">Ver tour</button>}
+      >
+        Agora você pode aprovar lançamentos em lote direto do painel.
+      </Alert>
+    </Sec>
+
+    <Sec title="Fechável">
+      {shown ? (
+        <Alert
+          type="success"
+          title="Backup automático ativado"
+          closable
+          onClose={() => setShown(false)}
+        >
+          Seus dados são salvos a cada 6 horas em ambiente criptografado.
+        </Alert>
+      ) : (
+        <div style={{fontSize:13,color:"var(--gray-500)",fontStyle:"italic"}}>Alerta fechado. <a href="#" onClick={e=>{e.preventDefault();setShown(true);}} style={{color:"var(--orange-500)"}}>Reexibir</a></div>
+      )}
+    </Sec>
+
+    <Sec title="Sem ícone">
+      <Alert type="info" icon={null} title="Modo compacto">
+        Use quando o alerta vem junto de outros elementos com ícone, para evitar ruído visual.
+      </Alert>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Alert"]) || "render(<div>Sem exemplo para Alert</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>type</code></td><td>string</td><td>"info"</td><td class="desc">info · success · warning · danger</td></tr>
+  <tr><td><code>title</code></td><td>node</td><td>—</td><td class="desc">Título em negrito</td></tr>
+  <tr><td><code>children</code></td><td>node</td><td>—</td><td class="desc">Mensagem</td></tr>
+  <tr><td><code>icon</code></td><td>string | null</td><td>auto</td><td class="desc">Nome Lucide, ou <code>null</code> para ocultar</td></tr>
+  <tr><td><code>action</code></td><td>node</td><td>—</td><td class="desc">Botão/link à direita</td></tr>
+  <tr><td><code>closable</code></td><td>boolean</td><td>false</td><td class="desc">Mostra X para dispensar</td></tr>
+  <tr><td><code>onClose</code></td><td>() ⇒ void</td><td>—</td><td class="desc">Callback do botão fechar</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Mensagem persistente em banner quando a ação do usuário é necessária — divergência fiscal, consentimento, erro bloqueante.</li>
+      <li>Sempre pares ícone + título + descrição curta; action opcional à direita.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Confirmações transitórias ("salvo com sucesso") — use Toast.</li>
+      <li>Vários alerts empilhados competindo pela atenção.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Alert/index.css
+++ b/ux_references/ui_kits/components/Alert/index.css
@@ -1,0 +1,32 @@
+
+.grd-alert {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 14px; border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+  font-family: var(--font-sans);
+}
+/* Semantica via Lighthouse tokens + rampas oficiais da paleta */
+.grd-alert-info    { background: var(--info-soft);    border-color: var(--signal-blue);   color: #002E6B; }
+.grd-alert-success { background: var(--success-soft); border-color: var(--signal-green);  color: #0B5A2E; }
+.grd-alert-warning { background: var(--yellow-100);   border-color: var(--yellow-500);    color: var(--yellow-900); }
+.grd-alert-danger  { background: var(--danger-soft);  border-color: var(--signal-red);    color: #7A0E0E; }
+
+.grd-alert-ic { flex-shrink: 0; padding-top: 1px; }
+.grd-alert-info .grd-alert-ic    { color: var(--signal-blue); }
+.grd-alert-success .grd-alert-ic { color: var(--signal-green); }
+.grd-alert-warning .grd-alert-ic { color: var(--yellow-900); }
+.grd-alert-danger .grd-alert-ic  { color: var(--signal-red); }
+
+.grd-alert-body { flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.grd-alert-title { font-size: 14px; font-weight: 600; line-height: 1.4; }
+.grd-alert-msg { font-size: 13px; line-height: 1.5; }
+.grd-alert-msg p { margin: 0; }
+
+.grd-alert-action { flex-shrink: 0; margin-left: 4px; }
+.grd-alert-close {
+  border: 0; background: transparent; cursor: pointer; color: inherit; opacity: 0.6;
+  width: 24px; height: 24px; border-radius: var(--radius-sm);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.grd-alert-close:hover { opacity: 1; background: color-mix(in oklab, currentColor 10%, transparent); }

--- a/ux_references/ui_kits/components/Alert/index.tsx
+++ b/ux_references/ui_kits/components/Alert/index.tsx
@@ -1,0 +1,57 @@
+
+/**
+ * Alert — banner inline com severidade.
+ * Tipos: info | success | warning | danger.
+ */
+
+interface AlertProps {
+  type?: "info" | "success" | "warning" | "danger";
+  title?: React.ReactNode;
+  children?: React.ReactNode;
+  icon?: string | null;
+  closable?: boolean;
+  onClose?: () => void;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+const ALERT_ICON: Record<string, string> = {
+  info: "info",
+  success: "circle-check",
+  warning: "triangle-alert",
+  danger: "circle-x",
+};
+
+function Alert({
+  type = "info",
+  title,
+  children,
+  icon,
+  closable = false,
+  onClose,
+  action,
+  className = "",
+}: AlertProps) {
+  const IconCmp = (window as any).Icon;
+  const iconName = icon === null ? null : (icon ?? ALERT_ICON[type]);
+  const cls = ["grd-alert", `grd-alert-${type}`, className].filter(Boolean).join(" ");
+  return (
+    <div role="alert" className={cls}>
+      {iconName && IconCmp && (
+        <span className="grd-alert-ic"><IconCmp name={iconName} size={18} /></span>
+      )}
+      <div className="grd-alert-body">
+        {title && <div className="grd-alert-title">{title}</div>}
+        {children && <div className="grd-alert-msg">{children}</div>}
+      </div>
+      {action && <div className="grd-alert-action">{action}</div>}
+      {closable && IconCmp && (
+        <button className="grd-alert-close" onClick={onClose} aria-label="Fechar">
+          <IconCmp name="x" size={15} />
+        </button>
+      )}
+    </div>
+  );
+}
+Alert.displayName = "Alert";
+(window as any).Alert = Alert;

--- a/ux_references/ui_kits/components/Avatar/Avatar.playground.html
+++ b/ux_references/ui_kits/components/Avatar/Avatar.playground.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Avatar · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · IDENTIDADE</div>
+  <h1 class="pg-title">Avatar</h1>
+  <span class="pg-codename">import Avatar from "ui_kits/components/Avatar"</span>
+  <p class="pg-desc">Representa uma pessoa ou entidade. Carrega imagem ou cai em iniciais coloridas. Cinco tamanhos, círculo/quadrado, opcional ponto de status.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, variant }: { title: string; children: React.ReactNode; variant?: string }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className={"pg-stage "+(variant||"")}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Tamanhos">
+      <Avatar size="xs" name="Ana Lima" />
+      <Avatar size="sm" name="Bruno Castro" color="laranja" />
+      <Avatar size="md" name="Carla Diniz" color="verde" />
+      <Avatar size="lg" name="Daniel Efe" color="azul" />
+      <Avatar size="xl" name="Elisa Faria" color="rosa" />
+    </Sec>
+    <Sec title="Com imagem">
+      <Avatar src="https://i.pravatar.cc/96?img=12" name="Usuário 12" size="lg" />
+      <Avatar src="https://i.pravatar.cc/96?img=25" name="Usuário 25" size="lg" />
+      <Avatar src="https://i.pravatar.cc/96?img=38" name="Usuário 38" size="lg" />
+    </Sec>
+    <Sec title="Cores · fallback">
+      <Avatar name="Ana Lima" color="violeta" />
+      <Avatar name="Bruno Castro" color="laranja" />
+      <Avatar name="Carla Diniz" color="verde" />
+      <Avatar name="Daniel Efe" color="azul" />
+      <Avatar name="Elisa Faria" color="rosa" />
+      <Avatar name="Felipe Gomes" color="amarelo" />
+    </Sec>
+    <Sec title="Status">
+      <Avatar name="Ana Lima" status="online" />
+      <Avatar name="Bruno Castro" status="busy" color="laranja" />
+      <Avatar name="Carla Diniz" status="away" color="verde" />
+      <Avatar name="Daniel Efe" status="offline" color="azul" />
+    </Sec>
+    <Sec title="Quadrado">
+      <Avatar shape="square" name="Kp" color="laranja" size="lg" />
+      <Avatar shape="square" name="Dório" color="violeta" size="lg" />
+      <Avatar shape="square" src="https://i.pravatar.cc/96?img=7" name="7" size="lg" />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+function ExampleApp() {
+  const code = `
+function UserMenu() {
+  const [online, setOnline] = React.useState(true);
+
+  return (
+    <button
+      onClick={() => setOnline(!online)}
+      style={{
+        display: 'flex', gap: 8, alignItems: 'center',
+        padding: '6px 14px 6px 6px',
+        background: '#fff',
+        border: '1px solid var(--border)',
+        borderRadius: "var(--radius-pill)", cursor: 'pointer', font: 'inherit'
+      }}
+    >
+      <Avatar name="Ana Lima" color="violeta" size="sm" status={online ? "online" : "offline"} />
+      <span style={{ fontSize: 13, fontWeight: 500 }}>Ana Lima</span>
+      <span style={{ fontSize: 11, color: 'var(--gray-500)' }}>(clique)</span>
+    </button>
+  );
+}
+
+render(<UserMenu />);
+`;
+  return <LiveCode code={code} />;
+}
+ReactDOM.createRoot(document.getElementById('example-root')!).render(<ExampleApp />);
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>src</code></td><td>string</td><td>—</td><td class="desc">URL da imagem; se vazio, renderiza iniciais</td></tr>
+  <tr><td><code>name</code></td><td>string</td><td>—</td><td class="desc">Nome completo; gera iniciais (Ana Lima → AL)</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td><code>"md"</code></td><td class="desc">xs · sm · md · lg · xl</td></tr>
+  <tr><td><code>shape</code></td><td>string</td><td><code>"circle"</code></td><td class="desc">circle · square</td></tr>
+  <tr><td><code>color</code></td><td>string</td><td><code>"violeta"</code></td><td class="desc">violeta · laranja · verde · azul · rosa · amarelo</td></tr>
+  <tr><td><code>status</code></td><td>string</td><td>—</td><td class="desc">online · offline · busy · away</td></tr>
+</table>
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Iniciais como fallback quando não há foto; cor do grupo violeta/laranja conforme papel.</li>
+      <li>Tamanhos consistentes: sm em listas, md em headers, lg/xl em perfil.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Avatares genéricos em agentes — AgentCard usa ícone <code>bot</code>.</li>
+      <li>Gradientes ou cores fora da paleta.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Avatar/index.css
+++ b/ux_references/ui_kits/components/Avatar/index.css
@@ -1,0 +1,50 @@
+/* Avatar */
+.grd-avatar {
+  position: relative;
+  display: inline-flex; align-items: center; justify-content: center;
+  overflow: hidden;
+  color: #fff; font-weight: 600; letter-spacing: -0.01em;
+  user-select: none;
+  background: var(--gray-300);
+}
+.grd-avatar img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.grd-avatar-initials { font-family: var(--font-sans); line-height: 1; }
+
+.grd-avatar-circle { border-radius: var(--radius-pill); }
+.grd-avatar-square { border-radius: var(--radius-md); }
+
+/* Sizes */
+.grd-avatar-xs { width: 20px; height: 20px; font-size: 9px; }
+.grd-avatar-sm { width: 28px; height: 28px; font-size: 11px; }
+.grd-avatar-md { width: 36px; height: 36px; font-size: 13px; }
+.grd-avatar-lg { width: 48px; height: 48px; font-size: 17px; }
+.grd-avatar-xl { width: 64px; height: 64px; font-size: 22px; }
+
+/* Fallback colors — paleta oficial Guardia + Signal para verde/azul */
+.grd-avatar-fallback-violet { background: var(--violet-500); }
+.grd-avatar-fallback-orange { background: var(--orange-500); }
+.grd-avatar-fallback-pink   { background: var(--pink-500); }
+.grd-avatar-fallback-yellow { background: var(--yellow-500); color: var(--violet-900); }
+.grd-avatar-fallback-green  { background: var(--signal-green); }
+.grd-avatar-fallback-blue   { background: var(--signal-blue); }
+.grd-avatar-fallback-gray   { background: var(--gray-500); }
+
+/* Aliases PT (legado) — apontam para os mesmos tokens; usar nomes EN em código novo */
+.grd-avatar-fallback-violeta { background: var(--violet-500); }
+.grd-avatar-fallback-laranja { background: var(--orange-500); }
+.grd-avatar-fallback-rosa    { background: var(--pink-500); }
+.grd-avatar-fallback-amarelo { background: var(--yellow-500); color: var(--violet-900); }
+.grd-avatar-fallback-verde   { background: var(--signal-green); }
+.grd-avatar-fallback-azul    { background: var(--signal-blue); }
+
+/* Status dot */
+.grd-avatar-status {
+  position: absolute; bottom: 0; right: 0;
+  width: 30%; height: 30%; min-width: 8px; min-height: 8px;
+  border-radius: var(--radius-pill); border: 2px solid #fff;
+}
+.grd-avatar-square .grd-avatar-status { bottom: -3px; right: -3px; }
+.grd-avatar-status-online  { background: var(--signal-green); }
+.grd-avatar-status-offline { background: var(--gray-300); }
+.grd-avatar-status-busy    { background: var(--signal-red); }
+.grd-avatar-status-away    { background: var(--signal-yellow); }

--- a/ux_references/ui_kits/components/Avatar/index.tsx
+++ b/ux_references/ui_kits/components/Avatar/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * Avatar — identidade visual de uma pessoa ou entidade.
+ * Props:
+ *   src        URL da imagem
+ *   name       nome (gera iniciais como fallback)
+ *   size       xs (20) · sm (28) · md (36) · lg (48) · xl (64)
+ *   shape      circle (default) · square
+ *   status     online · offline · busy · away (adiciona ponto)
+ *   color      violet · orange · pink · yellow · green · blue · gray (cor do fallback)
+ *              Aliases PT aceitos: violeta, laranja, rosa, amarelo, verde, azul
+ */
+
+type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
+type AvatarShape = "circle" | "square";
+type AvatarStatus = "online" | "offline" | "busy" | "away";
+type AvatarColor =
+  | "violet" | "orange" | "pink" | "yellow" | "green" | "blue" | "gray"
+  | "violeta" | "laranja" | "rosa" | "amarelo" | "verde" | "azul";
+
+interface AvatarProps extends React.HTMLAttributes<HTMLSpanElement> {
+  src?: string;
+  name?: string;
+  size?: AvatarSize;
+  shape?: AvatarShape;
+  status?: AvatarStatus;
+  color?: AvatarColor;
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function Avatar({
+  src, name, size = "md", shape = "circle", status, color = "violet",
+  className = "", ...rest
+}: AvatarProps) {
+  const cls = [
+    "grd-avatar", `grd-avatar-${size}`, `grd-avatar-${shape}`,
+    !src && `grd-avatar-fallback-${color}`,
+    className,
+  ].filter(Boolean).join(" ");
+  return (
+    <span className={cls} {...rest}>
+      {src ? (
+        <img src={src} alt={name || ""} />
+      ) : (
+        <span className="grd-avatar-initials">{initials(name || "?")}</span>
+      )}
+      {status && <span className={`grd-avatar-status grd-avatar-status-${status}`} aria-label={status} />}
+    </span>
+  );
+}
+Avatar.displayName = "Avatar";
+(window as any).Avatar = Avatar;

--- a/ux_references/ui_kits/components/Badge/Badge.playground.html
+++ b/ux_references/ui_kits/components/Badge/Badge.playground.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Badge · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · STATUS</div>
+  <h1 class="pg-title">Badge</h1>
+  <span class="pg-codename">import Badge from "ui_kits/components/Badge"</span>
+  <p class="pg-desc">Rótulo compacto para status, tag ou contagem. 7 variantes semânticas × 3 aparências (solid, soft, outline) × 2 shapes. Ponto indicador opcional.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage">{children}</div></div>);
+}
+const VARS = ["neutral","brand","accent","success","warning","danger","info"] as const;
+function App() {
+  return (<>
+    <Sec title="Variantes · soft (default)">
+      {VARS.map(v => <Badge key={v} variant={v}>{v}</Badge>)}
+    </Sec>
+    <Sec title="Solid">
+      {VARS.map(v => <Badge key={v} variant={v} appearance="solid">{v}</Badge>)}
+    </Sec>
+    <Sec title="Outline">
+      {VARS.map(v => <Badge key={v} variant={v} appearance="outline">{v}</Badge>)}
+    </Sec>
+    <Sec title="Com dot (status ao vivo)">
+      <Badge variant="success" dot>Online</Badge>
+      <Badge variant="warning" dot>Pendente</Badge>
+      <Badge variant="danger" dot>Crítico</Badge>
+      <Badge variant="info" dot>Sincronizando</Badge>
+      <Badge variant="neutral" dot>Offline</Badge>
+    </Sec>
+    <Sec title="Shape · square">
+      <Badge variant="brand" shape="square">v2.1.4</Badge>
+      <Badge variant="accent" shape="square" appearance="solid">NOVO</Badge>
+      <Badge variant="neutral" shape="square" appearance="outline">beta</Badge>
+    </Sec>
+    <Sec title="Contagens">
+      <Badge variant="brand" appearance="solid">3</Badge>
+      <Badge variant="danger" appearance="solid">12</Badge>
+      <Badge variant="accent" appearance="solid">99+</Badge>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Badge"]) || "render(<div>Sem exemplo para Badge</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"neutral"</td><td class="desc">neutral · brand · accent · success · warning · danger · info</td></tr>
+  <tr><td><code>appearance</code></td><td>string</td><td>"soft"</td><td class="desc">solid · soft · outline</td></tr>
+  <tr><td><code>shape</code></td><td>string</td><td>"pill"</td><td class="desc">pill · square</td></tr>
+  <tr><td><code>dot</code></td><td>boolean</td><td>false</td><td class="desc">Mostra ponto indicador à esquerda</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Status curto e não-interativo: conciliado, pendente, divergente, novo.</li>
+      <li>Uma palavra, sentence case; combine com <code>Icon</code> quando categorizar.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Ações clicáveis — use <code>Chip</code> ou <code>Button</code>.</li>
+      <li>Mais de 2 badges adjacentes no mesmo elemento.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Badge/index.css
+++ b/ux_references/ui_kits/components/Badge/index.css
@@ -1,0 +1,49 @@
+/* Badge */
+.grd-badge {
+  --grd-b-bg: var(--gray-100);
+  --grd-b-fg: var(--gray-700);
+  --grd-b-bd: transparent;
+
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--grd-b-bg); color: var(--grd-b-fg);
+  border: 1px solid var(--grd-b-bd);
+  font-size: 11px; font-weight: 600; line-height: 1;
+  letter-spacing: 0.02em;
+  padding: 4px 9px;
+  white-space: nowrap;
+}
+.grd-badge-pill { border-radius: var(--radius-pill); }
+.grd-badge-square { border-radius: var(--radius-sm); }
+.grd-badge-dot {
+  width: 6px; height: 6px; border-radius: var(--radius-pill);
+  background: currentColor;
+}
+
+/* Soft (default) */
+.grd-badge-soft.grd-badge-neutral { --grd-b-bg: var(--gray-100); --grd-b-fg: var(--gray-700); }
+.grd-badge-soft.grd-badge-brand   { --grd-b-bg: var(--violet-100); --grd-b-fg: var(--violet-700); }
+.grd-badge-soft.grd-badge-accent  { --grd-b-bg: var(--orange-100); --grd-b-fg: var(--orange-700); }
+.grd-badge-soft.grd-badge-success { --grd-b-bg: var(--success-soft); --grd-b-fg: color-mix(in oklab, var(--signal-green) 52%, black); }
+.grd-badge-soft.grd-badge-warning { --grd-b-bg: var(--yellow-100);   --grd-b-fg: var(--yellow-900); }
+.grd-badge-soft.grd-badge-danger  { --grd-b-bg: var(--danger-soft);  --grd-b-fg: color-mix(in oklab, var(--signal-red)   45%, black); }
+.grd-badge-soft.grd-badge-info    { --grd-b-bg: var(--info-soft);    --grd-b-fg: color-mix(in oklab, var(--signal-blue)  62%, black); }
+
+/* Solid */
+.grd-badge-solid { --grd-b-fg: #fff; }
+.grd-badge-solid.grd-badge-neutral { --grd-b-bg: var(--gray-500); }
+.grd-badge-solid.grd-badge-brand   { --grd-b-bg: var(--violet-500); }
+.grd-badge-solid.grd-badge-accent  { --grd-b-bg: var(--orange-500); }
+.grd-badge-solid.grd-badge-success { --grd-b-bg: var(--signal-green); }
+.grd-badge-solid.grd-badge-warning { --grd-b-bg: var(--signal-yellow); --grd-b-fg: var(--violet-900); }
+.grd-badge-solid.grd-badge-danger  { --grd-b-bg: var(--signal-red); }
+.grd-badge-solid.grd-badge-info    { --grd-b-bg: var(--signal-blue); }
+
+/* Outline */
+.grd-badge-outline { --grd-b-bg: transparent; }
+.grd-badge-outline.grd-badge-neutral { --grd-b-fg: var(--gray-700); --grd-b-bd: var(--border-strong); }
+.grd-badge-outline.grd-badge-brand   { --grd-b-fg: var(--violet-500); --grd-b-bd: var(--violet-500); }
+.grd-badge-outline.grd-badge-accent  { --grd-b-fg: var(--orange-500); --grd-b-bd: var(--orange-500); }
+.grd-badge-outline.grd-badge-success { --grd-b-fg: var(--signal-green); --grd-b-bd: var(--signal-green); }
+.grd-badge-outline.grd-badge-warning { --grd-b-fg: var(--yellow-900); --grd-b-bd: var(--signal-yellow); }
+.grd-badge-outline.grd-badge-danger  { --grd-b-fg: var(--signal-red); --grd-b-bd: var(--signal-red); }
+.grd-badge-outline.grd-badge-info    { --grd-b-fg: var(--signal-blue); --grd-b-bd: var(--signal-blue); }

--- a/ux_references/ui_kits/components/Badge/index.tsx
+++ b/ux_references/ui_kits/components/Badge/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * Badge — rótulo compacto para status/tag/contagem.
+ * Variantes: neutral · brand · accent · success · warning · danger · info
+ * Estilos: solid (default) · soft · outline
+ * Shape: pill (default) · square
+ * Com ponto opcional (dot).
+ */
+
+type BadgeVariant = "neutral" | "brand" | "accent" | "success" | "warning" | "danger" | "info";
+type BadgeStyle = "solid" | "soft" | "outline";
+
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+  appearance?: BadgeStyle;
+  shape?: "pill" | "square";
+  dot?: boolean;
+}
+
+function Badge({
+  variant = "neutral",
+  appearance = "soft",
+  shape = "pill",
+  dot = false,
+  className = "",
+  children,
+  ...rest
+}: BadgeProps) {
+  const cls = [
+    "grd-badge",
+    `grd-badge-${variant}`,
+    `grd-badge-${appearance}`,
+    `grd-badge-${shape}`,
+    className,
+  ].filter(Boolean).join(" ");
+  return (
+    <span className={cls} {...rest}>
+      {dot && <span className="grd-badge-dot" />}
+      {children}
+    </span>
+  );
+}
+Badge.displayName = "Badge";
+(window as any).Badge = Badge;

--- a/ux_references/ui_kits/components/Breadcrumbs/Breadcrumbs.playground.html
+++ b/ux_references/ui_kits/components/Breadcrumbs/Breadcrumbs.playground.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Breadcrumbs · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">NAVEGAÇÃO · HIERARQUIA</div>
+  <h1 class="pg-title">Breadcrumbs</h1>
+  <span class="pg-codename">import Breadcrumbs from "ui_kits/components/Breadcrumbs"</span>
+  <p class="pg-desc">Trilha de migalhas para orientação em hierarquias profundas. Último item é o atual (não é link). Use <code>maxItems</code> para truncar caminhos longos.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",gap:12}}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Caminho simples">
+      <Breadcrumbs items={[
+        { label: "Home", href: "#", icon: "home" },
+        { label: "Empresas", href: "#" },
+        { label: "Alfa Comércio LTDA" },
+      ]}/>
+    </Sec>
+
+    <Sec title="Profundo">
+      <Breadcrumbs items={[
+        { label: "Home", href: "#", icon: "home" },
+        { label: "Empresas", href: "#" },
+        { label: "Alfa Comércio LTDA", href: "#" },
+        { label: "Fiscal", href: "#" },
+        { label: "Notas fiscais", href: "#" },
+        { label: "NF 4891 — Fornecedor Beta" },
+      ]}/>
+    </Sec>
+
+    <Sec title="Truncado (maxItems=4)">
+      <Breadcrumbs maxItems={4} items={[
+        { label: "Home", href: "#", icon: "home" },
+        { label: "Empresas", href: "#" },
+        { label: "Alfa Comércio LTDA", href: "#" },
+        { label: "Fiscal", href: "#" },
+        { label: "Notas fiscais", href: "#" },
+        { label: "NF 4891" },
+      ]}/>
+    </Sec>
+
+    <Sec title="Separador customizado">
+      <Breadcrumbs separator="›" items={[
+        { label: "Workspace", href: "#" },
+        { label: "Clientes", href: "#" },
+        { label: "Alfa" },
+      ]}/>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Breadcrumbs"]) || "render(<div>Sem exemplo para Breadcrumbs</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>items</code></td><td>array</td><td>—</td><td class="desc">{`{ label, href?, icon?, onClick? }[]`}</td></tr>
+  <tr><td><code>separator</code></td><td>node</td><td>chevron-right</td><td class="desc">Separador entre itens</td></tr>
+  <tr><td><code>maxItems</code></td><td>number</td><td>—</td><td class="desc">Trunca com "…" quando excedido</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Navegação hierárquica em fluxos profundos: Cliente › Empresa › Conciliação › Lote.</li>
+      <li>Último item como estado atual (não clicável).</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Breadcrumbs para histórico linear (use <code>Tabs</code> ou volta).</li>
+      <li>Mais de 5 níveis — trunque com ellipsis.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Breadcrumbs/index.css
+++ b/ux_references/ui_kits/components/Breadcrumbs/index.css
@@ -1,0 +1,18 @@
+
+.grd-bc { font-family: var(--font-sans); font-size: 13px; }
+.grd-bc ol { list-style: none; padding: 0; margin: 0; display: flex; align-items: center; flex-wrap: wrap; gap: 2px; }
+.grd-bc-item { display: inline-flex; align-items: center; gap: 6px; }
+.grd-bc-link {
+  display: inline-flex; align-items: center; gap: 4px;
+  color: var(--fg-muted);
+  text-decoration: none;
+  padding: 2px 4px; border-radius: var(--radius-sm);
+  transition: color 120ms, background 120ms;
+}
+.grd-bc-link:hover { color: var(--violet-700); background: var(--violet-50); }
+.grd-bc-static { display: inline-flex; align-items: center; gap: 4px; color: var(--fg-muted); padding: 2px 4px; }
+.grd-bc-current {
+  display: inline-flex; align-items: center; gap: 4px;
+  color: var(--fg); font-weight: 600; padding: 2px 4px;
+}
+.grd-bc-sep { color: var(--gray-400); display: inline-flex; align-items: center; }

--- a/ux_references/ui_kits/components/Breadcrumbs/index.tsx
+++ b/ux_references/ui_kits/components/Breadcrumbs/index.tsx
@@ -1,0 +1,53 @@
+
+/**
+ * Breadcrumbs — trilha de navegação hierárquica.
+ * items: { label, href?, icon? }[]. Último item = atual, sem link.
+ */
+
+interface BCItem { label: React.ReactNode; href?: string; icon?: string; onClick?: () => void }
+interface BreadcrumbsProps {
+  items: BCItem[];
+  separator?: React.ReactNode;
+  maxItems?: number;
+  className?: string;
+}
+
+function Breadcrumbs({ items, separator, maxItems, className = "" }: BreadcrumbsProps) {
+  const IconCmp = (window as any).Icon;
+  let show = items;
+  if (maxItems && items.length > maxItems) {
+    show = [items[0], { label: "…" } as BCItem, ...items.slice(items.length - (maxItems - 2))];
+  }
+  const sep = separator ?? (IconCmp ? <IconCmp name="chevron-right" size={13} /> : "/");
+  return (
+    <nav aria-label="breadcrumb" className={`grd-bc ${className}`}>
+      <ol>
+        {show.map((it, i) => {
+          const isLast = i === show.length - 1;
+          return (
+            <li key={i} className="grd-bc-item">
+              {!isLast && (it.href || it.onClick) ? (
+                <a
+                  className="grd-bc-link"
+                  href={it.href}
+                  onClick={(e) => { if (it.onClick) { e.preventDefault(); it.onClick(); } }}
+                >
+                  {it.icon && IconCmp && <IconCmp name={it.icon} size={13} />}
+                  <span>{it.label}</span>
+                </a>
+              ) : (
+                <span className={isLast ? "grd-bc-current" : "grd-bc-static"}>
+                  {it.icon && IconCmp && <IconCmp name={it.icon} size={13} />}
+                  <span>{it.label}</span>
+                </span>
+              )}
+              {!isLast && <span className="grd-bc-sep" aria-hidden>{sep}</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+Breadcrumbs.displayName = "Breadcrumbs";
+(window as any).Breadcrumbs = Breadcrumbs;

--- a/ux_references/ui_kits/components/Button/Button.playground.html
+++ b/ux_references/ui_kits/components/Button/Button.playground.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Button · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Spinner/index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · AÇÃO</div>
+  <h1 class="pg-title">Button</h1>
+  <span class="pg-codename">import Button from "ui_kits/components/Button"</span>
+  <p class="pg-desc">Ação interativa principal. Seis variantes, três tamanhos, slots para ícones e estado <code>loading</code>. Primário é o violeta; <code>accent</code> laranja é reservado para conversão; <code>outline</code> e <code>ghost</code> para ações secundárias.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Spinner/index.tsx?v=10"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+  function Section({ title, children }: { title: string; children: React.ReactNode }) {
+    return (
+      <div className="pg-sec">
+        <p className="pg-sec-title">{title}</p>
+        <div className="pg-stage">{children}</div>
+      </div>
+    );
+  }
+
+  function App() {
+    return (
+      <>
+        <Section title="Variantes">
+          <Button variant="primary">Primário</Button>
+          <Button variant="accent">Accent</Button>
+          <Button variant="outline">Outline</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="destructive">Excluir</Button>
+          <Button variant="link">Link</Button>
+        </Section>
+
+        <Section title="Tamanhos">
+          <Button size="sm">Small</Button>
+          <Button size="md">Medium</Button>
+          <Button size="lg">Large</Button>
+        </Section>
+
+        <Section title="Com ícones">
+          <Button leftIcon="plus">Novo cliente</Button>
+          <Button variant="accent" rightIcon="arrow-right">Continuar</Button>
+          <Button variant="outline" leftIcon="download">Exportar</Button>
+          <Button variant="ghost" leftIcon="refresh">Atualizar</Button>
+          <Button variant="destructive" leftIcon="trash">Excluir conta</Button>
+        </Section>
+
+        <Section title="Estados">
+          <Button>Default</Button>
+          <Button loading>Carregando</Button>
+          <Button disabled>Desabilitado</Button>
+          <Button variant="accent" loading>Salvando</Button>
+        </Section>
+
+        <Section title="Full width">
+          <div style={{ width: '100%', maxWidth: 420 }}>
+            <Button fullWidth leftIcon="check">Confirmar pagamento</Button>
+          </div>
+        </Section>
+      </>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+function ExampleApp() {
+  const code = `
+function Checkout() {
+  const [saving, setSaving] = React.useState(false);
+  const [done, setDone] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!saving) return;
+    const t = setTimeout(() => { setSaving(false); setDone(true); }, 1500);
+    return () => clearTimeout(t);
+  }, [saving]);
+
+  return (
+    <div style={{ display: 'flex', gap: 12 }}>
+      <Button variant="ghost" onClick={() => { setSaving(false); setDone(false); }}>
+        Voltar
+      </Button>
+      <Button
+        variant="accent"
+        size="lg"
+        rightIcon={done ? "check" : "arrow-right"}
+        loading={saving}
+        onClick={() => setSaving(true)}
+      >
+        {done ? "Confirmado" : "Confirmar pagamento"}
+      </Button>
+    </div>
+  );
+}
+
+render(<Checkout />);
+`;
+  return <LiveCode code={code} />;
+}
+ReactDOM.createRoot(document.getElementById('example-root')!).render(<ExampleApp />);
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>variant</code></td><td>string</td><td><code>"primary"</code></td><td class="desc">primary · accent · outline · ghost · destructive · link</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td><code>"md"</code></td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>leftIcon</code></td><td>IconName</td><td>—</td><td class="desc">Nome do glifo (de <code>&lt;Icon /&gt;</code>)</td></tr>
+  <tr><td><code>rightIcon</code></td><td>IconName</td><td>—</td><td class="desc">Idem, à direita do label</td></tr>
+  <tr><td><code>loading</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Mostra spinner e desabilita clique</td></tr>
+  <tr><td><code>fullWidth</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Ocupa 100% do container</td></tr>
+  <tr><td><code>disabled</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Desabilita interação</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Uma ação primária por tela — reserve <em>accent</em> laranja para conversão/CTA hero.</li>
+      <li>Label em sentence case com verbo de ação ("Salvar lançamento", não "Salvar").</li>
+      <li>Destructive apenas para ações irreversíveis com confirmação.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Dois botões primários competindo na mesma tela.</li>
+      <li>Labels vagos ("OK", "Enviar") sem objeto.</li>
+      <li>Gradientes ou sombras no botão — a hierarquia é por cor sólida e peso.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Button/index.css
+++ b/ux_references/ui_kits/components/Button/index.css
@@ -1,0 +1,76 @@
+/* Button */
+.grd-btn {
+  --grd-btn-bg: var(--violet-500);
+  --grd-btn-fg: #fff;
+  --grd-btn-bd: transparent;
+  --grd-btn-bg-hover: var(--violet-700);
+
+  font-family: var(--font-sans); font-weight: 700;
+  border: 1px solid var(--grd-btn-bd); border-radius: var(--radius-md);
+  background: var(--grd-btn-bg); color: var(--grd-btn-fg);
+  cursor: pointer;
+  padding: 9px 16px; font-size: 14px;  /* default = md */
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  line-height: 1; white-space: nowrap;
+  transition: background 160ms var(--ease-standard),
+              color 160ms var(--ease-standard),
+              border-color 160ms var(--ease-standard),
+              box-shadow 160ms var(--ease-standard);
+}
+.grd-btn:hover:not(:disabled) { background: var(--grd-btn-bg-hover); }
+.grd-btn:focus-visible { outline: none; box-shadow: var(--focus-ring-accent); }
+.grd-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.grd-btn.grd-btn-loading:disabled { opacity: 0.85; cursor: progress; }
+
+.grd-btn-label { display: inline-block; }
+.grd-btn-full { width: 100%; }
+
+/* Sizes */
+.grd-btn-sm { padding: 6px 12px; font-size: 13px; border-radius: var(--radius-sm); }
+.grd-btn-md { padding: 9px 16px; font-size: 14px; }
+.grd-btn-lg { padding: 12px 22px; font-size: 15px; border-radius: var(--radius-lg); }
+
+/* Variants */
+.grd-btn-primary {
+  --grd-btn-bg: var(--violet-500);
+  --grd-btn-fg: #fff;
+  --grd-btn-bg-hover: var(--violet-700);
+}
+.grd-btn-secondary {
+  --grd-btn-bg: var(--violet-100);
+  --grd-btn-fg: var(--violet-700);
+  --grd-btn-bg-hover: var(--violet-200);
+}
+.grd-btn-accent {
+  --grd-btn-bg: var(--orange-500);
+  --grd-btn-fg: #fff;
+  --grd-btn-bg-hover: var(--orange-700);
+}
+.grd-btn-outline {
+  --grd-btn-bg: #fff;
+  --grd-btn-fg: var(--violet-500);
+  --grd-btn-bd: var(--violet-500);
+  --grd-btn-bg-hover: var(--violet-100);
+}
+.grd-btn-ghost {
+  --grd-btn-bg: transparent;
+  --grd-btn-fg: var(--violet-500);
+  --grd-btn-bg-hover: var(--violet-100);
+}
+.grd-btn-destructive {
+  --grd-btn-bg: var(--signal-red);
+  --grd-btn-fg: #fff;
+  --grd-btn-bg-hover: color-mix(in oklab, var(--signal-red) 82%, black);
+}
+.grd-btn-link {
+  --grd-btn-bg: transparent;
+  --grd-btn-fg: var(--orange-500);
+  --grd-btn-bg-hover: transparent;
+  padding: 0; text-decoration: underline;
+}
+.grd-btn-link:hover:not(:disabled) { color: var(--orange-700); }
+
+/* Loading state */
+.grd-btn-loading { position: relative; }
+.grd-btn-loading .grd-btn-label { opacity: 0.9; }
+.grd-btn-loader { display: inline-flex; margin-right: -2px; }

--- a/ux_references/ui_kits/components/Button/index.tsx
+++ b/ux_references/ui_kits/components/Button/index.tsx
@@ -1,0 +1,69 @@
+/**
+ * Button — botão interativo principal
+ * -----------------------------------
+ * Variantes visuais:
+ *   primary      violeta preenchido (CTA principal)
+ *   accent       laranja preenchido (CTA de conversão / destaque)
+ *   outline      borda violeta, fundo branco
+ *   ghost        sem fundo, hover suave
+ *   destructive  vermelho, ação irreversível
+ *   link         parece link sublinhado
+ *
+ * Tamanhos: sm · md (default) · lg
+ *
+ * Slots:
+ *   leftIcon / rightIcon  → nome do Icon (<Icon name="..." />)
+ *   loading               → substitui conteúdo por spinner
+ *   disabled              → desabilita interação
+ */
+
+type ButtonVariant = "primary" | "accent" | "outline" | "ghost" | "destructive" | "link";
+type ButtonSize = "sm" | "md" | "lg";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  leftIcon?: string;
+  rightIcon?: string;
+  loading?: boolean;
+  fullWidth?: boolean;
+}
+
+function Button({
+  variant = "primary",
+  size = "md",
+  leftIcon,
+  rightIcon,
+  loading = false,
+  fullWidth = false,
+  disabled,
+  children,
+  className = "",
+  ...rest
+}: ButtonProps) {
+  const IconCmp = (window as any).Icon;
+  const SpinnerCmp = (window as any).Spinner;
+  const cls = [
+    "grd-btn",
+    `grd-btn-${variant}`,
+    `grd-btn-${size}`,
+    fullWidth && "grd-btn-full",
+    loading && "grd-btn-loading",
+    className,
+  ].filter(Boolean).join(" ");
+
+  const iconSize = size === "sm" ? 13 : size === "lg" ? 18 : 15;
+  const spinnerSize = size === "sm" ? "xs" : size === "lg" ? "md" : "sm";
+
+  return (
+    <button className={cls} disabled={disabled || loading} {...rest}>
+      {loading && SpinnerCmp && <SpinnerCmp size={spinnerSize} className="grd-btn-loader" />}
+      {!loading && leftIcon && IconCmp && <IconCmp name={leftIcon} size={iconSize} />}
+      <span className="grd-btn-label">{children}</span>
+      {!loading && rightIcon && IconCmp && <IconCmp name={rightIcon} size={iconSize} />}
+    </button>
+  );
+}
+
+Button.displayName = "Button";
+(window as any).Button = Button;

--- a/ux_references/ui_kits/components/ButtonGroup/ButtonGroup.playground.html
+++ b/ux_references/ui_kits/components/ButtonGroup/ButtonGroup.playground.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>ButtonGroup · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../IconButton/index.css">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · AÇÃO</div>
+  <h1 class="pg-title">ButtonGroup</h1>
+  <span class="pg-codename">import ButtonGroup from "ui_kits/components/ButtonGroup"</span>
+  <p class="pg-desc">Agrupa <code>Button</code> / <code>IconButton</code> em barra. Modo <code>attached</code> (default) colapsa bordas internas; <code>spaced</code> mantém gap. Horizontal ou vertical.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../IconButton/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage">{children}</div></div>);
+}
+function App() {
+  const [view, setView] = React.useState("lista");
+  return (<>
+    <Sec title="Attached · horizontal (default)">
+      <ButtonGroup>
+        <Button variant="outline">Dia</Button>
+        <Button variant="outline">Semana</Button>
+        <Button variant="primary">Mês</Button>
+        <Button variant="outline">Ano</Button>
+      </ButtonGroup>
+    </Sec>
+    <Sec title="Attached · IconButtons (toolbar)">
+      <ButtonGroup>
+        <IconButton icon="list" variant="outline" aria-label="Lista" />
+        <IconButton icon="grid-2x2" variant="outline" aria-label="Grade" />
+        <IconButton icon="kanban" variant="outline" aria-label="Kanban" />
+      </ButtonGroup>
+    </Sec>
+    <Sec title="Spaced · gap entre botões">
+      <ButtonGroup attached={false}>
+        <Button variant="ghost" leftIcon="arrow-left">Voltar</Button>
+        <Button variant="outline">Salvar rascunho</Button>
+        <Button variant="accent" rightIcon="arrow-right">Continuar</Button>
+      </ButtonGroup>
+    </Sec>
+    <Sec title="Vertical">
+      <ButtonGroup orientation="vertical">
+        <Button variant="outline" leftIcon="file-text">Exportar PDF</Button>
+        <Button variant="outline" leftIcon="file-spreadsheet">Exportar Excel</Button>
+        <Button variant="outline" leftIcon="download">Download CSV</Button>
+      </ButtonGroup>
+    </Sec>
+    <Sec title="Segmented control (estado selecionado)">
+      <ButtonGroup>
+        {["lista","kanban","timeline"].map(v => (
+          <Button key={v} variant={view===v ? "primary" : "outline"} onClick={() => setView(v)} style={{textTransform:"capitalize"}}>
+            {v}
+          </Button>
+        ))}
+      </ButtonGroup>
+      <span style={{fontSize:12,color:"var(--gray-500)",marginLeft:12}}>visualização: <b>{view}</b></span>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["ButtonGroup"]) || "render(<div>Sem exemplo para ButtonGroup</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>orientation</code></td><td>string</td><td>"horizontal"</td><td class="desc">horizontal · vertical</td></tr>
+  <tr><td><code>attached</code></td><td>boolean</td><td>true</td><td class="desc">Colapsa bordas internas (segmented) vs. mantém gap</td></tr>
+  <tr><td><code>children</code></td><td>ReactNode</td><td>—</td><td class="desc">Buttons ou IconButtons</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Ações mutuamente exclusivas relacionadas (filtros de período, densidade de tabela, modos de visualização).</li>
+      <li>Máximo 4 itens; indique seleção pelo <code>pressed</code>.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Ações não relacionadas ("salvar" + "excluir" juntos).</li>
+      <li>Mais de 4 opções — use <code>Select</code> ou <code>Menu</code>.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/ButtonGroup/index.css
+++ b/ux_references/ui_kits/components/ButtonGroup/index.css
@@ -1,0 +1,25 @@
+/* ButtonGroup */
+.grd-btngroup { display: inline-flex; }
+.grd-btngroup-horizontal { flex-direction: row; }
+.grd-btngroup-vertical { flex-direction: column; }
+.grd-btngroup-spaced { gap: 8px; }
+
+/* Attached: remove radius and collapse borders between children */
+.grd-btngroup-attached.grd-btngroup-horizontal > .grd-btn:not(:first-child),
+.grd-btngroup-attached.grd-btngroup-horizontal > .grd-iconbtn:not(:first-child) {
+  border-top-left-radius: 0; border-bottom-left-radius: 0;
+  margin-left: -1px;
+}
+.grd-btngroup-attached.grd-btngroup-horizontal > .grd-btn:not(:last-child),
+.grd-btngroup-attached.grd-btngroup-horizontal > .grd-iconbtn:not(:last-child) {
+  border-top-right-radius: 0; border-bottom-right-radius: 0;
+}
+.grd-btngroup-attached.grd-btngroup-vertical > .grd-btn:not(:first-child),
+.grd-btngroup-attached.grd-btngroup-vertical > .grd-iconbtn:not(:first-child) {
+  border-top-left-radius: 0; border-top-right-radius: 0;
+  margin-top: -1px;
+}
+.grd-btngroup-attached.grd-btngroup-vertical > .grd-btn:not(:last-child),
+.grd-btngroup-attached.grd-btngroup-vertical > .grd-iconbtn:not(:last-child) {
+  border-bottom-left-radius: 0; border-bottom-right-radius: 0;
+}

--- a/ux_references/ui_kits/components/ButtonGroup/index.tsx
+++ b/ux_references/ui_kits/components/ButtonGroup/index.tsx
@@ -1,0 +1,29 @@
+/**
+ * ButtonGroup — agrupa Buttons/IconButtons visualmente conectados.
+ * Props: orientation (horizontal | vertical), attached (default true).
+ * Filhos se encaixam: primeiro ganha radius-esquerdo, último ganha
+ * radius-direito, bordas internas colapsam.
+ */
+
+interface ButtonGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical";
+  attached?: boolean;
+}
+
+function ButtonGroup({
+  orientation = "horizontal",
+  attached = true,
+  className = "",
+  children,
+  ...rest
+}: ButtonGroupProps) {
+  const cls = [
+    "grd-btngroup",
+    `grd-btngroup-${orientation}`,
+    attached ? "grd-btngroup-attached" : "grd-btngroup-spaced",
+    className,
+  ].filter(Boolean).join(" ");
+  return <div role="group" className={cls} {...rest}>{children}</div>;
+}
+ButtonGroup.displayName = "ButtonGroup";
+(window as any).ButtonGroup = ButtonGroup;

--- a/ux_references/ui_kits/components/Calendar/Calendar.playground.html
+++ b/ux_references/ui_kits/components/Calendar/Calendar.playground.html
@@ -1,0 +1,344 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Calendar · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=4">
+<link rel="stylesheet" href="../Badge/index.css">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../Avatar/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">DATA · AGENDA</div>
+  <h1 class="pg-title">Calendar</h1>
+  <span class="pg-codename">import Calendar from "ui_kits/components/Calendar"</span>
+  <p class="pg-desc">Calendário grande para visualização de eventos em painéis — fechamento mensal, prazos fiscais, agenda da equipe. Três visões (<code>month</code>, <code>week</code>, <code>agenda</code>), eventos tipados por tom, suporte a multi-dia e all-day, legenda e truncamento automático de dias lotados com "+N mais".</p>
+  <p class="pg-desc" style="color: var(--gray-500); font-size: 12px;">Para seleção de datas em um campo de formulário, use <code>DatePicker</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Avatar/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=3"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="pg-sec">
+      <p className="pg-sec-title">{title}</p>
+      <div className="pg-stage" style={{padding:28,alignItems:"stretch",flexDirection:"column",gap:24}}>
+        {children}
+      </div>
+    </div>
+  );
+}
+function Frame({ children, label, maxWidth }: { children: React.ReactNode; label?: string; maxWidth?: number }) {
+  return (
+    <div>
+      {label && <div style={{ fontSize: 11.5, color: "var(--fg-muted)", marginBottom: 10, fontWeight: 600, letterSpacing: ".04em", textTransform: "uppercase" }}>{label}</div>}
+      <div style={{ maxWidth }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/*  Dados — calendário fiscal da equipe contábil (Nov/2025)          */
+/* ---------------------------------------------------------------- */
+
+/* Usamos um mês "estável" para o snapshot, não new Date() */
+const REF = new Date(2025, 10, 1); /* Novembro 2025 */
+
+const FISCAL_EVENTS = [
+  { id: "e1",  date: "2025-11-07", time: "23:59", title: "DCTFWeb Outubro",   tone: "red",    icon: "alert" },
+  { id: "e2",  date: "2025-11-07", time: "23:59", title: "FGTS",              tone: "red",    icon: "alert" },
+  { id: "e3",  date: "2025-11-10", time: "09:00", title: "Revisão Porto Brasil",  tone: "violet", icon: "users" },
+  { id: "e4",  date: "2025-11-14", time: "23:59", title: "SPED Contribuições",tone: "orange", icon: "file-text" },
+  { id: "e5",  date: "2025-11-14", time: "14:00", title: "Call Tech Ltda",    tone: "blue",   icon: "users" },
+  { id: "e6",  date: "2025-11-17", time: "11:30", title: "Onboarding Volt Café", tone: "green",  icon: "check" },
+  { id: "e7",  date: "2025-11-20", time: "23:59", title: "DARF IRRF",         tone: "red",    icon: "alert" },
+  { id: "e8",  date: "2025-11-20", time: "23:59", title: "DARF CSRF",         tone: "red",    icon: "alert" },
+  { id: "e9",  date: "2025-11-20", time: "23:59", title: "DAS Simples",       tone: "orange", icon: "file-text" },
+  { id: "e10", date: "2025-11-25", time: "23:59", title: "PIS/COFINS",        tone: "orange", icon: "file-text" },
+  { id: "e11", date: "2025-11-25", time: "15:00", title: "Fechamento Pietra Moda", tone: "violet", icon: "users" },
+  { id: "e12", date: "2025-11-28", time: "23:59", title: "IRPJ/CSLL",         tone: "red",    icon: "alert" },
+  { id: "e13", date: "2025-11-11", allDay: true,  title: "Treinamento equipe",   tone: "blue" },
+  { id: "e14", date: "2025-11-21", allDay: true,  title: "Offsite — São Paulo", tone: "violet" },
+  /* Dia lotado (dia 14) — para demo de "+N mais" */
+  { id: "e15", date: "2025-11-14", time: "10:30", title: "Conferência folha",tone: "yellow" },
+  { id: "e16", date: "2025-11-14", time: "16:00", title: "Review Rafa Costa", tone: "neutral" },
+  /* Evento multi-dia */
+  { id: "e17", date: "2025-11-03", endDate: "2025-11-05", allDay: true, title: "Fechamento mensal", tone: "green" },
+];
+
+const FISCAL_LEGEND = [
+  { label: "Prazo crítico",   tone: "red" },
+  { label: "Obrigação fiscal", tone: "orange" },
+  { label: "Reunião cliente",  tone: "violet" },
+  { label: "Interno",          tone: "blue" },
+  { label: "Marco",            tone: "green" },
+];
+
+/* ---------------------------------------------------------------- */
+/*  Demos                                                            */
+/* ---------------------------------------------------------------- */
+
+function MonthDemo() {
+  const [date, setDate] = React.useState(REF);
+  const [sel, setSel]   = React.useState(null);
+  const [clicked, setClicked] = React.useState(null);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ height: 680, display: "flex" }}>
+        <Calendar
+          view="month"
+          date={date}
+          onDateChange={setDate}
+          events={FISCAL_EVENTS}
+          selectedDate={sel}
+          onDayClick={(d) => setSel(d)}
+          onEventClick={(ev) => setClicked(ev)}
+          legend={FISCAL_LEGEND}
+        />
+      </div>
+      <div style={{ display: "flex", gap: 16, fontSize: 12.5, color: "var(--fg-muted)", flexWrap: "wrap" }}>
+        <span><strong style={{ color: "var(--fg)" }}>Dia selecionado:</strong> {sel ? sel.toLocaleDateString("pt-BR") : "—"}</span>
+        <span><strong style={{ color: "var(--fg)" }}>Último evento clicado:</strong> {clicked ? String(clicked.title) : "—"}</span>
+      </div>
+    </div>
+  );
+}
+
+function WeekDemo() {
+  const [date, setDate] = React.useState(new Date(2025, 10, 12));
+  return (
+    <div style={{ height: 520, display: "flex" }}>
+      <Calendar
+        view="week"
+        date={date}
+        onDateChange={setDate}
+        events={FISCAL_EVENTS}
+        legend={FISCAL_LEGEND}
+      />
+    </div>
+  );
+}
+
+function AgendaDemo() {
+  const [date, setDate] = React.useState(REF);
+  return (
+    <div style={{ height: 580, display: "flex" }}>
+      <Calendar
+        view="agenda"
+        date={date}
+        onDateChange={setDate}
+        events={FISCAL_EVENTS}
+        title="Agenda de Novembro"
+      />
+    </div>
+  );
+}
+
+function WithWeekNumbersDemo() {
+  const [date, setDate] = React.useState(REF);
+  return (
+    <div style={{ height: 620, display: "flex" }}>
+      <Calendar
+        view="month"
+        date={date}
+        onDateChange={setDate}
+        events={FISCAL_EVENTS.slice(0, 6)}
+        weekStartsOn={1}
+        showWeekNumbers
+      />
+    </div>
+  );
+}
+
+function CompactDemo() {
+  /* Mês sem eventos — visão "limpa" de planejamento */
+  const [date, setDate] = React.useState(REF);
+  const [sel, setSel]   = React.useState(new Date(2025, 10, 17));
+  return (
+    <div style={{ height: 520, display: "flex" }}>
+      <Calendar
+        view="month"
+        date={date}
+        onDateChange={setDate}
+        events={[]}
+        selectedDate={sel}
+        onDayClick={setSel}
+        maxEventsPerDay={0}
+      />
+    </div>
+  );
+}
+
+function PersonalDemo() {
+  /* Agenda de uma pessoa — semana atual com muitas reuniões */
+  const mondayThis = React.useMemo(() => {
+    const d = new Date(2025, 10, 10); /* Seg 10/Nov */
+    return d;
+  }, []);
+  const events = [
+    { id: "p1", date: "2025-11-10", time: "09:00", title: "Daily", tone: "neutral" },
+    { id: "p2", date: "2025-11-10", time: "10:30", title: "1:1 Marina", tone: "violet" },
+    { id: "p3", date: "2025-11-10", time: "14:00", title: "Revisão Porto Brasil", tone: "blue" },
+    { id: "p4", date: "2025-11-11", allDay: true,  title: "Treinamento", tone: "green" },
+    { id: "p5", date: "2025-11-12", time: "09:00", title: "Daily", tone: "neutral" },
+    { id: "p6", date: "2025-11-12", time: "11:00", title: "Planning sprint 42", tone: "violet" },
+    { id: "p7", date: "2025-11-12", time: "15:00", title: "Call Volt Café", tone: "blue" },
+    { id: "p8", date: "2025-11-13", time: "09:00", title: "Daily", tone: "neutral" },
+    { id: "p9", date: "2025-11-13", time: "14:00", title: "DCTFWeb — revisão", tone: "orange" },
+    { id: "p10",date: "2025-11-14", time: "09:00", title: "Daily", tone: "neutral" },
+    { id: "p11",date: "2025-11-14", time: "16:00", title: "Retro sprint", tone: "violet" },
+  ];
+  return (
+    <div style={{ height: 560, display: "flex" }}>
+      <Calendar
+        view="week"
+        date={mondayThis}
+        events={events}
+        weekStartsOn={1}
+      />
+    </div>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/*  App                                                              */
+/* ---------------------------------------------------------------- */
+
+function App() {
+  return (
+    <>
+      <Sec title="Calendário fiscal — visão mensal">
+        <Frame label="Novembro / 2025 · prazos, obrigações e reuniões">
+          <MonthDemo />
+        </Frame>
+      </Sec>
+
+      <Sec title="Visão de semana">
+        <Frame label="Dias 9–15 Nov 2025 · eventos em coluna">
+          <WeekDemo />
+        </Frame>
+      </Sec>
+
+      <Sec title="Visão de agenda">
+        <Frame label="Lista cronológica — ideal para relatório">
+          <AgendaDemo />
+        </Frame>
+      </Sec>
+
+      <Sec title="Semana começando na segunda, com números ISO">
+        <Frame label="weekStartsOn={1} · showWeekNumbers">
+          <WithWeekNumbersDemo />
+        </Frame>
+      </Sec>
+
+      <Sec title="Agenda pessoal — uma semana corrida">
+        <Frame label="Reuniões de um contador em uma semana de fechamento">
+          <PersonalDemo />
+        </Frame>
+      </Sec>
+
+      <Sec title="Sem eventos — apenas seleção de data em painel">
+        <Frame label="maxEventsPerDay={0} · uso como navegador puro" maxWidth={520}>
+          <CompactDemo />
+        </Frame>
+      </Sec>
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Calendar"]) || "render(<div>Sem exemplo para Calendar</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<!-- API ------------------------------------------------------- -->
+<h2 class="pg-h2">API</h2>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Padrão</th><th></th></tr>
+  <tr><td><code>view</code></td><td>"month" · "week" · "agenda"</td><td>"month"</td><td class="desc">Qual visão renderizar</td></tr>
+  <tr><td><code>date</code> · <code>defaultDate</code></td><td>Date</td><td>hoje</td><td class="desc">Mês/semana em exibição</td></tr>
+  <tr><td><code>onDateChange</code></td><td>(d) => void</td><td>—</td><td class="desc">Disparado ao navegar (prev/next/today)</td></tr>
+  <tr><td><code>events</code></td><td>CalendarEvent[]</td><td>[]</td><td class="desc">Lista de eventos; multi-dia via <code>endDate</code></td></tr>
+  <tr><td><code>onEventClick</code></td><td>(ev) => void</td><td>—</td><td class="desc">Clique em uma pílula de evento</td></tr>
+  <tr><td><code>onDayClick</code></td><td>(date) => void</td><td>—</td><td class="desc">Clique em uma célula de dia</td></tr>
+  <tr><td><code>selectedDate</code></td><td>Date | null</td><td>—</td><td class="desc">Destaca a célula como selecionada</td></tr>
+  <tr><td><code>maxEventsPerDay</code></td><td>number</td><td>3</td><td class="desc">Acima disso, condensa com "+N mais"</td></tr>
+  <tr><td><code>weekStartsOn</code></td><td>0 (dom) · 1 (seg)</td><td>0</td><td class="desc">Domingo ou segunda como primeira coluna</td></tr>
+  <tr><td><code>showWeekNumbers</code></td><td>bool</td><td>false</td><td class="desc">Coluna extra com número ISO da semana</td></tr>
+  <tr><td><code>toolbar</code></td><td>bool</td><td>true</td><td class="desc">Header com "Hoje", navegação e título</td></tr>
+  <tr><td><code>title</code></td><td>string</td><td>—</td><td class="desc">Substitui "Mês Ano" no toolbar</td></tr>
+  <tr><td><code>legend</code></td><td>{`{ label, tone }[]`}</td><td>—</td><td class="desc">Legenda de tons abaixo do grid</td></tr>
+</table>
+
+<h3 class="pg-h3">CalendarEvent</h3>
+
+<table class="pg-api">
+  <tr><th>Campo</th><th>Tipo</th><th></th></tr>
+  <tr><td><code>id</code></td><td>string</td><td class="desc">Chave única</td></tr>
+  <tr><td><code>date</code></td><td>Date · "YYYY-MM-DD"</td><td class="desc">Data de início</td></tr>
+  <tr><td><code>endDate</code></td><td>Date · "YYYY-MM-DD"</td><td class="desc">Data final (eventos multi-dia)</td></tr>
+  <tr><td><code>title</code></td><td>ReactNode</td><td class="desc">Texto do evento</td></tr>
+  <tr><td><code>tone</code></td><td>violet · orange · blue · green · red · yellow · neutral</td><td class="desc">Cor semântica da pílula</td></tr>
+  <tr><td><code>time</code></td><td>string</td><td class="desc">Hora do evento, ex. "14:00"</td></tr>
+  <tr><td><code>allDay</code></td><td>bool</td><td class="desc">Pílula sem horário, fundo preenchido</td></tr>
+  <tr><td><code>icon</code></td><td>string</td><td class="desc">Nome do ícone no Icon set</td></tr>
+</table>
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Painéis de acompanhamento com eventos datados — prazos fiscais, fechamentos, reuniões com clientes.</li>
+      <li>Relatórios mensais com densidade média (até ~40 eventos/mês).</li>
+      <li>Quando <code>week</code> ou <code>agenda</code> fornecerem contexto complementar ao mesmo conjunto de dados.</li>
+      <li>Legenda por tom quando há 3+ tipos de evento coexistindo.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Campo de formulário para escolher uma data — use <code>DatePicker</code>.</li>
+      <li>Calendários com &gt; 100 eventos por mês — considere uma lista filtrável ou DataTable.</li>
+      <li>Agendamento por blocos de tempo (horários cheios) — este calendário é para marcadores, não para escala de horário.</li>
+      <li>Cards de tarefas com muitos campos — mova para <code>Kanban</code> ou <code>Drawer</code>.</li>
+    </ul>
+  </div>
+</div>
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Calendar/index.css
+++ b/ux_references/ui_kits/components/Calendar/index.css
@@ -1,0 +1,542 @@
+/* ============================================================
+   Calendar — visualização grande (mês, semana, agenda)
+   Prefixo: .grd-cal
+   ============================================================ */
+
+.grd-cal {
+  font-family: var(--font-sans);
+  color: var(--fg);
+  background: var(--surface);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Toolbar ─────────────────────────────────────────────── */
+
+.grd-cal-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--gray-200);
+  background: var(--surface);
+}
+.grd-cal-toolbar-l {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.grd-cal-toolbar-r {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.grd-cal-today-btn {
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 6px 12px;
+  height: 32px;
+  cursor: pointer;
+  transition: background 120ms, border-color 120ms;
+}
+.grd-cal-today-btn:hover { background: var(--gray-50); border-color: var(--gray-400); }
+.grd-cal-today-btn:focus-visible { outline: none; box-shadow: var(--focus-ring); border-color: var(--violet-500); }
+
+.grd-cal-nav {
+  display: inline-flex;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  height: 32px;
+}
+.grd-cal-nav-btn {
+  width: 32px;
+  height: 100%;
+  background: var(--surface);
+  border: 0;
+  color: var(--fg);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 120ms;
+}
+.grd-cal-nav-btn + .grd-cal-nav-btn { border-left: 1px solid var(--border-strong); }
+.grd-cal-nav-btn:hover { background: var(--gray-50); }
+.grd-cal-nav-btn:focus-visible { outline: none; background: var(--violet-50); color: var(--violet-700); }
+
+.grd-cal-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--fg);
+  margin: 0;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── View switcher (visual; view é controlado externamente) ── */
+
+.grd-cal-views {
+  display: inline-flex;
+  background: var(--gray-100);
+  border-radius: var(--radius-md);
+  padding: 3px;
+  gap: 2px;
+}
+.grd-cal-view {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  padding: 5px 12px;
+  border-radius: calc(var(--radius-md) - 3px);
+  user-select: none;
+  transition: background 120ms, color 120ms;
+}
+.grd-cal-view-active {
+  background: var(--surface);
+  color: var(--fg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+/* ── Month grid ──────────────────────────────────────────── */
+
+.grd-cal-month {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.grd-cal-month-head {
+  display: grid;
+  background: var(--gray-200);
+  gap: 1px;
+  border-bottom: 1px solid var(--gray-200);
+}
+.grd-cal-month-body {
+  display: grid;
+  grid-auto-rows: minmax(112px, 1fr);
+  background: var(--gray-200);
+  gap: 1px;
+  flex: 1;
+  min-height: 0;
+}
+
+.grd-cal-wday {
+  padding: 10px 12px 8px;
+  background: var(--surface);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--fg-muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.grd-cal-wn-hdr { background: var(--gray-50); }
+
+.grd-cal-wn {
+  background: var(--gray-50);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--gray-500);
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+}
+
+.grd-cal-day {
+  background: var(--surface);
+  padding: 6px 8px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  min-height: 0;
+  cursor: default;
+  transition: background 120ms;
+  position: relative;
+}
+.grd-cal-day[role="button"] { cursor: pointer; }
+.grd-cal-day[role="button"]:hover { background: var(--gray-50); }
+.grd-cal-day[role="button"]:focus-visible { outline: none; background: var(--violet-50); }
+
+.grd-cal-day-out { background: var(--gray-50); }
+.grd-cal-day-out .grd-cal-day-num { color: var(--gray-400); }
+.grd-cal-day-we .grd-cal-day-num { color: var(--gray-500); }
+
+.grd-cal-day-sel {
+  background: var(--violet-50);
+  box-shadow: inset 0 0 0 2px var(--violet-500);
+}
+
+.grd-cal-day-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 22px;
+}
+.grd-cal-day-num {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.grd-cal-day-today-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--violet-500);
+  color: var(--surface);
+  font-weight: 700;
+  font-size: 12.5px;
+}
+
+.grd-cal-day-events {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+
+/* ── Event pill (inside cells) ───────────────────────────── */
+
+.grd-cal-ev {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--fg);
+  background: var(--gray-100);
+  border: 0;
+  border-left: 3px solid var(--gray-400);
+  border-radius: 3px;
+  padding: 3px 6px 3px 5px;
+  text-align: left;
+  cursor: pointer;
+  min-width: 0;
+  width: 100%;
+  transition: background 120ms;
+}
+.grd-cal-ev:hover { filter: brightness(0.97); }
+.grd-cal-ev:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+.grd-cal-ev-ic { display: inline-flex; flex: none; opacity: 0.9; }
+.grd-cal-ev-time {
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+  flex: none;
+}
+.grd-cal-ev-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.grd-cal-ev-allday {
+  border-left-width: 0;
+  padding-left: 8px;
+}
+
+.grd-cal-ev-more {
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  background: transparent;
+  border: 0;
+  padding: 2px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: left;
+}
+.grd-cal-ev-more:hover { background: var(--gray-100); color: var(--fg); }
+
+/* ── Tones ───────────────────────────────────────────────── */
+
+.grd-cal-tone-violet  { background: var(--violet-50);  border-left-color: var(--violet-500);  color: var(--violet-700); }
+.grd-cal-tone-blue    { background: var(--blue-50);    border-left-color: var(--blue-500);    color: var(--blue-700); }
+.grd-cal-tone-green   { background: #E8F5EE;            border-left-color: var(--signal-green); color: #15803d; }
+.grd-cal-tone-red     { background: #FEECEC;            border-left-color: var(--signal-red);   color: #b91c1c; }
+.grd-cal-tone-orange  { background: #FFF2E6;            border-left-color: var(--orange-500);   color: var(--orange-700); }
+.grd-cal-tone-yellow  { background: #FEF7D6;            border-left-color: var(--signal-yellow); color: #854d0e; }
+.grd-cal-tone-neutral { background: var(--gray-100);    border-left-color: var(--gray-500);     color: var(--fg); }
+
+/* allDay pill: remove border-left, coloriza fundo completo */
+.grd-cal-ev-allday.grd-cal-tone-violet  { background: var(--violet-500);   color: #fff; }
+.grd-cal-ev-allday.grd-cal-tone-blue    { background: var(--blue-500);     color: #fff; }
+.grd-cal-ev-allday.grd-cal-tone-green   { background: var(--signal-green); color: #fff; }
+.grd-cal-ev-allday.grd-cal-tone-red     { background: var(--signal-red);   color: #fff; }
+.grd-cal-ev-allday.grd-cal-tone-orange  { background: var(--orange-500);   color: #fff; }
+.grd-cal-ev-allday.grd-cal-tone-yellow  { background: var(--signal-yellow); color: #1f2937; }
+.grd-cal-ev-allday.grd-cal-tone-neutral { background: var(--gray-600);     color: #fff; }
+.grd-cal-ev-allday .grd-cal-ev-time { color: inherit; opacity: 0.9; }
+
+/* ── Today highlight ─────────────────────────────────────── */
+
+.grd-cal-day-today { background: #FDFDFF; }
+.grd-cal-day-today.grd-cal-day-sel { background: var(--violet-50); }
+
+/* ── Week strip ──────────────────────────────────────────── */
+
+.grd-cal-week {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.grd-cal-week-head {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  background: var(--gray-200);
+  gap: 1px;
+  border-bottom: 1px solid var(--gray-200);
+}
+.grd-cal-week-hc {
+  background: var(--surface);
+  padding: 14px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+.grd-cal-week-hc-we { background: var(--gray-50); }
+.grd-cal-week-hc-today { background: #FDFDFF; }
+.grd-cal-week-wd {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--fg-muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.grd-cal-week-dn {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--fg);
+  letter-spacing: -0.02em;
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.grd-cal-week-dn .grd-cal-day-today-pill {
+  width: 32px;
+  height: 32px;
+  font-size: 16px;
+}
+
+.grd-cal-week-body {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+  background: var(--gray-200);
+  flex: 1;
+  min-height: 280px;
+}
+.grd-cal-week-col {
+  background: var(--surface);
+  padding: 10px 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  cursor: default;
+  overflow: hidden;
+}
+.grd-cal-week-col-we { background: var(--gray-50); }
+.grd-cal-week-col-today { background: #FDFDFF; }
+.grd-cal-week-col-sel { box-shadow: inset 0 0 0 2px var(--violet-500); }
+
+.grd-cal-week-empty {
+  color: var(--gray-400);
+  font-size: 12px;
+  padding: 4px 0;
+}
+
+.grd-cal-ev-block {
+  width: 100%;
+  max-width: 100%;
+  padding: 6px 8px 6px 7px;
+  border-radius: 4px;
+  font-size: 12px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  line-height: 1.35;
+  gap: 4px 6px;
+  overflow: hidden;
+  min-width: 0;
+}
+.grd-cal-ev-block .grd-cal-ev-time { flex: none; }
+.grd-cal-ev-block .grd-cal-ev-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* ── Agenda view ─────────────────────────────────────────── */
+
+.grd-cal-agenda {
+  padding: 6px 0;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}
+.grd-cal-agenda-empty {
+  padding: 40px 24px;
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: 14px;
+}
+.grd-cal-agenda-day {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 16px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--gray-100);
+}
+.grd-cal-agenda-day:last-child { border-bottom: 0; }
+
+.grd-cal-agenda-date {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding-top: 2px;
+}
+.grd-cal-agenda-dn {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--fg);
+  letter-spacing: -0.02em;
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.grd-cal-agenda-wd {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--fg-muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.grd-cal-agenda-date-today .grd-cal-agenda-dn { color: var(--violet-600); }
+.grd-cal-agenda-date-today .grd-cal-agenda-wd { color: var(--violet-600); }
+
+.grd-cal-agenda-evs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.grd-cal-agenda-ev {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg);
+  background: var(--surface);
+  border: 1px solid var(--gray-200);
+  border-left: 3px solid var(--gray-400);
+  border-radius: var(--radius-md);
+  padding: 10px 14px;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background 120ms, border-color 120ms;
+}
+.grd-cal-agenda-ev:hover { background: var(--gray-50); }
+
+.grd-cal-agenda-ev .grd-cal-ev-ic {
+  flex: none;
+  color: var(--fg-muted);
+}
+.grd-cal-agenda-ev .grd-cal-ev-time {
+  flex: none;
+  color: var(--fg-muted);
+  font-weight: 600;
+  font-size: 12.5px;
+  min-width: 72px;
+}
+.grd-cal-agenda-ev .grd-cal-ev-title {
+  font-weight: 600;
+  color: var(--fg);
+  white-space: normal;
+  overflow: visible;
+  flex: 1;
+  min-width: 0;
+}
+
+.grd-cal-agenda-ev.grd-cal-tone-violet  { border-left-color: var(--violet-500); }
+.grd-cal-agenda-ev.grd-cal-tone-blue    { border-left-color: var(--blue-500); }
+.grd-cal-agenda-ev.grd-cal-tone-green   { border-left-color: var(--signal-green); }
+.grd-cal-agenda-ev.grd-cal-tone-red     { border-left-color: var(--signal-red); }
+.grd-cal-agenda-ev.grd-cal-tone-orange  { border-left-color: var(--orange-500); }
+.grd-cal-agenda-ev.grd-cal-tone-yellow  { border-left-color: var(--signal-yellow); }
+.grd-cal-agenda-ev.grd-cal-tone-neutral { border-left-color: var(--gray-500); }
+
+/* ── Legend ──────────────────────────────────────────────── */
+
+.grd-cal-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 20px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--gray-200);
+  background: var(--gray-50);
+}
+.grd-cal-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--fg);
+}
+.grd-cal-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  display: inline-block;
+}
+.grd-cal-legend-dot.grd-cal-tone-violet  { background: var(--violet-500); }
+.grd-cal-legend-dot.grd-cal-tone-blue    { background: var(--blue-500); }
+.grd-cal-legend-dot.grd-cal-tone-green   { background: var(--signal-green); }
+.grd-cal-legend-dot.grd-cal-tone-red     { background: var(--signal-red); }
+.grd-cal-legend-dot.grd-cal-tone-orange  { background: var(--orange-500); }
+.grd-cal-legend-dot.grd-cal-tone-yellow  { background: var(--signal-yellow); }
+.grd-cal-legend-dot.grd-cal-tone-neutral { background: var(--gray-500); }
+
+/* ── Agenda variant (view=agenda) sem borda interna ─────── */
+
+.grd-cal-agenda { border-top: 0; }

--- a/ux_references/ui_kits/components/Calendar/index.tsx
+++ b/ux_references/ui_kits/components/Calendar/index.tsx
@@ -1,0 +1,486 @@
+
+/**
+ * Calendar — calendário grande para visualização de eventos.
+ *
+ * Diferente do DatePicker (compacto, seletor de input), o Calendar é para
+ * painéis: fechamento mensal, prazos fiscais, agenda da equipe.
+ *
+ * Props:
+ *   view:          "month" (default) · "week" · "agenda"
+ *   date:          Date — mês/semana em exibição (controlado)
+ *   defaultDate
+ *   onDateChange:  (d: Date) => void
+ *   events:        CalendarEvent[]
+ *   onEventClick:  (ev) => void
+ *   onDayClick:    (date) => void
+ *   selectedDate:  Date | null — célula destacada
+ *   maxEventsPerDay: número antes de virar "+N mais"
+ *   weekStartsOn:  0 (domingo, default) | 1 (segunda)
+ *   showWeekNumbers: bool
+ *   toolbar:       bool (default true) — header com navegação
+ *   title:         string opcional — substitui mês/ano no toolbar
+ *   legend:        array { label, tone } para legenda embaixo
+ */
+
+interface CalendarEvent {
+  id: string;
+  date: Date | string;       /* "YYYY-MM-DD" ou Date */
+  endDate?: Date | string;   /* para eventos multi-dia */
+  title: React.ReactNode;
+  tone?: "violet" | "orange" | "blue" | "green" | "red" | "yellow" | "neutral";
+  icon?: string;
+  time?: string;             /* "14:00" */
+  allDay?: boolean;
+  meta?: any;                /* livre */
+}
+
+interface CalendarProps {
+  view?: "month" | "week" | "agenda";
+  date?: Date;
+  defaultDate?: Date;
+  onDateChange?: (d: Date) => void;
+  events?: CalendarEvent[];
+  onEventClick?: (ev: CalendarEvent) => void;
+  onDayClick?: (date: Date) => void;
+  selectedDate?: Date | null;
+  maxEventsPerDay?: number;
+  weekStartsOn?: 0 | 1;
+  showWeekNumbers?: boolean;
+  toolbar?: boolean;
+  title?: string;
+  legend?: Array<{ label: string; tone: CalendarEvent["tone"] }>;
+  className?: string;
+}
+
+const CAL_MONTHS = ["Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro"];
+const CAL_WDAYS_SHORT = ["Dom","Seg","Ter","Qua","Qui","Sex","Sáb"];
+
+function toDate(v: Date | string): Date {
+  if (v instanceof Date) return v;
+  const [y, m, d] = v.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+function sameDayCal(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+function startOfWeek(d: Date, weekStart: 0 | 1): Date {
+  const day = d.getDay();
+  const diff = (day - weekStart + 7) % 7;
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() - diff);
+}
+function getISOWeek(d: Date): number {
+  const tmp = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  const dayNum = tmp.getUTCDay() || 7;
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
+  return Math.ceil(((+tmp - +yearStart) / 86400000 + 1) / 7);
+}
+
+function Calendar({
+  view = "month",
+  date,
+  defaultDate,
+  onDateChange,
+  events = [],
+  onEventClick,
+  onDayClick,
+  selectedDate,
+  maxEventsPerDay = 3,
+  weekStartsOn = 0,
+  showWeekNumbers = false,
+  toolbar = true,
+  title,
+  legend,
+  className = "",
+}: CalendarProps) {
+  const IconCmp = (window as any).Icon;
+  const [internal, setInternal] = React.useState<Date>(defaultDate ?? new Date());
+  const current = date !== undefined ? date : internal;
+
+  function setDate(d: Date) {
+    if (date === undefined) setInternal(d);
+    onDateChange?.(d);
+  }
+  function goPrev() {
+    if (view === "month") setDate(new Date(current.getFullYear(), current.getMonth() - 1, 1));
+    else if (view === "week") setDate(new Date(current.getFullYear(), current.getMonth(), current.getDate() - 7));
+    else setDate(new Date(current.getFullYear(), current.getMonth() - 1, 1));
+  }
+  function goNext() {
+    if (view === "month") setDate(new Date(current.getFullYear(), current.getMonth() + 1, 1));
+    else if (view === "week") setDate(new Date(current.getFullYear(), current.getMonth(), current.getDate() + 7));
+    else setDate(new Date(current.getFullYear(), current.getMonth() + 1, 1));
+  }
+  function goToday() {
+    setDate(new Date());
+  }
+
+  const wdaysOrdered = weekStartsOn === 1
+    ? [...CAL_WDAYS_SHORT.slice(1), CAL_WDAYS_SHORT[0]]
+    : CAL_WDAYS_SHORT;
+
+  /* Indexar eventos por "YYYY-M-D" */
+  const eventsByDay = React.useMemo(() => {
+    const map: Record<string, CalendarEvent[]> = {};
+    for (const ev of events) {
+      const start = toDate(ev.date);
+      const end = ev.endDate ? toDate(ev.endDate) : start;
+      const cursor = new Date(start);
+      while (cursor <= end) {
+        const key = `${cursor.getFullYear()}-${cursor.getMonth()}-${cursor.getDate()}`;
+        (map[key] ||= []).push(ev);
+        cursor.setDate(cursor.getDate() + 1);
+      }
+    }
+    /* Ordena: allDay primeiro, depois por time */
+    for (const k in map) {
+      map[k].sort((a, b) => {
+        if (!!a.allDay !== !!b.allDay) return a.allDay ? -1 : 1;
+        return (a.time || "").localeCompare(b.time || "");
+      });
+    }
+    return map;
+  }, [events]);
+
+  const today = new Date();
+  const titleText =
+    title ??
+    (view === "week"
+      ? weekTitle(current, weekStartsOn)
+      : `${CAL_MONTHS[current.getMonth()]} ${current.getFullYear()}`);
+
+  const rootCls = ["grd-cal", `grd-cal-${view}`, className].filter(Boolean).join(" ");
+
+  return (
+    <div className={rootCls}>
+      {toolbar && (
+        <div className="grd-cal-toolbar">
+          <div className="grd-cal-toolbar-l">
+            <button type="button" className="grd-cal-today-btn" onClick={goToday}>Hoje</button>
+            <div className="grd-cal-nav">
+              <button type="button" className="grd-cal-nav-btn" onClick={goPrev} aria-label="Anterior">
+                {IconCmp && <IconCmp name="chevron-left" size={16} />}
+              </button>
+              <button type="button" className="grd-cal-nav-btn" onClick={goNext} aria-label="Próximo">
+                {IconCmp && <IconCmp name="chevron-right" size={16} />}
+              </button>
+            </div>
+            <h2 className="grd-cal-title">{titleText}</h2>
+          </div>
+          <div className="grd-cal-toolbar-r">
+            <ViewSwitcher value={view} />
+          </div>
+        </div>
+      )}
+
+      {view === "month" && (
+        <MonthGrid
+          viewDate={current}
+          today={today}
+          eventsByDay={eventsByDay}
+          weekStartsOn={weekStartsOn}
+          wdaysOrdered={wdaysOrdered}
+          showWeekNumbers={showWeekNumbers}
+          maxEventsPerDay={maxEventsPerDay}
+          onDayClick={onDayClick}
+          onEventClick={onEventClick}
+          selectedDate={selectedDate}
+        />
+      )}
+
+      {view === "week" && (
+        <WeekStrip
+          viewDate={current}
+          today={today}
+          eventsByDay={eventsByDay}
+          weekStartsOn={weekStartsOn}
+          wdaysOrdered={wdaysOrdered}
+          onDayClick={onDayClick}
+          onEventClick={onEventClick}
+          selectedDate={selectedDate}
+        />
+      )}
+
+      {view === "agenda" && (
+        <Agenda
+          viewDate={current}
+          today={today}
+          events={events}
+          onEventClick={onEventClick}
+        />
+      )}
+
+      {legend && legend.length > 0 && (
+        <div className="grd-cal-legend">
+          {legend.map((l, i) => (
+            <span key={i} className="grd-cal-legend-item">
+              <span className={`grd-cal-legend-dot grd-cal-tone-${l.tone || "neutral"}`} aria-hidden />
+              {l.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── View switcher ─────────────────────────────────────── */
+
+function ViewSwitcher({ value }: { value: string }) {
+  /* Placeholder visual (não-interativo) — view é controlado externamente */
+  return (
+    <div className="grd-cal-views" role="tablist" aria-label="Visualização">
+      {[
+        { id: "month",  label: "Mês" },
+        { id: "week",   label: "Semana" },
+        { id: "agenda", label: "Agenda" },
+      ].map((v) => (
+        <span key={v.id} className={`grd-cal-view ${value === v.id ? "grd-cal-view-active" : ""}`}>
+          {v.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/* ─── Month grid ────────────────────────────────────────── */
+
+function MonthGrid({
+  viewDate, today, eventsByDay, weekStartsOn, wdaysOrdered,
+  showWeekNumbers, maxEventsPerDay, onDayClick, onEventClick, selectedDate,
+}: any) {
+  const IconCmp = (window as any).Icon;
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth();
+  const firstDay = new Date(year, month, 1);
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const offset = (firstDay.getDay() - weekStartsOn + 7) % 7;
+
+  const cells: Array<{ date: Date; inMonth: boolean }> = [];
+  for (let i = offset - 1; i >= 0; i--) {
+    cells.push({ date: new Date(year, month, -i), inMonth: false });
+  }
+  for (let i = 1; i <= daysInMonth; i++) {
+    cells.push({ date: new Date(year, month, i), inMonth: true });
+  }
+  while (cells.length % 7 !== 0) {
+    const last = cells[cells.length - 1].date;
+    cells.push({ date: new Date(last.getFullYear(), last.getMonth(), last.getDate() + 1), inMonth: false });
+  }
+  /* Garantir 6 linhas para altura estável */
+  while (cells.length < 42) {
+    const last = cells[cells.length - 1].date;
+    cells.push({ date: new Date(last.getFullYear(), last.getMonth(), last.getDate() + 1), inMonth: false });
+  }
+
+  const rows: Array<typeof cells> = [];
+  for (let i = 0; i < cells.length; i += 7) rows.push(cells.slice(i, i + 7));
+
+  const colTemplate = showWeekNumbers ? "42px repeat(7, minmax(0, 1fr))" : "repeat(7, minmax(0, 1fr))";
+
+  return (
+    <div className="grd-cal-month">
+      {/* Header */}
+      <div className="grd-cal-month-head" style={{ gridTemplateColumns: colTemplate }}>
+        {showWeekNumbers && <div className="grd-cal-wn-hdr" aria-hidden />}
+        {wdaysOrdered.map((w: string, i: number) => (
+          <div key={`h${i}`} className="grd-cal-wday">{w}</div>
+        ))}
+      </div>
+
+      {/* Body */}
+      <div className="grd-cal-month-body" style={{ gridTemplateColumns: colTemplate }}>
+        {rows.map((row, ri) => (
+          <React.Fragment key={`r${ri}`}>
+            {showWeekNumbers && (
+              <div className="grd-cal-wn">{getISOWeek(row[0].date)}</div>
+            )}
+            {row.map((c, ci) => {
+            const key = `${c.date.getFullYear()}-${c.date.getMonth()}-${c.date.getDate()}`;
+            const dayEvents = eventsByDay[key] || [];
+            const isToday = sameDayCal(c.date, today);
+            const isSel   = selectedDate && sameDayCal(c.date, selectedDate);
+            const isWeekend = c.date.getDay() === 0 || c.date.getDay() === 6;
+            const visible = dayEvents.slice(0, maxEventsPerDay);
+            const hidden  = dayEvents.length - visible.length;
+
+            const cellCls = [
+              "grd-cal-day",
+              !c.inMonth && "grd-cal-day-out",
+              isWeekend && "grd-cal-day-we",
+              isToday && "grd-cal-day-today",
+              isSel && "grd-cal-day-sel",
+              dayEvents.length > 0 && "grd-cal-day-has",
+            ].filter(Boolean).join(" ");
+
+            return (
+              <div key={`c${ri}${ci}`}
+                   className={cellCls}
+                   onClick={() => onDayClick?.(c.date)}
+                   role={onDayClick ? "button" : undefined}
+                   tabIndex={onDayClick ? 0 : undefined}
+              >
+                <div className="grd-cal-day-head">
+                  <span className="grd-cal-day-num">
+                    {isToday
+                      ? <span className="grd-cal-day-today-pill">{c.date.getDate()}</span>
+                      : c.date.getDate()
+                    }
+                  </span>
+                </div>
+                <div className="grd-cal-day-events">
+                  {visible.map((ev: CalendarEvent, ei: number) => (
+                    <button
+                      key={ev.id + ei}
+                      type="button"
+                      className={`grd-cal-ev grd-cal-tone-${ev.tone || "neutral"} ${ev.allDay ? "grd-cal-ev-allday" : ""}`}
+                      onClick={(e) => { e.stopPropagation(); onEventClick?.(ev); }}
+                      title={typeof ev.title === "string" ? ev.title : undefined}
+                    >
+                      {ev.icon && IconCmp && <span className="grd-cal-ev-ic"><IconCmp name={ev.icon} size={11} /></span>}
+                      {ev.time && <span className="grd-cal-ev-time">{ev.time}</span>}
+                      <span className="grd-cal-ev-title">{ev.title}</span>
+                    </button>
+                  ))}
+                  {hidden > 0 && (
+                    <button type="button" className="grd-cal-ev-more"
+                            onClick={(e) => { e.stopPropagation(); onDayClick?.(c.date); }}>
+                      +{hidden} mais
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </React.Fragment>
+      ))}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Week strip ───────────────────────────────────────── */
+
+function WeekStrip({
+  viewDate, today, eventsByDay, weekStartsOn, wdaysOrdered, onDayClick, onEventClick, selectedDate,
+}: any) {
+  const IconCmp = (window as any).Icon;
+  const start = startOfWeek(viewDate, weekStartsOn);
+  const days: Date[] = [];
+  for (let i = 0; i < 7; i++) days.push(new Date(start.getFullYear(), start.getMonth(), start.getDate() + i));
+
+  return (
+    <div className="grd-cal-week">
+      <div className="grd-cal-week-head">
+        {days.map((d, i) => {
+          const isToday = sameDayCal(d, today);
+          const isWeekend = d.getDay() === 0 || d.getDay() === 6;
+          return (
+            <div key={i} className={["grd-cal-week-hc", isToday && "grd-cal-week-hc-today", isWeekend && "grd-cal-week-hc-we"].filter(Boolean).join(" ")}>
+              <span className="grd-cal-week-wd">{wdaysOrdered[i]}</span>
+              <span className="grd-cal-week-dn">
+                {isToday ? <span className="grd-cal-day-today-pill">{d.getDate()}</span> : d.getDate()}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="grd-cal-week-body">
+        {days.map((d, i) => {
+          const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+          const dayEvents = eventsByDay[key] || [];
+          const isToday = sameDayCal(d, today);
+          const isSel   = selectedDate && sameDayCal(d, selectedDate);
+          const isWeekend = d.getDay() === 0 || d.getDay() === 6;
+          return (
+            <div key={i}
+                 className={["grd-cal-week-col", isToday && "grd-cal-week-col-today", isSel && "grd-cal-week-col-sel", isWeekend && "grd-cal-week-col-we"].filter(Boolean).join(" ")}
+                 onClick={() => onDayClick?.(d)}>
+              {dayEvents.length === 0 && <div className="grd-cal-week-empty">—</div>}
+              {dayEvents.map((ev: CalendarEvent, ei: number) => (
+                <button
+                  key={ev.id + ei}
+                  type="button"
+                  className={`grd-cal-ev grd-cal-ev-block grd-cal-tone-${ev.tone || "neutral"}`}
+                  onClick={(e) => { e.stopPropagation(); onEventClick?.(ev); }}
+                >
+                  {ev.icon && IconCmp && <span className="grd-cal-ev-ic"><IconCmp name={ev.icon} size={12} /></span>}
+                  {ev.time && <span className="grd-cal-ev-time">{ev.time}</span>}
+                  <span className="grd-cal-ev-title">{ev.title}</span>
+                </button>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Agenda ───────────────────────────────────────────── */
+
+function Agenda({ viewDate, today, events, onEventClick }: any) {
+  const IconCmp = (window as any).Icon;
+  /* Agenda mostra o mês inteiro — só dias com eventos, ordenados */
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth();
+  const monthEvents = events
+    .map((ev: CalendarEvent) => ({ ev, d: toDate(ev.date) }))
+    .filter(({ d }: any) => d.getFullYear() === year && d.getMonth() === month)
+    .sort((a: any, b: any) => +a.d - +b.d || (a.ev.time || "").localeCompare(b.ev.time || ""));
+
+  /* Agrupa por dia */
+  const byDay: Record<string, { d: Date; events: CalendarEvent[] }> = {};
+  for (const { ev, d } of monthEvents) {
+    const k = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+    (byDay[k] ||= { d, events: [] }).events.push(ev);
+  }
+  const days = Object.values(byDay);
+
+  return (
+    <div className="grd-cal-agenda">
+      {days.length === 0 && (
+        <div className="grd-cal-agenda-empty">Nenhum evento neste mês.</div>
+      )}
+      {days.map(({ d, events: dayEvents }, i) => {
+        const isToday = sameDayCal(d, today);
+        return (
+          <div key={i} className="grd-cal-agenda-day">
+            <div className={`grd-cal-agenda-date ${isToday ? "grd-cal-agenda-date-today" : ""}`}>
+              <span className="grd-cal-agenda-dn">{d.getDate()}</span>
+              <span className="grd-cal-agenda-wd">{CAL_WDAYS_SHORT[d.getDay()]}</span>
+            </div>
+            <div className="grd-cal-agenda-evs">
+              {dayEvents.map((ev, ei) => (
+                <button
+                  key={ev.id + ei}
+                  type="button"
+                  className={`grd-cal-agenda-ev grd-cal-tone-${ev.tone || "neutral"}`}
+                  onClick={() => onEventClick?.(ev)}
+                >
+                  {ev.icon && IconCmp && <span className="grd-cal-ev-ic"><IconCmp name={ev.icon} size={13} /></span>}
+                  <span className="grd-cal-ev-time">{ev.allDay ? "Dia inteiro" : (ev.time || "")}</span>
+                  <span className="grd-cal-ev-title">{ev.title}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function weekTitle(d: Date, ws: 0 | 1): string {
+  const start = startOfWeek(d, ws);
+  const end = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 6);
+  const sameMonth = start.getMonth() === end.getMonth();
+  const fmt = (x: Date) => `${x.getDate()} ${CAL_MONTHS[x.getMonth()].slice(0,3).toLowerCase()}`;
+  if (sameMonth) {
+    return `${start.getDate()}–${end.getDate()} ${CAL_MONTHS[start.getMonth()]} ${start.getFullYear()}`;
+  }
+  return `${fmt(start)} – ${fmt(end)} ${start.getFullYear()}`;
+}
+
+Calendar.displayName = "Calendar";
+(window as any).Calendar = Calendar;

--- a/ux_references/ui_kits/components/Card/Card.playground.html
+++ b/ux_references/ui_kits/components/Card/Card.playground.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Card · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=11">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../Badge/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">CONTAINER · CARD</div>
+  <h1 class="pg-title">Card</h1>
+  <span class="pg-codename">import Card from "ui_kits/components/Card"</span>
+  <p class="pg-desc">Contêiner base com padding, borda e sombra. Composição via subcomponentes: <code>Card.Header</code>, <code>Card.Body</code>, <code>Card.Footer</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{alignItems:"stretch",flexWrap:"wrap",gap:16}}>{children}</div></div>);
+}
+
+function App() {
+  const Icon = (window as any).Icon;
+  return (<>
+    <Sec title="Variantes">
+      {(["plain","outlined","elevated","filled"] as const).map(v => (
+        <Card key={v} variant={v} padding="md" className="" >
+          <div style={{fontSize:11,letterSpacing:"0.12em",color:"var(--gray-500)",fontWeight:600,textTransform:"uppercase"}}>variant="{v}"</div>
+          <div style={{marginTop:6,fontSize:14,color:"var(--fg)",lineHeight:1.5}}>Container base para {v === "plain" ? "conteúdo leve sem borda." : v === "outlined" ? "conteúdo em lista." : v === "elevated" ? "blocos de destaque." : "estados informativos."}</div>
+        </Card>
+      ))}
+    </Sec>
+
+    <Sec title="Com Header + Body + Footer">
+      <div style={{width:"100%",maxWidth:560}}>
+        <Card variant="outlined" padding="none">
+          <Card.Header
+            icon={<Icon name="receipt-text" size={18} />}
+            title="Alfa Comércio LTDA"
+            description="CNPJ 42.110.877/0001-55 · Simples Nacional"
+            actions={<button className="grd-btn grd-btn-ghost grd-btn-sm">Editar</button>}
+          />
+          <Card.Body>
+            <div style={{display:"grid",gridTemplateColumns:"repeat(3, 1fr)",gap:20,fontSize:13}}>
+              <div><div style={{color:"var(--fg-muted)",fontSize:12}}>Lançamentos</div><div style={{fontWeight:600,fontSize:20,color:"var(--fg)",marginTop:4,fontVariantNumeric:"tabular-nums"}}>248</div></div>
+              <div><div style={{color:"var(--fg-muted)",fontSize:12}}>Pendências</div><div style={{fontWeight:600,fontSize:20,color:"var(--orange-500)",marginTop:4,fontVariantNumeric:"tabular-nums"}}>11</div></div>
+              <div><div style={{color:"var(--fg-muted)",fontSize:12}}>Conciliado</div><div style={{fontWeight:600,fontSize:20,color:"var(--signal-green)",marginTop:4,fontVariantNumeric:"tabular-nums"}}>96%</div></div>
+            </div>
+          </Card.Body>
+          <Card.Footer>
+            <span className="grd-badge grd-badge-soft grd-badge-success grd-badge-pill">
+              <span className="grd-badge-dot" />
+              Ativa
+            </span>
+            <button className="grd-btn grd-btn-primary grd-btn-sm">Abrir painel</button>
+          </Card.Footer>
+        </Card>
+      </div>
+    </Sec>
+
+    <Sec title="Paddings">
+      {(["none","sm","md","lg"] as const).map(p => (
+        <Card key={p} variant="outlined" padding={p}>
+          <div style={{fontSize:11,color:"var(--gray-500)",fontWeight:600,textTransform:"uppercase",letterSpacing:"0.1em"}}>padding="{p}"</div>
+        </Card>
+      ))}
+    </Sec>
+
+    <Sec title="Interativo (clicável)">
+      <Card variant="outlined" interactive onClick={() => alert("click")} padding="md">
+        <div style={{display:"flex",alignItems:"center",gap:10,fontWeight:600,color:"var(--fg)"}}>
+          <Icon name="plus" size={16} /> Adicionar nova empresa
+        </div>
+        <div style={{fontSize:13,color:"var(--fg-muted)",marginTop:4}}>Clique para iniciar o onboarding em 3 etapas.</div>
+      </Card>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Card"]) || "render(<div>Sem exemplo para Card</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"outlined"</td><td class="desc">plain · outlined · elevated · filled</td></tr>
+  <tr><td><code>padding</code></td><td>string</td><td>"md"</td><td class="desc">none · sm · md · lg</td></tr>
+  <tr><td><code>interactive</code></td><td>boolean</td><td>false</td><td class="desc">Adiciona hover + cursor pointer</td></tr>
+  <tr><td><code>onClick</code></td><td>() ⇒ void</td><td>—</td><td class="desc">Torna o Card um botão</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Container de uma unidade de informação — lançamento, cliente, relatório.</li>
+      <li>Borda sutil + padding 18-24px + sombra mínima.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Cards aninhados dentro de cards.</li>
+      <li>Sombras pesadas ou bordas coloridas como acento padrão.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Card/index.css
+++ b/ux_references/ui_kits/components/Card/index.css
@@ -1,0 +1,46 @@
+
+.grd-card {
+  font-family: var(--font-sans);
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  text-align: left;
+  display: flex; flex-direction: column;
+  color: var(--fg);
+  border: 1px solid transparent;
+}
+.grd-card-plain    { background: transparent; }
+.grd-card-outlined { border-color: var(--border); }
+.grd-card-filled   { background: var(--gray-50); }
+.grd-card-elevated { box-shadow: var(--shadow-md); }
+
+.grd-card-p-none { padding: 0; }
+.grd-card-p-sm   { padding: 12px; }
+.grd-card-p-md   { padding: 16px; }
+.grd-card-p-lg   { padding: 20px; }
+
+.grd-card-ia { cursor: pointer; transition: box-shadow 160ms var(--ease-standard), border-color 160ms, transform 160ms; }
+button.grd-card { font-family: inherit; width: 100%; }
+.grd-card-ia:hover { border-color: var(--violet-300); box-shadow: var(--shadow-lg); }
+.grd-card-ia:active { transform: translateY(1px); }
+
+.grd-card-head { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 10px; }
+.grd-card-head-ic {
+  flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px; border-radius: var(--radius-md);
+  background: var(--violet-100); color: var(--violet-500);
+}
+.grd-card-head-text { flex: 1; display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.grd-card-head-title { font-size: 15px; font-weight: 600; color: var(--fg); margin: 0; line-height: 1.35; }
+.grd-card-head-desc { font-size: 13px; color: var(--fg-muted); margin: 0; line-height: 1.5; }
+.grd-card-head-act { flex-shrink: 0; display: inline-flex; align-items: center; gap: 6px; }
+
+.grd-card-body { font-size: 13.5px; color: var(--fg); line-height: 1.55; }
+.grd-card-foot {
+  margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border);
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+}
+
+/* Quando Card tem padding="none", Header/Body/Footer trazem seu próprio padding */
+.grd-card-p-none > .grd-card-head { padding: 20px 24px 0; margin-bottom: 16px; }
+.grd-card-p-none > .grd-card-body { padding: 4px 24px 20px; }
+.grd-card-p-none > .grd-card-foot { padding: 14px 24px; margin-top: 0; }

--- a/ux_references/ui_kits/components/Card/index.tsx
+++ b/ux_references/ui_kits/components/Card/index.tsx
@@ -1,0 +1,57 @@
+
+/**
+ * Card — contêiner com padding, borda e sombra leve.
+ * Composição:
+ *   <Card>
+ *     <Card.Header title="…" description="…" actions={<…/>} />
+ *     <Card.Body>…</Card.Body>
+ *     <Card.Footer>…</Card.Footer>
+ *   </Card>
+ * Variant: plain | outlined (default) | elevated | filled
+ * Interactive: hover feedback + cursor
+ */
+
+interface CardProps {
+  variant?: "plain" | "outlined" | "elevated" | "filled";
+  padding?: "none" | "sm" | "md" | "lg";
+  interactive?: boolean;
+  onClick?: () => void;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+function Card({ variant = "outlined", padding = "md", interactive, onClick, className = "", children }: CardProps) {
+  const cls = [
+    "grd-card",
+    `grd-card-${variant}`,
+    `grd-card-p-${padding}`,
+    interactive && "grd-card-ia",
+    className,
+  ].filter(Boolean).join(" ");
+  const Tag = onClick ? "button" : "div";
+  return <Tag className={cls} onClick={onClick}>{children}</Tag>;
+}
+
+function CardHeader({ title, description, actions, icon, className = "" }: { title?: React.ReactNode; description?: React.ReactNode; actions?: React.ReactNode; icon?: React.ReactNode; className?: string }) {
+  return (
+    <div className={`grd-card-head ${className}`}>
+      {icon && <div className="grd-card-head-ic">{icon}</div>}
+      <div className="grd-card-head-text">
+        {title && <h3 className="grd-card-head-title">{title}</h3>}
+        {description && <p className="grd-card-head-desc">{description}</p>}
+      </div>
+      {actions && <div className="grd-card-head-act">{actions}</div>}
+    </div>
+  );
+}
+function CardBody({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return <div className={`grd-card-body ${className}`}>{children}</div>;
+}
+function CardFooter({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return <div className={`grd-card-foot ${className}`}>{children}</div>;
+}
+(Card as any).Header = CardHeader;
+(Card as any).Body = CardBody;
+(Card as any).Footer = CardFooter;
+Card.displayName = "Card";
+(window as any).Card = Card;

--- a/ux_references/ui_kits/components/Chart/Chart.playground.html
+++ b/ux_references/ui_kits/components/Chart/Chart.playground.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Chart · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">DATA · GRÁFICO</div>
+  <h1 class="pg-title">Chart</h1>
+  <span class="pg-codename">import Chart from "ui_kits/components/Chart"</span>
+  <p class="pg-desc">Gráfico SVG leve sem dependências. Linha (com multi-série) e barra. Tons violeta, verde ou multi.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:24,gap:18,flexWrap:"wrap",alignItems:"stretch"}}>{children}</div></div>);
+}
+function Frame({ children, w=520 }: { children: React.ReactNode; w?: number }) {
+  return (<div style={{width:w,background:"var(--papel)",border:"1px solid var(--gray-200)",borderRadius:"var(--radius-lg)",padding:16}}>{children}</div>);
+}
+
+const MESES = ["Jan","Fev","Mar","Abr","Mai","Jun","Jul","Ago","Set","Out","Nov","Dez"];
+
+const RECEITA = MESES.map((m, i) => ({ label: m, value: 120000 + Math.round(Math.sin(i/1.5)*40000 + i*4200) }));
+
+const CONCILIADOS = MESES.slice(0,8).map((m, i) => ({
+  label: m,
+  series: {
+    "Aprovados": 210 + i*14 + Math.round(Math.sin(i)*18),
+    "Pendentes": 42 - i*3  + Math.round(Math.cos(i)*6),
+    "Rejeitados": 8 + Math.round(Math.sin(i*1.3)*3),
+  }
+}));
+
+const CONF = MESES.slice(0,8).map((m, i) => ({
+  label: m,
+  series: { "Taxa de confiança": 88 + Math.round(Math.sin(i/1.2)*3 + i/2) }
+}));
+
+function fmtBRL(v: number) { return "R$ " + (v/1000).toFixed(0) + "k"; }
+function fmtPct(v: number) { return v + "%"; }
+
+function App() {
+  return (<>
+    <Sec title="Barra · tom violeta (padrão)">
+      <Frame>
+        <Chart type="bar" data={RECEITA} title="Receita por mês · 2026" yFormatter={fmtBRL} height={220} />
+      </Frame>
+    </Sec>
+
+    <Sec title="Linha · série única (área preenchida)">
+      <Frame>
+        <Chart type="line" data={CONF} title="Taxa média de confiança (%)" tone="green" series={["Taxa de confiança"]} yFormatter={fmtPct} height={200} />
+      </Frame>
+    </Sec>
+
+    <Sec title="Linha · multi-série (tom multi com legenda)">
+      <Frame w={620}>
+        <Chart
+          type="line"
+          data={CONCILIADOS}
+          title="Lançamentos por status"
+          tone="multi"
+          series={["Aprovados", "Pendentes", "Rejeitados"]}
+          height={240}
+        />
+      </Frame>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Chart"]) || "render(<div>Sem exemplo para Chart</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>type</code></td><td>string</td><td>—</td><td class="desc">line · bar</td></tr>
+  <tr><td><code>data</code></td><td>array</td><td>—</td><td class="desc">
+    Para <code>bar</code>: <code>{`{label,value}[]`}</code><br/>
+    Para <code>line</code>: <code>{`{label,series:{name:val}}[]`}</code></td></tr>
+  <tr><td><code>series</code></td><td>string[]</td><td>—</td><td class="desc">Nomes das séries (line)</td></tr>
+  <tr><td><code>tone</code></td><td>string</td><td>"violet"</td><td class="desc">violet · green · multi</td></tr>
+  <tr><td><code>height</code></td><td>number</td><td>220</td><td class="desc">Altura em px</td></tr>
+  <tr><td><code>yFormatter</code></td><td>fn</td><td>fmtNum</td><td class="desc">Formata eixo Y e tooltips</td></tr>
+  <tr><td><code>showGrid</code></td><td>boolean</td><td>true</td><td class="desc">Linhas de grade</td></tr>
+  <tr><td><code>title</code></td><td>node</td><td>—</td><td class="desc">Título acima do gráfico</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Tendência temporal (receita, conciliação, SLA); categorias limitadas (≤ 7 séries).</li>
+      <li>Sempre com eixo Y rotulado, formato BRL/percentual coerente.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Pizza com mais de 5 fatias — use barras.</li>
+      <li>Eixos sem unidade; cores aleatórias fora da paleta.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Chart/index.css
+++ b/ux_references/ui_kits/components/Chart/index.css
@@ -1,0 +1,8 @@
+
+.grd-ch { font-family: var(--font-sans); }
+.grd-ch-title { font-size: 13px; font-weight: 600; color: var(--fg); margin-bottom: 8px; }
+.grd-ch-ylab,
+.grd-ch-xlab { font-size: 11px; fill: var(--fg-muted); font-family: var(--font-sans); font-feature-settings: "tnum"; font-variant-numeric: tabular-nums; }
+.grd-ch-legend { display: flex; flex-wrap: wrap; gap: 10px 16px; margin-top: 10px; font-size: 12px; color: var(--fg-muted); }
+.grd-ch-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+.grd-ch-legend-dot { width: 10px; height: 10px; border-radius: 50%; }

--- a/ux_references/ui_kits/components/Chart/index.tsx
+++ b/ux_references/ui_kits/components/Chart/index.tsx
@@ -1,0 +1,142 @@
+
+/**
+ * Chart — SVG chart leve, sem deps. Suporta 'line' e 'bar'.
+ * Props:
+ *   type: "line" | "bar"
+ *   data: { label: string; value: number }[]  (bar)
+ *       ou { label: string; series: Record<string, number> }[]  (line multi-serie)
+ *   series: string[]  (line) — nomes das séries no objeto
+ *   tone: "violet" | "multi" — cor(es)
+ *   height, yFormatter, showGrid
+ */
+
+type BarPoint = { label: string; value: number; color?: string };
+type LinePoint = { label: string; series: Record<string, number> };
+interface ChartProps {
+  type: "line" | "bar";
+  data: any[];
+  series?: string[];
+  tone?: "violet" | "green" | "multi";
+  height?: number;
+  yFormatter?: (v: number) => string;
+  showGrid?: boolean;
+  title?: React.ReactNode;
+  className?: string;
+}
+
+const CHART_COLORS = ["#4F186D", "#FF6F3C", "#FBBC04", "#34A853", "#4285F4", "#9F5DB3"];
+
+function fmtNum(v: number) {
+  if (Math.abs(v) >= 1000000) return `${(v/1000000).toFixed(1)}M`;
+  if (Math.abs(v) >= 1000) return `${(v/1000).toFixed(1)}k`;
+  return v.toLocaleString("pt-BR", { maximumFractionDigits: 1 });
+}
+
+function Chart({
+  type, data, series, tone = "violet", height = 220,
+  yFormatter = fmtNum, showGrid = true, title, className = "",
+}: ChartProps) {
+  const pad = { top: 16, right: 16, bottom: 28, left: 44 };
+  const W = 600;
+  const H = height;
+  const innerW = W - pad.left - pad.right;
+  const innerH = H - pad.top - pad.bottom;
+
+  let maxY = 0;
+  if (type === "bar") {
+    maxY = Math.max(...(data as BarPoint[]).map(d => d.value), 0);
+  } else {
+    const ser = series ?? Object.keys((data[0] as LinePoint)?.series ?? {});
+    (data as LinePoint[]).forEach(d => ser.forEach(s => { maxY = Math.max(maxY, d.series[s] ?? 0); }));
+  }
+  if (maxY === 0) maxY = 1;
+  // Round maxY up
+  const magnitude = Math.pow(10, Math.floor(Math.log10(maxY)));
+  maxY = Math.ceil(maxY / magnitude) * magnitude;
+
+  const ticks = 4;
+  const yTicks = Array.from({ length: ticks + 1 }, (_, i) => (maxY * i) / ticks);
+
+  const barColor = tone === "green" ? "var(--signal-green)" : "var(--violet-500)";
+
+  return (
+    <div className={`grd-ch ${className}`}>
+      {title && <div className="grd-ch-title">{title}</div>}
+      <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: "100%", height }}>
+        {/* Y grid + labels */}
+        {showGrid && yTicks.map((t, i) => {
+          const y = pad.top + innerH - (t / maxY) * innerH;
+          return (
+            <g key={i}>
+              <line x1={pad.left} x2={pad.left + innerW} y1={y} y2={y} stroke="var(--gray-200)" strokeWidth={1} strokeDasharray={i === 0 ? "0" : "2 3"} />
+              <text x={pad.left - 8} y={y} dominantBaseline="middle" textAnchor="end" className="grd-ch-ylab">{yFormatter(t)}</text>
+            </g>
+          );
+        })}
+        {/* X labels */}
+        {type === "bar" ? (() => {
+          const bars = data as BarPoint[];
+          const slot = innerW / bars.length;
+          const bw = Math.min(32, slot * 0.6);
+          return bars.map((d, i) => {
+            const x = pad.left + i * slot + (slot - bw) / 2;
+            const h = (d.value / maxY) * innerH;
+            const y = pad.top + innerH - h;
+            return (
+              <g key={i}>
+                <rect x={x} y={y} width={bw} height={h} rx={3} ry={3} fill={d.color ?? barColor}>
+                  <title>{`${d.label}: ${yFormatter(d.value)}`}</title>
+                </rect>
+                <text x={x + bw/2} y={pad.top + innerH + 16} textAnchor="middle" className="grd-ch-xlab">{d.label}</text>
+              </g>
+            );
+          });
+        })() : (() => {
+          const pts = data as LinePoint[];
+          const ser = series ?? Object.keys(pts[0]?.series ?? {});
+          const slot = innerW / Math.max(pts.length - 1, 1);
+          return (<>
+            {ser.map((s, si) => {
+              const color = tone === "multi" ? CHART_COLORS[si % CHART_COLORS.length] : barColor;
+              const path = pts.map((p, i) => {
+                const x = pad.left + i * slot;
+                const v = p.series[s] ?? 0;
+                const y = pad.top + innerH - (v / maxY) * innerH;
+                return `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`;
+              }).join(" ");
+              const areaPath = path + ` L${(pad.left + (pts.length - 1) * slot).toFixed(1)} ${(pad.top + innerH).toFixed(1)} L${pad.left.toFixed(1)} ${(pad.top + innerH).toFixed(1)} Z`;
+              return (
+                <g key={s}>
+                  {ser.length === 1 && <path d={areaPath} fill={color} opacity={0.1} />}
+                  <path d={path} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
+                  {pts.map((p, i) => {
+                    const x = pad.left + i * slot;
+                    const v = p.series[s] ?? 0;
+                    const y = pad.top + innerH - (v / maxY) * innerH;
+                    return <circle key={i} cx={x} cy={y} r={3} fill={color}><title>{`${s} • ${p.label}: ${yFormatter(v)}`}</title></circle>;
+                  })}
+                </g>
+              );
+            })}
+            {pts.map((p, i) => {
+              const x = pad.left + i * slot;
+              return <text key={i} x={x} y={pad.top + innerH + 16} textAnchor="middle" className="grd-ch-xlab">{p.label}</text>;
+            })}
+          </>);
+        })()}
+      </svg>
+      {type === "line" && series && series.length > 1 && tone === "multi" && (
+        <div className="grd-ch-legend">
+          {series.map((s, i) => (
+            <span key={s} className="grd-ch-legend-item">
+              <span className="grd-ch-legend-dot" style={{ background: CHART_COLORS[i % CHART_COLORS.length] }} />
+              {s}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+Chart.displayName = "Chart";
+(window as any).Chart = Chart;

--- a/ux_references/ui_kits/components/ChatMessage/ChatMessage.playground.html
+++ b/ux_references/ui_kits/components/ChatMessage/ChatMessage.playground.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>ChatMessage · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../ConfidenceIndicator/index.css">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../IconButton/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">CONTEÚDO · CHAT</div>
+  <h1 class="pg-title">ChatMessage</h1>
+  <span class="pg-codename">import ChatMessage from "ui_kits/components/ChatMessage"</span>
+  <p class="pg-desc">Bolha de conversa para copilots e transcrições. Roles: user, assistant, system. Inclui confidence e ações.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=3"></script>
+<script type="text/babel" data-presets="tsx" src="../ConfidenceIndicator/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../IconButton/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,flexDirection:"column",alignItems:"stretch",gap:12,maxWidth:720}}>{children}</div></div>);
+}
+
+function App() {
+  return (<>
+    <Sec title="Em contexto · copiloto classificando lançamentos">
+      <div style={{background:"var(--bg-subtle)",padding:20,borderRadius: "var(--radius-lg)",display:"flex",flexDirection:"column",gap:12}}>
+        <ChatMessage role="assistant" name="Agente Contábil" avatarIcon="bot" timestamp="14:32">
+          Encontrei 14 lançamentos com score abaixo de 85%. Quer que eu reclassifique com base no padrão dos últimos 6 meses?
+        </ChatMessage>
+        <ChatMessage role="user" name="Maria Santos" timestamp="14:32">
+          Sim, mas confirma cada um antes de aplicar.
+        </ChatMessage>
+        <ChatMessage
+          role="assistant" name="Agente Contábil" avatarIcon="bot" timestamp="14:33"
+          confidence="high"
+          actions={<>
+            <button className="grd-btn grd-btn-ghost grd-btn-sm">Pular</button>
+            <button className="grd-btn grd-btn-primary grd-btn-sm">Aprovar</button>
+          </>}
+        >
+          Começando pela <b>NF 8.394</b> — fornecedor AWS Brasil, R$ 4.280,00.<br/>
+          Sugestão: <b>3.1.4.06 · Infra cloud</b> (baseado em 22 transações similares).
+        </ChatMessage>
+        <ChatMessage role="system" avatarIcon="info" timestamp="14:33">
+          O agente criou um fluxo de revisão com 14 itens. Tempo estimado: 3 min.
+        </ChatMessage>
+        <ChatMessage role="user" name="Maria Santos" timestamp="14:34">
+          Aprovo a primeira. Veja as próximas.
+        </ChatMessage>
+      </div>
+    </Sec>
+
+    <Sec title="Conversa com agente contábil">
+      <ChatMessage role="system" avatarIcon="info" name="Guardia" timestamp="09:12">
+        Você iniciou uma nova sessão com o <b>Agente Contábil</b>. Contexto: Alfa Comércio LTDA — setembro/2026.
+      </ChatMessage>
+
+      <ChatMessage role="user" name="Luana" timestamp="09:13">
+        O que você fez com as 11 notas que ficaram pendentes ontem?
+      </ChatMessage>
+
+      <ChatMessage
+        role="assistant" name="Agente Contábil" avatarIcon="bot" timestamp="09:13"
+        confidence="high"
+        actions={<>
+          <button className="grd-btn grd-btn-ghost grd-btn-sm">Ver detalhes</button>
+          <button className="grd-btn grd-btn-secondary grd-btn-sm">Aplicar</button>
+        </>}
+      >
+        Das 11 pendentes, reclassifiquei 9 para a conta <code>4.1.02 — Despesas comerciais</code> com base no histórico do fornecedor.
+        As 2 restantes têm CFOP ambíguo (1102 vs 1403) e aguardam sua decisão.
+      </ChatMessage>
+
+      <ChatMessage role="user" name="Luana" timestamp="09:14">
+        Pode abrir o comparativo das duas pra mim?
+      </ChatMessage>
+
+      <ChatMessage
+        role="assistant" name="Agente Contábil" avatarIcon="bot" timestamp="09:14"
+        confidence="medium"
+        actions={<>
+          <button className="grd-btn grd-btn-secondary grd-btn-sm">Abrir comparativo</button>
+        </>}
+      >
+        Preparei o comparativo lado a lado. <b>NF 4891</b> tem natureza de revenda; <b>NF 4892</b>, de consumo interno — recomendo CFOPs distintos.
+      </ChatMessage>
+    </Sec>
+
+    <Sec title="Estados de confidence">
+      <ChatMessage role="assistant" name="Guardia" avatarIcon="bot" confidence="high" timestamp="agora">
+        Aprovei automaticamente os 237 lançamentos do lote atual.
+      </ChatMessage>
+      <ChatMessage role="assistant" name="Guardia" avatarIcon="bot" confidence="medium" timestamp="agora">
+        Encontrei 3 lançamentos que precisam da sua confirmação antes de aprovar.
+      </ChatMessage>
+      <ChatMessage role="assistant" name="Guardia" avatarIcon="bot" confidence="low" timestamp="agora">
+        Não tenho dados suficientes para classificar este lançamento com segurança.
+      </ChatMessage>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["ChatMessage"]) || "render(<div>Sem exemplo para ChatMessage</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>role</code></td><td>string</td><td>"assistant"</td><td class="desc">user · assistant · system</td></tr>
+  <tr><td><code>name</code></td><td>node</td><td>—</td><td class="desc">Nome exibido</td></tr>
+  <tr><td><code>avatar</code> · <code>avatarIcon</code></td><td>string</td><td>—</td><td class="desc">URL de imagem ou ícone Lucide fallback</td></tr>
+  <tr><td><code>timestamp</code></td><td>node</td><td>—</td><td class="desc">Horário</td></tr>
+  <tr><td><code>confidence</code></td><td>string</td><td>—</td><td class="desc">high · medium · low — mostra ConfidenceIndicator no rodapé</td></tr>
+  <tr><td><code>actions</code></td><td>node</td><td>—</td><td class="desc">Botões de ação</td></tr>
+  <tr><td><code>children</code></td><td>node</td><td>—</td><td class="desc">Corpo da mensagem</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Avatar <code>bot</code> em laranja à esquerda; humano à direita; sistema cinza centralizado.</li>
+      <li>Ações inline (aprovar/rejeitar) dentro da mensagem do agente quando houver decisão.</li>
+      <li>Incluir nome do agente e timestamp para rastreabilidade.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>"Typing" prolongado sem resposta concreta.</li>
+      <li>Mensagens do agente sem rastreabilidade (qual agente respondeu).</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/ChatMessage/index.css
+++ b/ux_references/ui_kits/components/ChatMessage/index.css
@@ -1,0 +1,44 @@
+
+.grd-cm {
+  display: flex; align-items: flex-start; gap: 10px;
+  font-family: var(--font-sans);
+  max-width: 100%;
+}
+.grd-cm-user { flex-direction: row-reverse; }
+
+.grd-cm-avatar {
+  width: 32px; height: 32px; border-radius: 50%;
+  flex-shrink: 0; overflow: hidden;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--violet-50); color: var(--violet-600);
+}
+.grd-cm-avatar img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.grd-cm-user .grd-cm-avatar { background: var(--orange-100); color: var(--orange-700); }
+.grd-cm-system .grd-cm-avatar { background: var(--gray-100); color: var(--fg-muted); }
+
+.grd-cm-bubble {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-xl); padding: 10px 14px;
+  max-width: 640px;
+  font-size: 14px; color: var(--fg); line-height: 1.5;
+}
+.grd-cm-user .grd-cm-bubble {
+  background: var(--violet-500); color: #fff; border-color: transparent;
+}
+.grd-cm-system .grd-cm-bubble {
+  background: var(--gray-50); color: var(--fg-muted); border-style: dashed;
+  font-size: 13px;
+}
+
+.grd-cm-head { display: flex; align-items: baseline; gap: 8px; margin-bottom: 2px; }
+.grd-cm-name { font-size: 12.5px; font-weight: 600; color: var(--fg); }
+.grd-cm-user .grd-cm-name { color: #fff; opacity: 0.9; }
+.grd-cm-ts { font-size: 11px; color: var(--fg-muted); font-feature-settings: "tnum"; font-variant-numeric: tabular-nums; }
+.grd-cm-user .grd-cm-ts { color: rgba(255,255,255,0.75); }
+
+.grd-cm-body p:first-child { margin-top: 0; }
+.grd-cm-body p:last-child { margin-bottom: 0; }
+
+.grd-cm-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border); }
+.grd-cm-user .grd-cm-foot { border-top-color: rgba(255,255,255,0.2); }
+.grd-cm-actions { display: inline-flex; gap: 4px; }

--- a/ux_references/ui_kits/components/ChatMessage/index.tsx
+++ b/ux_references/ui_kits/components/ChatMessage/index.tsx
@@ -1,0 +1,51 @@
+
+/**
+ * ChatMessage — bolha de conversa.
+ * Props: role (user|assistant|system), avatar, name, timestamp, children.
+ */
+
+interface ChatMessageProps {
+  role?: "user" | "assistant" | "system";
+  name?: React.ReactNode;
+  avatar?: string; // image url
+  avatarIcon?: string; // fallback icon name
+  timestamp?: React.ReactNode;
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+  confidence?: "high" | "medium" | "low";
+  className?: string;
+}
+
+function ChatMessage({
+  role = "assistant", name, avatar, avatarIcon,
+  timestamp, children, actions, confidence, className = "",
+}: ChatMessageProps) {
+  const IconCmp = (window as any).Icon;
+  const ConfIndicator = (window as any).ConfidenceIndicator;
+  const cls = ["grd-cm", `grd-cm-${role}`, className].filter(Boolean).join(" ");
+
+  return (
+    <div className={cls}>
+      <div className="grd-cm-avatar">
+        {avatar
+          ? <img src={avatar} alt="" />
+          : IconCmp && <IconCmp name={avatarIcon ?? (role === "user" ? "user" : role === "system" ? "info" : "bot")} size={16} />}
+      </div>
+      <div className="grd-cm-bubble">
+        <div className="grd-cm-head">
+          {name && <span className="grd-cm-name">{name}</span>}
+          {timestamp && <span className="grd-cm-ts">{timestamp}</span>}
+        </div>
+        <div className="grd-cm-body">{children}</div>
+        {(confidence || actions) && (
+          <div className="grd-cm-foot">
+            {confidence && ConfIndicator && <ConfIndicator level={confidence} size="sm" />}
+            {actions && <div className="grd-cm-actions">{actions}</div>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+ChatMessage.displayName = "ChatMessage";
+(window as any).ChatMessage = ChatMessage;

--- a/ux_references/ui_kits/components/Checkbox/Checkbox.playground.html
+++ b/ux_references/ui_kits/components/Checkbox/Checkbox.playground.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Checkbox · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORMS · SELEÇÃO MÚLTIPLA</div>
+  <h1 class="pg-title">Checkbox</h1>
+  <span class="pg-codename">import Checkbox from "ui_kits/components/Checkbox"</span>
+  <p class="pg-desc">Seleção de múltiplos itens ou confirmação de opções independentes. Inclui estado <code>indeterminate</code> para agregadores (selecionar todos) e validação visual por <code>invalid</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, variant }: { title: string; children: React.ReactNode; variant?: string }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className={"pg-stage col "+(variant||"")}>{children}</div></div>);
+}
+const CLIENTES = ["Contábil Silva &amp; Cia", "Escritório Nova Era", "Prime Partners", "Martins Consultoria"];
+
+function App() {
+  const [sel, setSel] = React.useState<Record<string, boolean>>({});
+  const count = Object.values(sel).filter(Boolean).length;
+  const todos = count === CLIENTES.length;
+  const algum = count > 0 && !todos;
+  return (<>
+    <Sec title="Tamanhos">
+      <Checkbox size="sm" label="Small" defaultChecked />
+      <Checkbox size="md" label="Medium (default)" defaultChecked />
+    </Sec>
+    <Sec title="Estados">
+      <Checkbox label="Default · desmarcado" />
+      <Checkbox label="Marcado" defaultChecked />
+      <Checkbox label="Indeterminado (selecionar todos parcial)" indeterminate />
+      <Checkbox label="Inválido" invalid defaultChecked />
+      <Checkbox label="Desabilitado (off)" disabled />
+      <Checkbox label="Desabilitado (on)" disabled defaultChecked />
+    </Sec>
+    <Sec title="Com descrição">
+      <Checkbox label="Aceito os termos de uso" description="Você pode revisar em guardia.com/termos a qualquer momento" />
+      <Checkbox label="Receber novidades por e-mail" description="Máximo 1 vez por semana, sem pegadinhas" defaultChecked />
+    </Sec>
+    <Sec title="Grupo com indeterminado · seleção em massa">
+      <Checkbox label={`Selecionar todos (${count}/${CLIENTES.length})`} checked={todos} indeterminate={algum} onChange={(e) => { const v = e.target.checked; setSel(CLIENTES.reduce((acc, c) => ({...acc, [c]: v}), {})); }} />
+      <div style={{ paddingLeft: 28, display: "flex", flexDirection: "column", gap: 8, borderLeft: "1px solid var(--border)" }}>
+        {CLIENTES.map((c) => (
+          <Checkbox key={c} label={c} checked={!!sel[c]} onChange={(e) => setSel({ ...sel, [c]: e.target.checked })} />
+        ))}
+      </div>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+function ExampleApp() {
+  const code = `
+function SelecionarClientes() {
+  const [sel, setSel] = React.useState({ a: false, b: true, c: false });
+  const ids = ["a", "b", "c"];
+  const todos = ids.every((k) => sel[k]);
+  const algum = ids.some((k) => sel[k]) && !todos;
+
+  const marcarTodos = (v) => setSel({ a: v, b: v, c: v });
+
+  return (
+    <div style={{ width: 320, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <Checkbox
+        label="Selecionar todos"
+        checked={todos}
+        indeterminate={algum}
+        onChange={(e) => marcarTodos(e.target.checked)}
+      />
+      <div style={{ paddingLeft: 24, display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <Checkbox label="Silva & Cia" checked={!!sel.a} onChange={(e) => setSel({ ...sel, a: e.target.checked })} />
+        <Checkbox label="Nova Era" checked={!!sel.b} onChange={(e) => setSel({ ...sel, b: e.target.checked })} />
+        <Checkbox label="Prime" checked={!!sel.c} onChange={(e) => setSel({ ...sel, c: e.target.checked })} />
+      </div>
+    </div>
+  );
+}
+
+render(<SelecionarClientes />);
+`;
+  return <LiveCode code={code} />;
+}
+ReactDOM.createRoot(document.getElementById('example-root')!).render(<ExampleApp />);
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>size</code></td><td>string</td><td><code>"md"</code></td><td class="desc">sm · md</td></tr>
+  <tr><td><code>checked</code></td><td>boolean</td><td>—</td><td class="desc">Uso controlado</td></tr>
+  <tr><td><code>indeterminate</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Estado misto (seleção parcial em grupo)</td></tr>
+  <tr><td><code>invalid</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Mostra borda vermelha (erro de validação)</td></tr>
+  <tr><td><code>label</code></td><td>ReactNode</td><td>—</td><td class="desc">Texto principal ao lado da caixa</td></tr>
+  <tr><td><code>description</code></td><td>ReactNode</td><td>—</td><td class="desc">Apoio abaixo do label</td></tr>
+  <tr><td><code>disabled</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Bloqueia interação</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Seleção múltipla independente (filtros de status, itens em lote).</li>
+      <li>Label clicável; estado <code>indeterminate</code> para seleção parcial.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Opções mutuamente exclusivas — use <code>Radio</code>.</li>
+      <li>Listas longas sem "selecionar tudo" quando ≥ 6 itens.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Checkbox/index.css
+++ b/ux_references/ui_kits/components/Checkbox/index.css
@@ -1,0 +1,40 @@
+
+.grd-cb {
+  display: inline-flex; align-items: flex-start; gap: 10px;
+  font-family: var(--font-sans); cursor: pointer;
+  -webkit-user-select: none; user-select: none;
+}
+.grd-cb-disabled { opacity: 0.55; cursor: not-allowed; }
+
+.grd-cb-box {
+  position: relative; flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.grd-cb input[type="checkbox"] {
+  position: absolute; inset: 0; opacity: 0; cursor: inherit; margin: 0;
+}
+.grd-cb-mark {
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--surface);
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: transparent;
+  transition: background 140ms, border-color 140ms, color 140ms, box-shadow 140ms;
+}
+.grd-cb-sm .grd-cb-mark { width: 16px; height: 16px; border-radius: var(--radius-sm); }
+.grd-cb-md .grd-cb-mark { width: 18px; height: 18px; }
+
+.grd-cb input:hover:not(:disabled) ~ .grd-cb-mark { border-color: var(--violet-500); }
+.grd-cb input:focus-visible ~ .grd-cb-mark { box-shadow: var(--focus-ring); }
+.grd-cb input:checked ~ .grd-cb-mark,
+.grd-cb input:indeterminate ~ .grd-cb-mark {
+  background: var(--violet-500); border-color: var(--violet-500); color: #fff;
+}
+
+.grd-cb-invalid .grd-cb-mark { border-color: var(--signal-red); }
+
+.grd-cb-text { display: inline-flex; flex-direction: column; gap: 2px; }
+.grd-cb-label { font-size: 14px; font-weight: 500; color: var(--fg); line-height: 1.4; }
+.grd-cb-desc { font-size: 12.5px; color: var(--fg-muted); line-height: 1.45; }
+.grd-cb-sm .grd-cb-label { font-size: 13px; }
+.grd-cb-sm .grd-cb-desc { font-size: 12px; }

--- a/ux_references/ui_kits/components/Checkbox/index.tsx
+++ b/ux_references/ui_kits/components/Checkbox/index.tsx
@@ -1,0 +1,70 @@
+
+/**
+ * Checkbox — seleção múltipla.
+ * Props: checked, indeterminate, size, invalid, label, description.
+ */
+
+interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size" | "type"> {
+  size?: "sm" | "md";
+  indeterminate?: boolean;
+  invalid?: boolean;
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+}
+
+function Checkbox({
+  size = "md",
+  indeterminate = false,
+  invalid,
+  label,
+  description,
+  className = "",
+  id,
+  checked,
+  disabled,
+  ...rest
+}: CheckboxProps) {
+  const ref = React.useRef<HTMLInputElement>(null);
+  const genId = React.useId();
+  const cbId = id ?? genId;
+  React.useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  const wrapCls = [
+    "grd-cb",
+    `grd-cb-${size}`,
+    invalid && "grd-cb-invalid",
+    disabled && "grd-cb-disabled",
+    className,
+  ].filter(Boolean).join(" ");
+  const IconCmp = (window as any).Icon;
+  return (
+    <label className={wrapCls} htmlFor={cbId}>
+      <span className="grd-cb-box">
+        <input
+          ref={ref}
+          id={cbId}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          {...rest}
+        />
+        <span className="grd-cb-mark">
+          {IconCmp && (
+            indeterminate
+              ? <IconCmp name="minus" size={size === "sm" ? 12 : 14} />
+              : <IconCmp name="check" size={size === "sm" ? 12 : 14} />
+          )}
+        </span>
+      </span>
+      {(label || description) && (
+        <span className="grd-cb-text">
+          {label && <span className="grd-cb-label">{label}</span>}
+          {description && <span className="grd-cb-desc">{description}</span>}
+        </span>
+      )}
+    </label>
+  );
+}
+Checkbox.displayName = "Checkbox";
+(window as any).Checkbox = Checkbox;

--- a/ux_references/ui_kits/components/Chip/Chip.playground.html
+++ b/ux_references/ui_kits/components/Chip/Chip.playground.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Chip · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · FILTRO/TAG</div>
+  <h1 class="pg-title">Chip</h1>
+  <span class="pg-codename">import Chip from "ui_kits/components/Chip"</span>
+  <p class="pg-desc">Token selecionável ou removível para filtros ativos, categorias e seleção múltipla. Diferente de <code>Badge</code> (passivo), o <code>Chip</code> é interativo.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage">{children}</div></div>);
+}
+function App() {
+  const [tags, setTags] = React.useState(["conciliado","pendente","ana-lima","março/2025"]);
+  const CATEG = ["Contábil", "Financeiro", "Fiscal", "Tributário"];
+  const [sel, setSel] = React.useState<Set<string>>(new Set(["Contábil"]));
+  const toggle = (c: string) => {
+    const next = new Set(sel); next.has(c) ? next.delete(c) : next.add(c);
+    setSel(next);
+  };
+  return (<>
+    <Sec title="Estático">
+      <Chip>neutro</Chip>
+      <Chip leftIcon="tag">com ícone</Chip>
+      <Chip selected leftIcon="check">selecionado</Chip>
+      <Chip disabled>desabilitado</Chip>
+    </Sec>
+    <Sec title="Filtros ativos · removíveis">
+      {tags.map(t => (
+        <Chip key={t} leftIcon="filter" onRemove={() => setTags(tags.filter(x => x !== t))}>{t}</Chip>
+      ))}
+      {tags.length === 0 && <span style={{fontSize:12,color:"var(--gray-500)"}}>nenhum filtro · <button onClick={() => setTags(["conciliado","pendente","ana-lima","março/2025"])} style={{background:"none",border:"none",color:"var(--violet-500)",cursor:"pointer",textDecoration:"underline",fontSize:12}}>restaurar</button></span>}
+    </Sec>
+    <Sec title="Seletor de categorias (toggle)">
+      {CATEG.map(c => (
+        <Chip key={c} selected={sel.has(c)} onClick={() => toggle(c)} style={{cursor:"pointer"}}>{c}</Chip>
+      ))}
+      <span style={{fontSize:12,color:"var(--gray-500)",marginLeft:12}}>
+        selecionadas: <b>{[...sel].join(", ") || "—"}</b>
+      </span>
+    </Sec>
+    <Sec title="Pessoas · combo ícone + remover">
+      <Chip leftIcon="user" onRemove={() => {}}>Ana Lima</Chip>
+      <Chip leftIcon="user" onRemove={() => {}}>Bruno Castro</Chip>
+      <Chip leftIcon="user" selected onRemove={() => {}}>Carla Diniz</Chip>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Chip"]) || "render(<div>Sem exemplo para Chip</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>selected</code></td><td>boolean</td><td>false</td><td class="desc">Estado selecionado (destaque violeta)</td></tr>
+  <tr><td><code>leftIcon</code></td><td>IconName</td><td>—</td><td class="desc">Glifo à esquerda do label</td></tr>
+  <tr><td><code>onRemove</code></td><td>() =&gt; void</td><td>—</td><td class="desc">Quando presente, mostra botão × no final</td></tr>
+  <tr><td><code>disabled</code></td><td>boolean</td><td>false</td><td class="desc">Bloqueia interação</td></tr>
+  <tr><td><code>onClick</code></td><td>fn</td><td>—</td><td class="desc">Para toggles, combine com <code>selected</code></td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Filtros removíveis ativos (ex.: "Itaú ×", "Pendentes ×") e tags editáveis.</li>
+      <li>Ícone <code>x</code> à direita quando removível.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Uso puramente decorativo — isso é <code>Badge</code>.</li>
+      <li>Chips estáticos sem interação.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Chip/index.css
+++ b/ux_references/ui_kits/components/Chip/index.css
@@ -1,0 +1,29 @@
+/* Chip */
+.grd-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px 5px 10px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  color: var(--fg);
+  font-size: 12px; font-weight: 500; line-height: 1;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: background 140ms var(--ease-standard),
+              border-color 140ms var(--ease-standard),
+              color 140ms var(--ease-standard);
+}
+.grd-chip:hover:not(.grd-chip-disabled) { background: var(--violet-100); border-color: var(--violet-500); }
+.grd-chip-selected {
+  background: var(--violet-500); border-color: var(--violet-500); color: #fff;
+}
+.grd-chip-selected:hover { background: var(--violet-700); border-color: var(--violet-700); }
+.grd-chip-disabled { opacity: 0.5; cursor: not-allowed; }
+
+.grd-chip-remove {
+  background: none; border: none; padding: 0; margin-left: 2px;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 16px; height: 16px; border-radius: var(--radius-pill);
+  cursor: pointer; color: inherit; opacity: 0.7;
+}
+.grd-chip-remove:hover:not(:disabled) { opacity: 1; background: rgba(255,255,255,0.2); }
+.grd-chip:not(.grd-chip-selected) .grd-chip-remove:hover:not(:disabled) { background: var(--violet-100); }

--- a/ux_references/ui_kits/components/Chip/index.tsx
+++ b/ux_references/ui_kits/components/Chip/index.tsx
@@ -1,0 +1,49 @@
+/**
+ * Chip — item selecionável/removível com estado.
+ * Use-cases: filtros ativos, tags em seletor, aplicáveis em listas.
+ * Props: selected, onRemove, leftIcon.
+ */
+
+interface ChipProps extends React.HTMLAttributes<HTMLSpanElement> {
+  selected?: boolean;
+  leftIcon?: string;
+  onRemove?: () => void;
+  disabled?: boolean;
+}
+
+function Chip({
+  selected = false,
+  leftIcon,
+  onRemove,
+  disabled = false,
+  className = "",
+  children,
+  ...rest
+}: ChipProps) {
+  const IconCmp = (window as any).Icon;
+  const cls = [
+    "grd-chip",
+    selected && "grd-chip-selected",
+    disabled && "grd-chip-disabled",
+    className,
+  ].filter(Boolean).join(" ");
+  return (
+    <span className={cls} {...rest}>
+      {leftIcon && IconCmp && <IconCmp name={leftIcon} size={13} />}
+      <span>{children}</span>
+      {onRemove && (
+        <button
+          type="button"
+          className="grd-chip-remove"
+          onClick={(e) => { e.stopPropagation(); onRemove(); }}
+          aria-label="Remover"
+          disabled={disabled}
+        >
+          {IconCmp && <IconCmp name="close" size={12} />}
+        </button>
+      )}
+    </span>
+  );
+}
+Chip.displayName = "Chip";
+(window as any).Chip = Chip;

--- a/ux_references/ui_kits/components/Combobox/Combobox.playground.html
+++ b/ux_references/ui_kits/components/Combobox/Combobox.playground.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Combobox · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Label/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORM · SELEÇÃO COM BUSCA</div>
+  <h1 class="pg-title">Combobox</h1>
+  <span class="pg-codename">import Combobox from "ui_kits/components/Combobox"</span>
+  <p class="pg-desc">Select com busca — para listas longas (clientes, contas, CNAEs). Aceita metadado por item e estado limpável.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Label/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+const EMPRESAS = [
+  { value: "alfa",    label: "Alfa Comércio LTDA",        meta: "42.110.877/0001-55" },
+  { value: "beta",    label: "Beta Serviços S.A.",        meta: "18.441.002/0001-10" },
+  { value: "casa",    label: "Casa & Jardim ME",          meta: "32.981.544/0001-22" },
+  { value: "delta",   label: "Delta Indústria",           meta: "77.112.655/0001-03" },
+  { value: "epsilon", label: "Epsilon Transportes",       meta: "09.338.211/0001-78" },
+  { value: "fenix",   label: "Fênix Consultoria",         meta: "14.005.900/0001-41" },
+  { value: "gama",    label: "Gama Logística",            meta: "22.776.812/0001-09" },
+  { value: "horus",   label: "Hórus Tecnologia ME",       meta: "38.441.905/0001-67" },
+];
+
+const CONTAS = [
+  { value: "1.1.01", label: "1.1.01 — Caixa" },
+  { value: "1.1.02", label: "1.1.02 — Bancos conta movimento" },
+  { value: "1.1.03", label: "1.1.03 — Aplicações financeiras" },
+  { value: "1.2.01", label: "1.2.01 — Duplicatas a receber" },
+  { value: "2.1.01", label: "2.1.01 — Fornecedores nacionais" },
+  { value: "2.1.02", label: "2.1.02 — Salários a pagar" },
+  { value: "3.1.01", label: "3.1.01 — Receita de serviços" },
+  { value: "4.1.01", label: "4.1.01 — Despesas administrativas", disabled: true },
+];
+
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,flexDirection:"column",alignItems:"flex-start",gap:14,maxWidth:520}}>{children}</div></div>);
+}
+
+function App() {
+  const [empresa, setEmpresa] = React.useState("beta");
+  const [conta, setConta] = React.useState("");
+  return (<>
+    <Sec title="Seleção de empresa (com meta)">
+      <Label>Empresa</Label>
+      <Combobox
+        options={EMPRESAS} value={empresa}
+        onChange={setEmpresa}
+        placeholder="Selecione uma empresa…"
+        searchPlaceholder="Buscar por razão ou CNPJ…"
+        clearable
+        leftIcon="building-2"
+      />
+    </Sec>
+    <Sec title="Plano de contas (item disabled)">
+      <Label>Conta contábil</Label>
+      <Combobox
+        options={CONTAS}
+        value={conta} onChange={setConta}
+        placeholder="Selecione uma conta…"
+        emptyText="Nenhuma conta encontrada"
+      />
+    </Sec>
+    <Sec title="Tamanhos">
+      <Combobox size="sm" options={EMPRESAS.slice(0,4)} placeholder="sm" />
+      <Combobox size="md" options={EMPRESAS.slice(0,4)} placeholder="md (padrão)" />
+      <Combobox size="lg" options={EMPRESAS.slice(0,4)} placeholder="lg" />
+    </Sec>
+    <Sec title="Estados">
+      <Combobox options={EMPRESAS.slice(0,3)} placeholder="Padrão" />
+      <Combobox options={EMPRESAS.slice(0,3)} placeholder="Inválido" invalid />
+      <Combobox options={EMPRESAS.slice(0,3)} placeholder="Desabilitado" disabled />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Combobox"]) || "render(<div>Sem exemplo para Combobox</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>options</code></td><td>{`{value,label,meta?,disabled?}[]`}</td><td>—</td><td class="desc">Lista filtrável</td></tr>
+  <tr><td><code>value</code> · <code>onChange</code></td><td>string · fn</td><td>—</td><td class="desc">Controlado</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>leftIcon</code></td><td>string</td><td>—</td><td class="desc">Ícone Lucide à esquerda</td></tr>
+  <tr><td><code>clearable</code></td><td>boolean</td><td>false</td><td class="desc">Botão X para limpar</td></tr>
+  <tr><td><code>invalid</code> · <code>disabled</code></td><td>boolean</td><td>—</td><td class="desc">Estados</td></tr>
+  <tr><td><code>emptyText</code> · <code>searchPlaceholder</code></td><td>string</td><td>—</td><td class="desc">Copy da busca</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Seleção em lista grande com busca — plano de contas, fornecedores, CFOPs.</li>
+      <li>Mostrar chave + descrição ("3.1.4.05 · Despesas com tecnologia").</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Listas curtas (< 7 itens) — use <code>Select</code> simples.</li>
+      <li>Combobox sem placeholder indicando o que se busca.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Combobox/index.css
+++ b/ux_references/ui_kits/components/Combobox/index.css
@@ -1,0 +1,79 @@
+
+.grd-cmb { position: relative; font-family: var(--font-sans); width: 100%; display: inline-block; }
+.grd-cmb-trigger {
+  display: inline-flex; align-items: center; gap: 8px;
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  text-align: left; cursor: pointer;
+  font-family: inherit; color: var(--fg);
+  transition: border-color 140ms, box-shadow 140ms;
+}
+.grd-cmb-sm .grd-cmb-trigger { padding: 6px 10px; font-size: 13px; height: 32px; }
+.grd-cmb-md .grd-cmb-trigger { padding: 8px 12px; font-size: 14px; height: 38px; }
+.grd-cmb-lg .grd-cmb-trigger { padding: 10px 14px; font-size: 15px; height: 46px; }
+
+.grd-cmb-trigger:hover:not(:disabled) { border-color: var(--violet-300); }
+.grd-cmb-open .grd-cmb-trigger,
+.grd-cmb-default .grd-cmb-trigger:focus-visible { border-color: var(--violet-500); box-shadow: var(--focus-ring); outline: none; }
+.grd-cmb-error .grd-cmb-trigger   { border-color: var(--signal-red); }
+.grd-cmb-error .grd-cmb-trigger:focus-visible { box-shadow: var(--focus-ring-error); outline: none; }
+.grd-cmb-success .grd-cmb-trigger { border-color: var(--signal-green); }
+.grd-cmb-success .grd-cmb-trigger:focus-visible { box-shadow: var(--focus-ring-success); outline: none; }
+.grd-cmb-disabled .grd-cmb-trigger { background: var(--gray-100); cursor: not-allowed; opacity: 0.7; }
+
+.grd-cmb-ic { color: var(--gray-500); display: inline-flex; flex-shrink: 0; }
+.grd-cmb-val { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.grd-cmb-val-ph { color: var(--gray-400); }
+.grd-cmb-chev { color: var(--gray-500); flex-shrink: 0; transition: transform 180ms; }
+.grd-cmb-open .grd-cmb-chev { transform: rotate(180deg); }
+.grd-cmb-clear {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 18px; height: 18px; border-radius: 50%;
+  border: 0; background: transparent; color: var(--gray-500); cursor: pointer;
+}
+.grd-cmb-clear:hover { background: var(--gray-100); color: var(--fg); }
+
+.grd-cmb-pop {
+  position: absolute; top: calc(100% + 4px); left: 0; right: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  z-index: 50;
+  max-height: 320px; display: flex; flex-direction: column;
+  animation: grd-cmb-in 140ms var(--ease-out);
+}
+@keyframes grd-cmb-in { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+
+.grd-cmb-search {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px; border-bottom: 1px solid var(--border);
+  color: var(--gray-500);
+}
+.grd-cmb-search input {
+  border: 0; outline: none; background: transparent;
+  font-family: inherit; font-size: 13.5px; color: var(--fg);
+  width: 100%; padding: 0; margin: 0;
+}
+.grd-cmb-list { overflow-y: auto; padding: 4px; flex: 1; }
+.grd-cmb-opt {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  width: 100%;
+  padding: 7px 10px; border: 0; background: transparent;
+  font-family: inherit; font-size: 13.5px; color: var(--fg);
+  text-align: left; cursor: pointer; border-radius: var(--radius-md);
+  transition: background 120ms;
+}
+.grd-cmb-opt:hover:not(:disabled) { background: var(--violet-50); }
+.grd-cmb-opt-sel { background: var(--violet-50); color: var(--violet-700); }
+.grd-cmb-opt-sel:hover { background: var(--violet-100); }
+.grd-cmb-opt-dis { opacity: 0.5; cursor: not-allowed; }
+.grd-cmb-opt-text { display: inline-flex; flex-direction: column; gap: 2px; min-width: 0; }
+.grd-cmb-opt-lbl { font-weight: 500; }
+.grd-cmb-opt-meta { font-size: 12px; color: var(--fg-muted); }
+.grd-cmb-opt-sel .grd-cmb-opt-meta { color: var(--violet-600); opacity: 0.85; }
+.grd-cmb-empty {
+  padding: 16px; text-align: center; color: var(--fg-muted); font-size: 13px;
+}

--- a/ux_references/ui_kits/components/Combobox/index.tsx
+++ b/ux_references/ui_kits/components/Combobox/index.tsx
@@ -1,0 +1,156 @@
+
+/**
+ * Combobox — dropdown com busca. Para listas longas (clientes, contas, CNAEs).
+ * Props: options [{value,label,meta?}], value, onChange, placeholder, searchPlaceholder.
+ */
+
+interface ComboOption {
+  value: string;
+  label: string;
+  meta?: React.ReactNode;
+  disabled?: boolean;
+}
+
+interface ComboboxProps {
+  options: ComboOption[];
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string, option?: ComboOption) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  size?: "sm" | "md" | "lg";
+  state?: "default" | "error" | "success";
+  invalid?: boolean;
+  disabled?: boolean;
+  leftIcon?: string;
+  emptyText?: string;
+  clearable?: boolean;
+  className?: string;
+}
+
+function Combobox({
+  options,
+  value,
+  defaultValue,
+  onChange,
+  placeholder = "Selecione…",
+  searchPlaceholder = "Buscar…",
+  size = "md",
+  state = "default",
+  invalid,
+  disabled,
+  leftIcon,
+  emptyText = "Nenhum resultado",
+  clearable = false,
+  className = "",
+}: ComboboxProps) {
+  const IconCmp = (window as any).Icon;
+  const [open, setOpen] = React.useState(false);
+  const [internal, setInternal] = React.useState<string>(defaultValue ?? "");
+  const [query, setQuery] = React.useState("");
+  const current = value !== undefined ? value : internal;
+  const selectedOpt = options.find(o => o.value === current);
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const searchRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  React.useEffect(() => {
+    if (open && searchRef.current) searchRef.current.focus();
+    if (!open) setQuery("");
+  }, [open]);
+
+  const filtered = query
+    ? options.filter(o => (o.label + " " + (typeof o.meta === "string" ? o.meta : "")).toLowerCase().includes(query.toLowerCase()))
+    : options;
+
+  const effective = invalid ? "error" : state;
+  const wrapCls = [
+    "grd-cmb",
+    `grd-cmb-${size}`,
+    `grd-cmb-${effective}`,
+    open && "grd-cmb-open",
+    disabled && "grd-cmb-disabled",
+    className,
+  ].filter(Boolean).join(" ");
+  const iconSize = size === "sm" ? 13 : size === "lg" ? 18 : 15;
+
+  function pick(opt: ComboOption) {
+    if (opt.disabled) return;
+    if (value === undefined) setInternal(opt.value);
+    onChange?.(opt.value, opt);
+    setOpen(false);
+  }
+
+  function clear(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (value === undefined) setInternal("");
+    onChange?.("", undefined);
+  }
+
+  return (
+    <div ref={rootRef} className={wrapCls}>
+      <button
+        type="button"
+        className="grd-cmb-trigger"
+        onClick={() => !disabled && setOpen(o => !o)}
+        disabled={disabled}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        {leftIcon && IconCmp && <span className="grd-cmb-ic"><IconCmp name={leftIcon} size={iconSize} /></span>}
+        <span className={`grd-cmb-val ${!selectedOpt ? "grd-cmb-val-ph" : ""}`}>
+          {selectedOpt ? selectedOpt.label : placeholder}
+        </span>
+        {clearable && selectedOpt && !disabled && IconCmp && (
+          <button type="button" className="grd-cmb-clear" onClick={clear} aria-label="Limpar">
+            <IconCmp name="x" size={iconSize - 1} />
+          </button>
+        )}
+        {IconCmp && <span className="grd-cmb-chev"><IconCmp name="chevron-down" size={iconSize} /></span>}
+      </button>
+      {open && (
+        <div className="grd-cmb-pop" role="listbox">
+          <div className="grd-cmb-search">
+            {IconCmp && <IconCmp name="search" size={14} />}
+            <input
+              ref={searchRef}
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder={searchPlaceholder}
+            />
+          </div>
+          <div className="grd-cmb-list">
+            {filtered.length === 0 && <div className="grd-cmb-empty">{emptyText}</div>}
+            {filtered.map(opt => (
+              <button
+                type="button"
+                key={opt.value}
+                className={`grd-cmb-opt ${opt.value === current ? "grd-cmb-opt-sel" : ""} ${opt.disabled ? "grd-cmb-opt-dis" : ""}`}
+                role="option"
+                aria-selected={opt.value === current}
+                onClick={() => pick(opt)}
+                disabled={opt.disabled}
+              >
+                <span className="grd-cmb-opt-text">
+                  <span className="grd-cmb-opt-lbl">{opt.label}</span>
+                  {opt.meta && <span className="grd-cmb-opt-meta">{opt.meta}</span>}
+                </span>
+                {opt.value === current && IconCmp && <IconCmp name="check" size={14} />}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+Combobox.displayName = "Combobox";
+(window as any).Combobox = Combobox;

--- a/ux_references/ui_kits/components/Command/Command.playground.html
+++ b/ux_references/ui_kits/components/Command/Command.playground.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Command · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">NAVEGAÇÃO · ⌘K</div>
+  <h1 class="pg-title">Command</h1>
+  <span class="pg-codename">import Command from "ui_kits/components/Command"</span>
+  <p class="pg-desc">Paleta de comandos com busca fuzzy, grupos, ícones, atalhos e navegação por teclado (↑/↓/↵/Esc).</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,flexDirection:"column",alignItems:"flex-start",gap:10}}>{children}</div></div>);
+}
+
+function App() {
+  const [open, setOpen] = React.useState(false);
+  const [log, setLog] = React.useState<string[]>([]);
+  function fire(x: string) { setLog(l => [x, ...l].slice(0, 6)); }
+
+  React.useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault(); setOpen(o => !o);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const items = [
+    {
+      group: "Navegar",
+      entries: [
+        { id: "n1", icon: "layout-dashboard", label: "Ir para início",    shortcut: "G I", keywords: "home dashboard", action: () => fire("Navegar: início") },
+        { id: "n2", icon: "inbox",            label: "Abrir inbox",       shortcut: "G B", keywords: "caixa entrada",   action: () => fire("Navegar: inbox") },
+        { id: "n3", icon: "users",            label: "Clientes",          shortcut: "G C", keywords: "empresas",        action: () => fire("Navegar: clientes") },
+        { id: "n4", icon: "arrow-left-right", label: "Conciliação",       shortcut: "G R", keywords: "recon",            action: () => fire("Navegar: conciliação") },
+      ],
+    },
+    {
+      group: "Ações",
+      entries: [
+        { id: "a1", icon: "plus-circle",  label: "Novo lançamento",    shortcut: "⌘N", action: () => fire("Ação: novo lançamento") },
+        { id: "a2", icon: "upload-cloud", label: "Importar extrato",   keywords: "ofx",  action: () => fire("Ação: importar extrato") },
+        { id: "a3", icon: "play",         label: "Rodar agente de fechamento", keywords: "contábil", action: () => fire("Ação: rodar agente") },
+        { id: "a4", icon: "download",     label: "Exportar em Excel",  shortcut: "⌘E",   action: () => fire("Ação: exportar") },
+      ],
+    },
+    {
+      group: "Configurações",
+      entries: [
+        { id: "c1", icon: "user",     label: "Meu perfil",              action: () => fire("Config: perfil") },
+        { id: "c2", icon: "shield",   label: "Segurança e permissões",  action: () => fire("Config: segurança") },
+        { id: "c3", icon: "plug-2",   label: "Integrações",             keywords: "api", action: () => fire("Config: integrações") },
+      ],
+    },
+  ];
+
+  return (<>
+    <Sec title="Abrir (Cmd+K ou Ctrl+K)">
+      <button className="grd-btn grd-btn-primary" onClick={() => setOpen(true)}>
+        Abrir paleta de comandos
+      </button>
+      <p style={{fontSize:13,color:"var(--gray-500)",margin:0}}>
+        Use ↑/↓ para navegar, ↵ para executar, Esc para fechar.
+      </p>
+      {log.length > 0 && (
+        <div style={{marginTop:8,display:"flex",flexDirection:"column",gap:4,fontSize:13,color:"var(--gray-700)",fontFamily:"var(--ff-mono)"}}>
+          {log.map((l, i) => <span key={i}>→ {l}</span>)}
+        </div>
+      )}
+      <Command open={open} onClose={() => setOpen(false)} items={items} placeholder="Buscar comando…" />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Command"]) || "render(<div>Sem exemplo para Command</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>open</code> · <code>onClose</code></td><td>boolean · fn</td><td>—</td><td class="desc">Controle</td></tr>
+  <tr><td><code>items</code></td><td>CmdGroup[]</td><td>—</td><td class="desc">Grupos com entradas</td></tr>
+  <tr><td><code>placeholder</code></td><td>string</td><td>"Buscar comando…"</td><td class="desc">Texto da busca</td></tr>
+  <tr><td><code>emptyText</code></td><td>string</td><td>"Nenhum resultado"</td><td class="desc">Estado vazio</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">CmdEntry</th></tr>
+  <tr><td><code>id</code> · <code>label</code></td><td>string · node</td><td>—</td><td class="desc">Identificador + rótulo</td></tr>
+  <tr><td><code>icon</code> · <code>shortcut</code></td><td>string</td><td>—</td><td class="desc">Ícone Lucide · atalho exibido</td></tr>
+  <tr><td><code>keywords</code></td><td>string</td><td>—</td><td class="desc">Termos extra para a busca</td></tr>
+  <tr><td><code>action</code></td><td>fn</td><td>—</td><td class="desc">Callback ao executar</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Palette de comando (⌘K) para power users: navegar rápido, disparar agente, abrir cliente.</li>
+      <li>Agrupar por seção ("Navegação", "Agentes", "Ações").</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Como substituto da navegação principal.</li>
+      <li>Comandos sem atalho de teclado visível.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Command/index.css
+++ b/ux_references/ui_kits/components/Command/index.css
@@ -1,0 +1,69 @@
+
+.grd-cmd-backdrop {
+  position: fixed; inset: 0; z-index: 1200;
+  background: color-mix(in oklab, var(--violet-900) 65%, transparent);
+  display: flex; align-items: flex-start; justify-content: center;
+  padding: 12vh 20px 20px;
+  animation: grd-cmd-fade 140ms var(--ease-out);
+}
+@keyframes grd-cmd-fade { from { opacity: 0; } to { opacity: 1; } }
+.grd-cmd {
+  width: 100%; max-width: 580px;
+  background: var(--surface); border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xl);
+  font-family: var(--font-sans);
+  overflow: hidden;
+  animation: grd-cmd-in 180ms var(--ease-out);
+}
+@keyframes grd-cmd-in { from { opacity: 0; transform: translateY(-8px) scale(0.98); } to { opacity: 1; transform: none; } }
+
+.grd-cmd-search {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 16px; border-bottom: 1px solid var(--border);
+  color: var(--fg-muted);
+}
+.grd-cmd-search input {
+  flex: 1; border: 0; outline: none; background: transparent;
+  font-family: inherit; font-size: 15px; color: var(--fg);
+  padding: 0;
+}
+.grd-cmd-search input::placeholder { color: var(--gray-400); }
+.grd-cmd-esc {
+  font-size: 10.5px; font-weight: 600; letter-spacing: 0.04em;
+  padding: 2px 6px; border-radius: var(--radius-sm); border: 1px solid var(--border);
+  color: var(--fg-muted); background: var(--gray-50);
+}
+
+.grd-cmd-list { max-height: 56vh; overflow-y: auto; padding: 6px; }
+.grd-cmd-empty { padding: 28px; text-align: center; color: var(--fg-muted); font-size: 13.5px; }
+
+.grd-cmd-group + .grd-cmd-group { margin-top: 2px; }
+.grd-cmd-group-lbl {
+  padding: 8px 10px 4px;
+  font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--fg-muted);
+}
+.grd-cmd-entry {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 0; background: transparent;
+  font-family: inherit; font-size: 14px; color: var(--fg);
+  text-align: left; cursor: pointer; border-radius: var(--radius-md);
+  transition: background 100ms;
+}
+.grd-cmd-entry-active { background: var(--violet-50); color: var(--violet-700); }
+.grd-cmd-entry-ic { color: var(--fg-muted); flex-shrink: 0; }
+.grd-cmd-entry-active .grd-cmd-entry-ic { color: var(--violet-600); }
+.grd-cmd-entry-text { flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.grd-cmd-entry-lbl { font-weight: 500; }
+.grd-cmd-entry-desc { font-size: 12.5px; color: var(--fg-muted); }
+.grd-cmd-entry-active .grd-cmd-entry-desc { color: var(--violet-600); }
+
+.grd-cmd-kbd {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+  padding: 2px 6px; border-radius: var(--radius-sm); border: 1px solid var(--border);
+  color: var(--fg-muted); background: var(--gray-50);
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}

--- a/ux_references/ui_kits/components/Command/index.tsx
+++ b/ux_references/ui_kits/components/Command/index.tsx
@@ -1,0 +1,127 @@
+
+/**
+ * Command — paleta de comandos (Cmd+K).
+ * Props: open, onClose, items (grupos), placeholder.
+ * Items: [{ group, entries: [{ id, label, shortcut?, icon?, keywords?, action? }] }]
+ */
+
+interface CmdEntry {
+  id: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  icon?: string;
+  shortcut?: string;
+  keywords?: string;
+  action?: () => void;
+}
+interface CmdGroup {
+  group: React.ReactNode;
+  entries: CmdEntry[];
+}
+interface CommandProps {
+  open: boolean;
+  onClose: () => void;
+  items: CmdGroup[];
+  placeholder?: string;
+  emptyText?: string;
+}
+
+function Command({ open, onClose, items, placeholder = "Buscar comando…", emptyText = "Nenhum resultado" }: CommandProps) {
+  const IconCmp = (window as any).Icon;
+  const [query, setQuery] = React.useState("");
+  const [activeIdx, setActiveIdx] = React.useState(0);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setQuery(""); setActiveIdx(0);
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
+    document.addEventListener("keydown", onKey);
+    const t = setTimeout(() => inputRef.current?.focus(), 60);
+    return () => { document.removeEventListener("keydown", onKey); clearTimeout(t); };
+  }, [open, onClose]);
+
+  const filtered: { group: React.ReactNode; entries: CmdEntry[] }[] = React.useMemo(() => {
+    if (!query) return items;
+    const q = query.toLowerCase();
+    return items
+      .map(g => ({
+        group: g.group,
+        entries: g.entries.filter(e => {
+          const hay = [
+            typeof e.label === "string" ? e.label : "",
+            e.keywords ?? "",
+            typeof e.description === "string" ? e.description : "",
+          ].join(" ").toLowerCase();
+          return hay.includes(q);
+        }),
+      }))
+      .filter(g => g.entries.length > 0);
+  }, [query, items]);
+
+  const flat: CmdEntry[] = React.useMemo(() => filtered.flatMap(g => g.entries), [filtered]);
+  React.useEffect(() => { setActiveIdx(0); }, [query]);
+
+  function handleKey(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") { e.preventDefault(); setActiveIdx(i => Math.min(i + 1, flat.length - 1)); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); setActiveIdx(i => Math.max(i - 1, 0)); }
+    else if (e.key === "Enter") {
+      e.preventDefault();
+      const entry = flat[activeIdx];
+      if (entry?.action) { entry.action(); onClose(); }
+    }
+  }
+
+  if (!open) return null;
+  return ReactDOM.createPortal(
+    <div className="grd-cmd-backdrop" onClick={onClose}>
+      <div className="grd-cmd" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+        <div className="grd-cmd-search">
+          {IconCmp && <IconCmp name="search" size={16} />}
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={handleKey}
+            placeholder={placeholder}
+          />
+          <kbd className="grd-cmd-esc">ESC</kbd>
+        </div>
+        <div className="grd-cmd-list">
+          {filtered.length === 0 && <div className="grd-cmd-empty">{emptyText}</div>}
+          {filtered.map((g, gi) => {
+            const baseIdx = filtered.slice(0, gi).reduce((a, b) => a + b.entries.length, 0);
+            return (
+              <div key={gi} className="grd-cmd-group">
+                <div className="grd-cmd-group-lbl">{g.group}</div>
+                {g.entries.map((e, ei) => {
+                  const idx = baseIdx + ei;
+                  const active = idx === activeIdx;
+                  return (
+                    <button
+                      key={e.id}
+                      type="button"
+                      className={`grd-cmd-entry ${active ? "grd-cmd-entry-active" : ""}`}
+                      onMouseEnter={() => setActiveIdx(idx)}
+                      onClick={() => { e.action?.(); onClose(); }}
+                    >
+                      {e.icon && IconCmp && <span className="grd-cmd-entry-ic"><IconCmp name={e.icon} size={15} /></span>}
+                      <span className="grd-cmd-entry-text">
+                        <span className="grd-cmd-entry-lbl">{e.label}</span>
+                        {e.description && <span className="grd-cmd-entry-desc">{e.description}</span>}
+                      </span>
+                      {e.shortcut && <kbd className="grd-cmd-kbd">{e.shortcut}</kbd>}
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+Command.displayName = "Command";
+(window as any).Command = Command;

--- a/ux_references/ui_kits/components/ConfidenceIndicator/ConfidenceIndicator.playground.html
+++ b/ux_references/ui_kits/components/ConfidenceIndicator/ConfidenceIndicator.playground.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>ConfidenceIndicator · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">IA · SEMÁFORO DE CONFIANÇA</div>
+  <h1 class="pg-title">ConfidenceIndicator</h1>
+  <span class="pg-codename">import ConfidenceIndicator from "ui_kits/components/ConfidenceIndicator"</span>
+  <p class="pg-desc">Comunica a confiança da Guardia em um output de IA. Três níveis alinhados ao sistema Lighthouse — <b style={{color:"var(--verde-500)"}}>alta (≥95%)</b>, <b style={{color:"var(--orange-500)"}}>revisar (80–94%)</b>, <b style={{color:"var(--vermelho-500)"}}>atenção (&lt;80%)</b>. Variantes: <code>chip</code>, <code>bar</code>, <code>dot</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",gap:10}}>{children}</div></div>);
+}
+function Row({ children }: any) {
+  return <div style={{display:"flex",gap:10,flexWrap:"wrap",alignItems:"center"}}>{children}</div>;
+}
+function App() {
+  return (<>
+    <Sec title="Em contexto · sugestão do agente num lançamento">
+      <div style={{padding:"14px 16px",background:"#fff",border:"1px solid var(--border)",borderRadius: "var(--radius-md)",display:"flex",gap:14,alignItems:"center",maxWidth:560}}>
+        <div style={{width:48,height:48,background:"var(--orange-500)",borderRadius: "var(--radius-md)",color:"#fff",display:"inline-flex",alignItems:"center",justifyContent:"center"}}>
+          <Icon name="bot" size={22} />
+        </div>
+        <div style={{flex:1}}>
+          <div style={{display:"flex",gap:8,alignItems:"center",marginBottom:4}}>
+            <strong style={{color:"var(--violet-500)",fontSize:14}}>Sugestão do agente</strong>
+            <ConfidenceIndicator level="high" value={97} size="sm" />
+          </div>
+          <p style={{margin:0,fontSize:13,color:"var(--gray-500)"}}>
+            Classificar em <b style={{color:"var(--violet-500)"}}>3.1.4.05 · Despesas com tecnologia</b>
+          </p>
+        </div>
+        <div style={{display:"flex",gap:6}}>
+          <button className="grd-btn grd-btn-ghost grd-btn-sm" aria-label="Rejeitar"><Icon name="x" size={14} /></button>
+          <button className="grd-btn grd-btn-primary grd-btn-sm" aria-label="Aceitar"><Icon name="check" size={14} /></button>
+        </div>
+      </div>
+    </Sec>
+
+    <Sec title="Chip · por nível">
+      <Row>
+        <ConfidenceIndicator level="high" value={97} />
+        <ConfidenceIndicator level="medium" value={86} />
+        <ConfidenceIndicator level="low" value={62} />
+      </Row>
+    </Sec>
+
+    <Sec title="Chip · sem valor numérico">
+      <Row>
+        <ConfidenceIndicator level="high" showValue={false} />
+        <ConfidenceIndicator level="medium" showValue={false} />
+        <ConfidenceIndicator level="low" showValue={false} />
+      </Row>
+    </Sec>
+
+    <Sec title="Dot · inline em listas">
+      <div style={{background:"#fff",border:"1px solid var(--border)",borderRadius:"var(--radius-md)",overflow:"hidden",maxWidth:520}}>
+        {[
+          ["NF 4891 · Fornecedor Alfa", 97, "Receita validada · 2110.01.001"],
+          ["NF 4892 · Telecom Beta",    86, "Categoria sugerida · revisar"],
+          ["NF 4893 · Uber Biz",        62, "Divergência de CNPJ na base"],
+        ].map(([t, v, d]: any, i) => (
+          <div key={i} style={{padding:"12px 14px",display:"flex",alignItems:"center",gap:12,borderBottom:i<2?"1px solid var(--border)":"none"}}>
+            <ConfidenceIndicator variant="dot" value={v} />
+            <div style={{flex:1,minWidth:0}}>
+              <div style={{fontSize:13,fontWeight:600,color:"var(--fg)"}}>{t}</div>
+              <div style={{fontSize:12,color:"var(--gray-500)"}}>{d}</div>
+            </div>
+            <span style={{fontSize:12,color:"var(--gray-500)",fontVariantNumeric:"tabular-nums"}}>{v}%</span>
+          </div>
+        ))}
+      </div>
+    </Sec>
+
+    <Sec title="Bar · detalhe">
+      <div style={{maxWidth:320,display:"flex",flexDirection:"column",gap:14}}>
+        <ConfidenceIndicator variant="bar" value={97} label="Classificação contábil" />
+        <ConfidenceIndicator variant="bar" value={86} label="Categoria fiscal" />
+        <ConfidenceIndicator variant="bar" value={62} label="Match fornecedor" />
+      </div>
+    </Sec>
+
+    <Sec title="Tamanhos (chip)">
+      <Row>
+        <ConfidenceIndicator size="sm" level="high" value={97} />
+        <ConfidenceIndicator size="md" level="high" value={97} />
+      </Row>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["ConfidenceIndicator"]) || "render(<div>Sem exemplo para ConfidenceIndicator</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>value</code></td><td>number</td><td>—</td><td class="desc">0–100; deriva o nível se <code>level</code> não for passado</td></tr>
+  <tr><td><code>level</code></td><td>string</td><td>—</td><td class="desc">high · medium · low (sobrepõe value)</td></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"chip"</td><td class="desc">chip · bar · dot</td></tr>
+  <tr><td><code>showValue</code></td><td>boolean</td><td>true</td><td class="desc">Exibe % (quando value é passado)</td></tr>
+  <tr><td><code>label</code></td><td>node</td><td>auto</td><td class="desc">Rótulo custom; default: "Alta confiança" / "Revisar" / "Atenção"</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Sempre com contexto textual (Alta / Revisar / Atenção), nunca só cor.</li>
+      <li>Verde ≥ 95% · laranja 80-94% · vermelho < 80% (thresholds configuráveis por cliente).</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Cor isolada sem número nem label.</li>
+      <li>Thresholds inconsistentes entre telas do mesmo produto.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/ConfidenceIndicator/index.css
+++ b/ux_references/ui_kits/components/ConfidenceIndicator/index.css
@@ -1,0 +1,46 @@
+
+/* Base */
+.grd-ci { font-family: var(--font-sans); font-feature-settings: "tnum"; font-variant-numeric: tabular-nums; }
+
+/* Chip */
+.grd-ci-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.grd-ci-chip.grd-ci-sm { padding: 2px 7px; font-size: 11px; }
+.grd-ci-chip.grd-ci-md { font-size: 12px; }
+.grd-ci-chip .grd-ci-val { font-weight: 700; opacity: 0.85; padding-left: 3px; border-left: 1px solid currentColor; border-color: color-mix(in oklab, currentColor 25%, transparent); }
+
+.grd-ci-lv-high.grd-ci-chip   { background: var(--success-soft); color: color-mix(in oklab, var(--signal-green) 52%, black); border-color: color-mix(in oklab, var(--signal-green) 30%, white); }
+.grd-ci-lv-medium.grd-ci-chip { background: var(--yellow-100);   color: var(--yellow-900);                                         border-color: var(--yellow-200); }
+.grd-ci-lv-low.grd-ci-chip    { background: var(--danger-soft);  color: color-mix(in oklab, var(--signal-red)   45%, black); border-color: color-mix(in oklab, var(--signal-red)   30%, white); }
+
+/* Dot */
+.grd-ci-dot {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12.5px; color: var(--fg);
+}
+.grd-ci-dot .grd-ci-dot {
+  width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+}
+.grd-ci-lv-high.grd-ci-dot .grd-ci-dot   { background: var(--signal-green);  box-shadow: 0 0 0 2px color-mix(in oklab, var(--signal-green)  22%, transparent); }
+.grd-ci-lv-medium.grd-ci-dot .grd-ci-dot { background: var(--signal-yellow); box-shadow: 0 0 0 2px color-mix(in oklab, var(--signal-yellow) 28%, transparent); }
+.grd-ci-lv-low.grd-ci-dot .grd-ci-dot    { background: var(--signal-red);    box-shadow: 0 0 0 2px color-mix(in oklab, var(--signal-red)    28%, transparent); }
+
+/* Bar */
+.grd-ci-bar { display: flex; flex-direction: column; gap: 5px; min-width: 140px; }
+.grd-ci-bar-track { height: 5px; background: var(--gray-200); border-radius: var(--radius-pill); overflow: hidden; }
+.grd-ci-bar-fill { height: 100%; border-radius: var(--radius-pill); transition: width 360ms var(--ease-standard); }
+.grd-ci-bar-meta { display: flex; align-items: center; justify-content: space-between; gap: 12px; font-size: 11.5px; }
+.grd-ci-bar-label { color: var(--fg-muted); font-weight: 500; }
+.grd-ci-bar-val { font-weight: 700; }
+
+.grd-ci-lv-high.grd-ci-bar .grd-ci-bar-fill   { background: var(--signal-green); }
+.grd-ci-lv-high.grd-ci-bar .grd-ci-bar-val    { color: color-mix(in oklab, var(--signal-green) 52%, black); }
+.grd-ci-lv-medium.grd-ci-bar .grd-ci-bar-fill { background: var(--signal-yellow); }
+.grd-ci-lv-medium.grd-ci-bar .grd-ci-bar-val  { color: var(--yellow-900); }
+.grd-ci-lv-low.grd-ci-bar .grd-ci-bar-fill    { background: var(--signal-red); }
+.grd-ci-lv-low.grd-ci-bar .grd-ci-bar-val     { color: color-mix(in oklab, var(--signal-red) 45%, black); }

--- a/ux_references/ui_kits/components/ConfidenceIndicator/index.tsx
+++ b/ux_references/ui_kits/components/ConfidenceIndicator/index.tsx
@@ -1,0 +1,80 @@
+
+/**
+ * ConfidenceIndicator — semáforo de confiança para outputs de IA.
+ *
+ * Códigos (alinhado ao sistema Lighthouse):
+ *   high:   verde  ≥ 95% — auto-aplicado
+ *   medium: ama/la 80-94% — revisar
+ *   low:    vermelho < 80% — requer decisão humana
+ *
+ * Variant:
+ *   chip (default) — selo compacto com texto
+ *   bar            — barra contínua
+ *   dot            — ponto mínimo
+ */
+
+type ConfidenceLevel = "high" | "medium" | "low";
+
+interface ConfidenceIndicatorProps {
+  value?: number;       // 0-100 (se passado, derivamos o level)
+  level?: ConfidenceLevel;
+  variant?: "chip" | "bar" | "dot";
+  showValue?: boolean;
+  label?: React.ReactNode;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+function deriveLevel(v: number): ConfidenceLevel {
+  if (v >= 95) return "high";
+  if (v >= 80) return "medium";
+  return "low";
+}
+const LABEL: Record<ConfidenceLevel, string> = {
+  high: "Alta confiança",
+  medium: "Revisar",
+  low: "Atenção",
+};
+
+function ConfidenceIndicator({
+  value, level, variant = "chip", showValue = true, label, size = "md", className = "",
+}: ConfidenceIndicatorProps) {
+  const lv: ConfidenceLevel = level ?? (value !== undefined ? deriveLevel(value) : "high");
+  const IconCmp = (window as any).Icon;
+  const cls = ["grd-ci", `grd-ci-${variant}`, `grd-ci-lv-${lv}`, `grd-ci-${size}`, className].filter(Boolean).join(" ");
+
+  if (variant === "dot") {
+    return <span className={cls} title={label ? undefined : LABEL[lv]}><span className="grd-ci-dot" />{label}</span>;
+  }
+
+  if (variant === "bar") {
+    const pct = value ?? (lv === "high" ? 97 : lv === "medium" ? 86 : 62);
+    return (
+      <div className={cls}>
+        <div className="grd-ci-bar-track">
+          <div className="grd-ci-bar-fill" style={{ width: `${pct}%` }} />
+        </div>
+        <div className="grd-ci-bar-meta">
+          <span className="grd-ci-bar-label">{label ?? LABEL[lv]}</span>
+          {showValue && value !== undefined && <span className="grd-ci-bar-val">{Math.round(value)}%</span>}
+        </div>
+      </div>
+    );
+  }
+
+  // chip
+  const ICON: Record<ConfidenceLevel, string> = {
+    high: "circle-check",
+    medium: "triangle-alert",
+    low: "circle-x",
+  };
+  return (
+    <span className={cls}>
+      {IconCmp && <IconCmp name={ICON[lv]} size={size === "sm" ? 12 : 14} />}
+      <span className="grd-ci-lab">{label ?? LABEL[lv]}</span>
+      {showValue && value !== undefined && <span className="grd-ci-val">{Math.round(value)}%</span>}
+    </span>
+  );
+}
+ConfidenceIndicator.displayName = "ConfidenceIndicator";
+(window as any).ConfidenceIndicator = ConfidenceIndicator;

--- a/ux_references/ui_kits/components/DataTable/DataTable.playground.html
+++ b/ux_references/ui_kits/components/DataTable/DataTable.playground.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>DataTable · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="../Checkbox/index.css">
+<link rel="stylesheet" href="../EmptyState/index.css">
+<link rel="stylesheet" href="../Badge/index.css">
+<link rel="stylesheet" href="../Avatar/index.css">
+<link rel="stylesheet" href="../IconButton/index.css">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">DATA · TABELA</div>
+  <h1 class="pg-title">DataTable</h1>
+  <span class="pg-codename">import DataTable from "ui_kits/components/DataTable"</span>
+  <p class="pg-desc">Tabela completa com ordenação, seleção, densidade configurável e render customizado por célula. Integra-se automaticamente com <code>Checkbox</code> e <code>EmptyState</code> quando disponíveis.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Checkbox/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Avatar/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../IconButton/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../EmptyState/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:'stretch'}}>{children}</div></div>);
+}
+
+const ROWS = [
+  { id:1, cliente:"Contábil Silva & Cia",  status:"conciliado",  valor: 128450.20, resp:"Ana Lima",     data:"12/03/2025" },
+  { id:2, cliente:"Escritório Nova Era",   status:"pendente",    valor:  34200.00, resp:"Bruno Castro", data:"11/03/2025" },
+  { id:3, cliente:"Prime Partners",        status:"divergente",  valor:  89120.75, resp:"Carla Diniz",  data:"11/03/2025" },
+  { id:4, cliente:"Martins Consultoria",   status:"conciliado",  valor:  12890.40, resp:"Daniel Efe",   data:"10/03/2025" },
+  { id:5, cliente:"Grupo Horizonte",       status:"pendente",    valor: 256700.90, resp:"Elisa Faria",  data:"10/03/2025" },
+];
+
+const fmtBRL = (v:number) => v.toLocaleString("pt-BR", { style:"currency", currency:"BRL" });
+
+function App() {
+  const [sel, setSel] = React.useState<Set<string|number>>(new Set([2]));
+
+  const cols = [
+    { id:"cliente", header:"Cliente", accessor:"cliente", sortable:true,
+      render:(v:string) => <div style={{display:"flex",alignItems:"center",gap:10}}>
+        <Avatar name={v} size="sm" color="violet" /><span>{v}</span>
+      </div>
+    },
+    { id:"status", header:"Status", accessor:"status", sortable:true,
+      render:(v:string) => {
+        const variant = v==="conciliado" ? "success" : v==="pendente" ? "warning" : "danger";
+        const label = v.charAt(0).toUpperCase() + v.slice(1);
+        return <Badge variant={variant}>{label}</Badge>;
+      }
+    },
+    { id:"valor", header:"Valor", accessor:"valor", align:"right" as const, sortable:true,
+      render:(v:number) => <span style={{fontFamily:"var(--font-mono)",fontSize:13}}>{fmtBRL(v)}</span>
+    },
+    { id:"resp", header:"Responsável", accessor:"resp", sortable:true },
+    { id:"data", header:"Atualizado em", accessor:"data", align:"right" as const },
+    { id:"acoes", header:"", width:40, align:"right" as const,
+      render:() => <IconButton icon="dots-vertical" variant="ghost" size="sm" aria-label="Ações" />
+    },
+  ];
+
+  return (<>
+    <Sec title="Completa — seleção + ordenação + render customizado">
+      <DataTable columns={cols} rows={ROWS} selectable selected={sel} onSelectedChange={setSel} defaultSort={{id:"valor",dir:"desc"}} rowKey={(r)=>r.id} />
+      <p style={{fontSize:12,color:"var(--gray-500)",margin:0}}>
+        Selecionados: <code style={{fontFamily:"var(--font-mono)",background:"var(--violet-100)",color:"var(--violet-700)",padding:"1px 6px",borderRadius: "var(--radius-sm)"}}>{[...sel].join(", ") || "—"}</code>
+      </p>
+    </Sec>
+
+    <Sec title="Densidades">
+      <p style={{fontSize:11,color:"var(--gray-500)",margin:"0 0 -4px",textTransform:"uppercase",letterSpacing:".08em"}}>Compact</p>
+      <DataTable columns={cols.slice(0,4)} rows={ROWS} density="compact" rowKey={(r)=>r.id} />
+      <p style={{fontSize:11,color:"var(--gray-500)",margin:"12px 0 -4px",textTransform:"uppercase",letterSpacing:".08em"}}>Comfortable</p>
+      <DataTable columns={cols.slice(0,4)} rows={ROWS.slice(0,3)} density="comfortable" rowKey={(r)=>r.id} />
+    </Sec>
+
+    <Sec title="Vazio">
+      <DataTable columns={cols.slice(0,4)} rows={[]} emptyText="Nenhuma conciliação no período" emptyIcon="inbox" rowKey={(r)=>r.id} />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["DataTable"]) || "render(<div>Sem exemplo para DataTable</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>columns</code></td><td>DTColumn[]</td><td>—</td><td class="desc">id · header · accessor · sortable · render · align · width</td></tr>
+  <tr><td><code>rows</code></td><td>any[]</td><td>—</td><td class="desc">Dados a exibir</td></tr>
+  <tr><td><code>rowKey</code></td><td>(row, i) =&gt; id</td><td>row.id ?? i</td><td class="desc">Chave estável de linha</td></tr>
+  <tr><td><code>selectable</code></td><td>boolean</td><td>false</td><td class="desc">Checkbox por linha + "selecionar todos"</td></tr>
+  <tr><td><code>density</code></td><td>string</td><td>"normal"</td><td class="desc">compact · normal · comfortable</td></tr>
+  <tr><td><code>stickyHeader</code></td><td>boolean</td><td>false</td><td class="desc">Cabeçalho fixo em scroll</td></tr>
+  <tr><td><code>sort</code>/<code>defaultSort</code></td><td>{id,dir}</td><td>null</td><td class="desc">Ordenação controlada/inicial</td></tr>
+  <tr><td><code>onRowClick</code></td><td>(row) =&gt; void</td><td>—</td><td class="desc">Click em linha inteira</td></tr>
+  <tr><td><code>emptyText</code>/<code>emptyIcon</code></td><td>ReactNode/IconName</td><td>"Sem dados"/"inbox"</td><td class="desc">Estado vazio</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Listas tabulares com ordenação, seleção em lote e densidade configurável.</li>
+      <li>Primeira coluna com identidade (nome/descrição), últimas com ações.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Cards disfarçados de tabela — se cada linha tem 3+ ações, reconsidere.</li>
+      <li>Scroll horizontal sem coluna fixa.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/DataTable/index.css
+++ b/ux_references/ui_kits/components/DataTable/index.css
@@ -1,0 +1,48 @@
+
+.grd-dt {
+  font-family: var(--font-sans);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden; /* clip inner table corners */
+}
+.grd-dt table {
+  width: 100%; border-collapse: separate; border-spacing: 0;
+  font-size: 13.5px; color: var(--fg);
+}
+.grd-dt thead th {
+  background: var(--gray-50);
+  color: var(--fg-muted);
+  text-align: left; font-weight: 600;
+  font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 14px;
+  user-select: none;
+  white-space: nowrap;
+}
+.grd-dt-sticky thead th { position: sticky; top: 0; z-index: 1; }
+.grd-dt-th-sort { cursor: pointer; }
+.grd-dt-th-sort:hover { color: var(--fg); background: var(--gray-100); }
+.grd-dt-th-lbl { display: inline-flex; align-items: center; gap: 6px; }
+.grd-dt-sort-ic { color: var(--gray-400); display: inline-flex; }
+.grd-dt-sort-cur { color: var(--violet-600); }
+
+.grd-dt tbody tr + tr td { border-top: 1px solid var(--border); }
+.grd-dt tbody tr:hover:not(.grd-dt-row-sel) { background: var(--violet-50); }
+.grd-dt-clickable tbody tr { cursor: pointer; }
+.grd-dt-row-sel { background: var(--violet-50); }
+.grd-dt td {
+  padding: 12px 14px;
+  vertical-align: middle;
+  line-height: 1.5;
+}
+.grd-dt-compact td,
+.grd-dt-compact th { padding: 7px 12px; }
+.grd-dt-comfortable td,
+.grd-dt-comfortable th { padding: 16px 18px; }
+
+.grd-dt-a-right  { text-align: right; font-feature-settings: "tnum"; font-variant-numeric: tabular-nums; }
+.grd-dt-a-center { text-align: center; }
+
+.grd-dt-sel { width: 40px; text-align: center; padding-right: 0 !important; }
+.grd-dt-empty { padding: 36px; text-align: center; color: var(--fg-muted); }

--- a/ux_references/ui_kits/components/DataTable/index.tsx
+++ b/ux_references/ui_kits/components/DataTable/index.tsx
@@ -1,0 +1,202 @@
+
+/**
+ * DataTable — tabela de dados com ordenação e seleção opcional.
+ *
+ * Props:
+ *   columns: { id, header, accessor(row)|key, width, align, sortable, render(v,row) }[]
+ *   rows:    any[]
+ *   rowKey?: (row) => string (default: row.id || index)
+ *   selectable?: boolean   - checkbox por linha
+ *   onRowClick?: (row) => void
+ *   emptyText?: string
+ *   density?: "compact" | "normal" | "comfortable"
+ *   stickyHeader?: boolean
+ *   sort?: { id: string; dir: "asc" | "desc" } | null   (controlado)
+ *   defaultSort?: same shape (não controlado)
+ *   onSortChange?: (sort) => void
+ */
+
+interface DTColumn<T = any> {
+  id: string;
+  header: React.ReactNode;
+  accessor?: keyof T | ((row: T) => any);
+  width?: number | string;
+  align?: "left" | "right" | "center";
+  sortable?: boolean;
+  render?: (value: any, row: T) => React.ReactNode;
+  className?: string;
+}
+interface DataTableProps<T = any> {
+  columns: DTColumn<T>[];
+  rows: T[];
+  rowKey?: (row: T, index: number) => string | number;
+  selectable?: boolean;
+  selected?: Set<string | number>;
+  onSelectedChange?: (s: Set<string | number>) => void;
+  onRowClick?: (row: T) => void;
+  emptyText?: React.ReactNode;
+  emptyIcon?: string;
+  density?: "compact" | "normal" | "comfortable";
+  stickyHeader?: boolean;
+  sort?: { id: string; dir: "asc" | "desc" } | null;
+  defaultSort?: { id: string; dir: "asc" | "desc" };
+  onSortChange?: (s: { id: string; dir: "asc" | "desc" } | null) => void;
+  className?: string;
+}
+
+function getVal(row: any, col: DTColumn) {
+  if (typeof col.accessor === "function") return col.accessor(row);
+  if (typeof col.accessor === "string") return row[col.accessor];
+  return row[col.id];
+}
+
+function DataTable<T extends Record<string, any> = any>({
+  columns, rows, rowKey, selectable, selected, onSelectedChange,
+  onRowClick, emptyText = "Sem dados", emptyIcon = "inbox",
+  density = "normal", stickyHeader = false,
+  sort, defaultSort, onSortChange, className = "",
+}: DataTableProps<T>) {
+  const IconCmp = (window as any).Icon;
+  const CheckboxCmp = (window as any).Checkbox;
+  const EmptyStateCmp = (window as any).EmptyState;
+
+  const [internalSort, setInternalSort] = React.useState<{ id: string; dir: "asc" | "desc" } | null>(defaultSort ?? null);
+  const current = sort !== undefined ? sort : internalSort;
+
+  const [internalSel, setInternalSel] = React.useState<Set<string | number>>(new Set());
+  const sel = selected !== undefined ? selected : internalSel;
+  const setSel = (next: Set<string | number>) => {
+    if (selected === undefined) setInternalSel(next);
+    onSelectedChange?.(next);
+  };
+  const rk = rowKey ?? ((r: any, i: number) => (r.id ?? r.key ?? i));
+
+  const sortedRows = React.useMemo(() => {
+    if (!current) return rows;
+    const col = columns.find(c => c.id === current.id);
+    if (!col) return rows;
+    const arr = [...rows];
+    arr.sort((a, b) => {
+      const va = getVal(a, col);
+      const vb = getVal(b, col);
+      if (va == null && vb == null) return 0;
+      if (va == null) return 1;
+      if (vb == null) return -1;
+      if (typeof va === "number" && typeof vb === "number") return current.dir === "asc" ? va - vb : vb - va;
+      const sa = String(va).toLocaleLowerCase("pt-BR");
+      const sb = String(vb).toLocaleLowerCase("pt-BR");
+      const cmp = sa.localeCompare(sb, "pt-BR");
+      return current.dir === "asc" ? cmp : -cmp;
+    });
+    return arr;
+  }, [rows, columns, current]);
+
+  function toggleSort(col: DTColumn) {
+    if (!col.sortable) return;
+    let next: { id: string; dir: "asc" | "desc" } | null;
+    if (!current || current.id !== col.id) next = { id: col.id, dir: "asc" };
+    else if (current.dir === "asc") next = { id: col.id, dir: "desc" };
+    else next = null;
+    if (sort === undefined) setInternalSort(next);
+    onSortChange?.(next);
+  }
+
+  const allSel = rows.length > 0 && rows.every((r, i) => sel.has(rk(r, i)));
+  const someSel = rows.some((r, i) => sel.has(rk(r, i))) && !allSel;
+
+  function toggleAll() {
+    if (allSel) setSel(new Set());
+    else setSel(new Set(rows.map((r, i) => rk(r, i))));
+  }
+  function toggleOne(k: string | number) {
+    const next = new Set(sel);
+    if (next.has(k)) next.delete(k); else next.add(k);
+    setSel(next);
+  }
+
+  const cls = [
+    "grd-dt",
+    `grd-dt-${density}`,
+    stickyHeader && "grd-dt-sticky",
+    onRowClick && "grd-dt-clickable",
+    className,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <div className={cls}>
+      <table>
+        <thead>
+          <tr>
+            {selectable && (
+              <th className="grd-dt-sel">
+                {CheckboxCmp && <CheckboxCmp checked={allSel} indeterminate={someSel} onChange={toggleAll} size="sm" />}
+              </th>
+            )}
+            {columns.map(col => {
+              const isCur = current?.id === col.id;
+              const cls = ["grd-dt-th", col.sortable && "grd-dt-th-sort", col.align && `grd-dt-a-${col.align}`].filter(Boolean).join(" ");
+              return (
+                <th
+                  key={col.id}
+                  className={cls}
+                  style={{ width: col.width }}
+                  onClick={() => toggleSort(col)}
+                >
+                  <span className="grd-dt-th-lbl">
+                    {col.header}
+                    {col.sortable && IconCmp && (
+                      <span className={`grd-dt-sort-ic ${isCur ? "grd-dt-sort-cur" : ""}`}>
+                        <IconCmp
+                          name={isCur && current!.dir === "desc" ? "arrow-down" : isCur ? "arrow-up" : "chevrons-up-down"}
+                          size={12}
+                        />
+                      </span>
+                    )}
+                  </span>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {sortedRows.length === 0 ? (
+            <tr>
+              <td colSpan={columns.length + (selectable ? 1 : 0)}>
+                {EmptyStateCmp
+                  ? <EmptyStateCmp icon={emptyIcon} title={emptyText} size="sm" />
+                  : <div className="grd-dt-empty">{emptyText}</div>}
+              </td>
+            </tr>
+          ) : sortedRows.map((row, i) => {
+            const k = rk(row, i);
+            const isSel = sel.has(k);
+            return (
+              <tr
+                key={k}
+                className={isSel ? "grd-dt-row-sel" : ""}
+                onClick={() => onRowClick?.(row)}
+              >
+                {selectable && (
+                  <td className="grd-dt-sel" onClick={(e) => e.stopPropagation()}>
+                    {CheckboxCmp && <CheckboxCmp checked={isSel} onChange={() => toggleOne(k)} size="sm" />}
+                  </td>
+                )}
+                {columns.map(col => {
+                  const v = getVal(row, col);
+                  const cellCls = ["grd-dt-td", col.align && `grd-dt-a-${col.align}`, col.className].filter(Boolean).join(" ");
+                  return (
+                    <td key={col.id} className={cellCls}>
+                      {col.render ? col.render(v, row) : v as any}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+DataTable.displayName = "DataTable";
+(window as any).DataTable = DataTable;

--- a/ux_references/ui_kits/components/DatePicker/DatePicker.playground.html
+++ b/ux_references/ui_kits/components/DatePicker/DatePicker.playground.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>DatePicker · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Label/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORM · DATA</div>
+  <h1 class="pg-title">DatePicker</h1>
+  <span class="pg-codename">import DatePicker from "ui_kits/components/DatePicker"</span>
+  <p class="pg-desc">Seletor de data única. Calendário em pt-BR, formato <code>dd/mm/aaaa</code>, com "Hoje" e limpar.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Label/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,gap:14,flexWrap:"wrap"}}>{children}</div></div>);
+}
+
+function App() {
+  const [d1, setD1] = React.useState<Date | null>(new Date(2026, 3, 15));
+  const [d2, setD2] = React.useState<Date | null>(null);
+  const today = new Date();
+  const minBiz = new Date(today.getFullYear(), today.getMonth(), 1);
+  const maxBiz = new Date(today.getFullYear(), today.getMonth() + 3, 0);
+
+  return (<>
+    <Sec title="Padrão">
+      <div style={{display:"flex",flexDirection:"column",gap:6,minWidth:220}}>
+        <Label>Data de competência</Label>
+        <DatePicker value={d1} onChange={setD1} />
+      </div>
+      <div style={{display:"flex",flexDirection:"column",gap:6,minWidth:220}}>
+        <Label>Vencimento</Label>
+        <DatePicker value={d2} onChange={setD2} placeholder="Escolha a data" />
+      </div>
+    </Sec>
+
+    <Sec title="Com limites (min/max)">
+      <div style={{display:"flex",flexDirection:"column",gap:6,minWidth:240}}>
+        <Label>Data de vencimento (próximos 3 meses)</Label>
+        <DatePicker min={minBiz} max={maxBiz} />
+      </div>
+    </Sec>
+
+    <Sec title="Tamanhos">
+      <DatePicker size="sm" placeholder="sm" />
+      <DatePicker size="md" placeholder="md (padrão)" />
+      <DatePicker size="lg" placeholder="lg" />
+    </Sec>
+
+    <Sec title="Estados">
+      <DatePicker placeholder="Inválido" invalid />
+      <DatePicker placeholder="Desabilitado" disabled defaultValue={new Date()} />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["DatePicker"]) || "render(<div>Sem exemplo para DatePicker</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>value</code> · <code>onChange</code></td><td>Date|null · fn</td><td>—</td><td class="desc">Controlado</td></tr>
+  <tr><td><code>defaultValue</code></td><td>Date|null</td><td>—</td><td class="desc">Não controlado</td></tr>
+  <tr><td><code>min</code> · <code>max</code></td><td>Date</td><td>—</td><td class="desc">Limites inclusivos</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>invalid</code> · <code>disabled</code></td><td>boolean</td><td>—</td><td class="desc">Estados</td></tr>
+  <tr><td><code>placeholder</code></td><td>string</td><td>"dd/mm/aaaa"</td><td class="desc">Texto vazio</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Selecionar datas fiscais, períodos contábeis; presets "hoje/semana/mês" quando houver range.</li>
+      <li>Formato <code>dd/mm/aaaa</code> por padrão.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Campos de data sem máscara em inputs críticos.</li>
+      <li>Permitir datas futuras em apuração retroativa.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/DatePicker/index.css
+++ b/ux_references/ui_kits/components/DatePicker/index.css
@@ -1,0 +1,82 @@
+
+.grd-dp { position: relative; display: inline-block; font-family: var(--font-sans); width: 100%; }
+.grd-dp-trigger {
+  display: inline-flex; align-items: center; gap: 8px;
+  width: 100%;
+  background: var(--surface); border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md); text-align: left; cursor: pointer;
+  font-family: inherit; color: var(--fg);
+  transition: border-color 140ms, box-shadow 140ms;
+}
+.grd-dp-sm .grd-dp-trigger { padding: 6px 10px; font-size: 13px; height: 32px; }
+.grd-dp-md .grd-dp-trigger { padding: 8px 12px; font-size: 14px; height: 38px; }
+.grd-dp-lg .grd-dp-trigger { padding: 10px 14px; font-size: 15px; height: 46px; }
+
+.grd-dp-trigger:hover:not(:disabled) { border-color: var(--violet-300); }
+.grd-dp-open .grd-dp-trigger,
+.grd-dp-trigger:focus-visible { border-color: var(--violet-500); box-shadow: var(--focus-ring); outline: none; }
+.grd-dp-invalid .grd-dp-trigger { border-color: var(--signal-red); }
+.grd-dp-invalid .grd-dp-trigger:focus-visible { box-shadow: var(--focus-ring-error); outline: none; }
+.grd-dp-disabled .grd-dp-trigger { background: var(--gray-100); cursor: not-allowed; opacity: 0.7; }
+
+.grd-dp-ic { color: var(--gray-500); display: inline-flex; }
+.grd-dp-val { flex: 1; font-feature-settings: "tnum"; font-variant-numeric: tabular-nums; }
+.grd-dp-val-ph { color: var(--gray-400); }
+.grd-dp-clear { width: 18px; height: 18px; border-radius: 50%; border: 0; background: transparent; color: var(--gray-500); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; }
+.grd-dp-clear:hover { background: var(--gray-100); color: var(--fg); }
+
+.grd-dp-pop {
+  position: absolute; top: calc(100% + 4px); left: 0;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-xl); box-shadow: var(--shadow-lg);
+  padding: 10px; z-index: 50; width: 280px;
+  animation: grd-dp-in 140ms var(--ease-out);
+}
+@keyframes grd-dp-in { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+
+.grd-dp-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 4px;
+  margin-bottom: 6px;
+}
+.grd-dp-nav {
+  width: 28px; height: 28px; border-radius: var(--radius-md);
+  border: 0; background: transparent; color: var(--fg);
+  cursor: pointer; display: inline-flex; align-items: center; justify-content: center;
+}
+.grd-dp-nav:hover { background: var(--violet-50); color: var(--violet-700); }
+.grd-dp-title { font-size: 13.5px; font-weight: 600; color: var(--fg); }
+
+.grd-dp-wdays {
+  display: grid; grid-template-columns: repeat(7, 1fr);
+  font-size: 11px; font-weight: 600; color: var(--gray-500);
+  text-transform: uppercase; letter-spacing: 0.02em;
+  margin-bottom: 4px;
+}
+.grd-dp-wdays span { text-align: center; padding: 4px 0; }
+
+.grd-dp-grid {
+  display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px;
+}
+.grd-dp-cell {
+  aspect-ratio: 1;
+  border: 0; background: transparent;
+  font-family: inherit; font-size: 13px; color: var(--fg);
+  border-radius: var(--radius-md); cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-feature-settings: "tnum"; font-variant-numeric: tabular-nums;
+  transition: background 120ms, color 120ms;
+}
+.grd-dp-cell:hover:not(:disabled) { background: var(--violet-50); color: var(--violet-700); }
+.grd-dp-cell-out { color: var(--gray-400); }
+.grd-dp-cell-today { font-weight: 700; color: var(--violet-600); }
+.grd-dp-cell-sel,
+.grd-dp-cell-sel:hover { background: var(--violet-500); color: var(--surface); font-weight: 600; }
+.grd-dp-cell-dis { opacity: 0.35; cursor: not-allowed; }
+
+.grd-dp-foot { display: flex; justify-content: flex-end; padding-top: 8px; margin-top: 8px; border-top: 1px solid var(--border); }
+.grd-dp-today {
+  border: 0; background: transparent;
+  font-family: inherit; font-size: 12px; font-weight: 600;
+  color: var(--violet-600); cursor: pointer; padding: 4px 8px; border-radius: var(--radius-sm);
+}
+.grd-dp-today:hover { background: var(--violet-50); }

--- a/ux_references/ui_kits/components/DatePicker/index.tsx
+++ b/ux_references/ui_kits/components/DatePicker/index.tsx
@@ -1,0 +1,179 @@
+
+/**
+ * DatePicker — seletor de data única.
+ * Props: value (Date | null), onChange, placeholder, size, min, max, invalid.
+ * Para range, use <DateRangePicker />.
+ */
+
+interface DatePickerProps {
+  value?: Date | null;
+  defaultValue?: Date | null;
+  onChange?: (date: Date | null) => void;
+  placeholder?: string;
+  size?: "sm" | "md" | "lg";
+  min?: Date;
+  max?: Date;
+  invalid?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+const DP_MONTHS = ["Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro"];
+const DP_WDAYS  = ["D","S","T","Q","Q","S","S"];
+
+function fmtBR(d: Date | null | undefined): string {
+  if (!d) return "";
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${p(d.getDate())}/${p(d.getMonth()+1)}/${d.getFullYear()}`;
+}
+function sameDay(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function DatePicker({
+  value,
+  defaultValue,
+  onChange,
+  placeholder = "dd/mm/aaaa",
+  size = "md",
+  min,
+  max,
+  invalid,
+  disabled,
+  className = "",
+}: DatePickerProps) {
+  const IconCmp = (window as any).Icon;
+  const [open, setOpen] = React.useState(false);
+  const [internal, setInternal] = React.useState<Date | null>(defaultValue ?? null);
+  const current = value !== undefined ? value : internal;
+  const [viewDate, setViewDate] = React.useState<Date>(current ?? new Date());
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const today = new Date();
+
+  const cells: Array<{ date: Date; inMonth: boolean; disabled: boolean } | null> = [];
+  // Leading blanks
+  const prevMonthLast = new Date(year, month, 0).getDate();
+  for (let i = firstDay - 1; i >= 0; i--) {
+    const d = new Date(year, month - 1, prevMonthLast - i);
+    cells.push({ date: d, inMonth: false, disabled: isOut(d, min, max) });
+  }
+  for (let i = 1; i <= daysInMonth; i++) {
+    const d = new Date(year, month, i);
+    cells.push({ date: d, inMonth: true, disabled: isOut(d, min, max) });
+  }
+  // Trailing to fill 6 rows
+  while (cells.length < 42) {
+    const last = cells[cells.length - 1]!.date;
+    const d = new Date(last.getFullYear(), last.getMonth(), last.getDate() + 1);
+    cells.push({ date: d, inMonth: false, disabled: isOut(d, min, max) });
+  }
+
+  function pick(d: Date) {
+    if (value === undefined) setInternal(d);
+    onChange?.(d);
+    setOpen(false);
+  }
+
+  function clear(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (value === undefined) setInternal(null);
+    onChange?.(null);
+  }
+
+  const cls = [
+    "grd-dp",
+    `grd-dp-${size}`,
+    invalid && "grd-dp-invalid",
+    disabled && "grd-dp-disabled",
+    open && "grd-dp-open",
+    className,
+  ].filter(Boolean).join(" ");
+  const iconSize = size === "sm" ? 13 : size === "lg" ? 18 : 15;
+
+  return (
+    <div ref={rootRef} className={cls}>
+      <button
+        type="button" className="grd-dp-trigger"
+        onClick={() => !disabled && setOpen(o => !o)}
+        disabled={disabled}
+        aria-haspopup="dialog" aria-expanded={open}
+      >
+        {IconCmp && <span className="grd-dp-ic"><IconCmp name="calendar" size={iconSize} /></span>}
+        <span className={`grd-dp-val ${!current ? "grd-dp-val-ph" : ""}`}>
+          {current ? fmtBR(current) : placeholder}
+        </span>
+        {current && !disabled && IconCmp && (
+          <button type="button" className="grd-dp-clear" onClick={clear} aria-label="Limpar">
+            <IconCmp name="x" size={iconSize - 1} />
+          </button>
+        )}
+      </button>
+
+      {open && (
+        <div className="grd-dp-pop" role="dialog">
+          <div className="grd-dp-head">
+            <button type="button" className="grd-dp-nav" onClick={() => setViewDate(new Date(year, month - 1, 1))} aria-label="Mês anterior">
+              {IconCmp && <IconCmp name="chevron-left" size={15} />}
+            </button>
+            <span className="grd-dp-title">{DP_MONTHS[month]} {year}</span>
+            <button type="button" className="grd-dp-nav" onClick={() => setViewDate(new Date(year, month + 1, 1))} aria-label="Próximo mês">
+              {IconCmp && <IconCmp name="chevron-right" size={15} />}
+            </button>
+          </div>
+          <div className="grd-dp-wdays">
+            {DP_WDAYS.map((w, i) => <span key={i}>{w}</span>)}
+          </div>
+          <div className="grd-dp-grid">
+            {cells.map((c, i) => {
+              if (!c) return <span key={i} />;
+              const isToday = sameDay(c.date, today);
+              const isSel = current && sameDay(c.date, current);
+              return (
+                <button
+                  key={i} type="button"
+                  className={[
+                    "grd-dp-cell",
+                    !c.inMonth && "grd-dp-cell-out",
+                    isToday && "grd-dp-cell-today",
+                    isSel && "grd-dp-cell-sel",
+                    c.disabled && "grd-dp-cell-dis",
+                  ].filter(Boolean).join(" ")}
+                  onClick={() => !c.disabled && pick(c.date)}
+                  disabled={c.disabled}
+                >
+                  {c.date.getDate()}
+                </button>
+              );
+            })}
+          </div>
+          <div className="grd-dp-foot">
+            <button type="button" className="grd-dp-today" onClick={() => pick(new Date())}>Hoje</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function isOut(d: Date, min?: Date, max?: Date): boolean {
+  if (min && d < new Date(min.getFullYear(), min.getMonth(), min.getDate())) return true;
+  if (max && d > new Date(max.getFullYear(), max.getMonth(), max.getDate())) return true;
+  return false;
+}
+
+DatePicker.displayName = "DatePicker";
+(window as any).DatePicker = DatePicker;

--- a/ux_references/ui_kits/components/Dialog/Dialog.playground.html
+++ b/ux_references/ui_kits/components/Dialog/Dialog.playground.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Dialog · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="../Label/index.css">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">OVERLAYS · MODAL</div>
+  <h1 class="pg-title">Dialog</h1>
+  <span class="pg-codename">import Dialog from "ui_kits/components/Dialog"</span>
+  <p class="pg-desc">Modal centralizado com backdrop. Três tamanhos, fechamento por ESC/backdrop/botão, portal para <code>document.body</code>. Para formulários longos prefira <code>Drawer</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Input/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Label/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage">{children}</div></div>);
+}
+
+function App() {
+  const [open, setOpen] = React.useState<string | null>(null);
+  const close = () => setOpen(null);
+
+  return (<>
+    <Sec title="Tamanhos">
+      <Button onClick={() => setOpen("sm")}>Abrir · Small</Button>
+      <Button onClick={() => setOpen("md")}>Abrir · Medium</Button>
+      <Button onClick={() => setOpen("lg")}>Abrir · Large</Button>
+    </Sec>
+
+    <Sec title="Casos de uso">
+      <Button variant="destructive" leftIcon="trash" onClick={() => setOpen("confirm")}>Excluir cliente</Button>
+      <Button variant="accent" leftIcon="plus" onClick={() => setOpen("form")}>Novo agente</Button>
+      <Button variant="outline" leftIcon="info" onClick={() => setOpen("info")}>Sobre conciliação</Button>
+    </Sec>
+
+    {/* small */}
+    <Dialog open={open==="sm"} onClose={close} size="sm" title="Título pequeno" description="Descrição curta para contexto.">
+      <p style={{margin:0,fontSize:13,lineHeight:1.6,color:"var(--gray-700)"}}>Corpo do dialog pequeno. Ideal para avisos rápidos.</p>
+    </Dialog>
+    {/* medium */}
+    <Dialog open={open==="md"} onClose={close} size="md" title="Médio (default)" description="Tamanho padrão para a maioria dos casos."
+      footer={<><Button variant="ghost" onClick={close}>Cancelar</Button><Button variant="primary" onClick={close}>Confirmar</Button></>}>
+      <p style={{margin:0,fontSize:13,lineHeight:1.6,color:"var(--gray-700)"}}>Conteúdo principal vai aqui. Botões ficam no <code>footer</code>.</p>
+    </Dialog>
+    {/* large */}
+    <Dialog open={open==="lg"} onClose={close} size="lg" title="Grande" description="Para conteúdo denso ou visualizações.">
+      <p style={{margin:0,fontSize:13,lineHeight:1.6,color:"var(--gray-700)"}}>Tamanho grande acomoda tabelas, gráficos ou multi-coluna.</p>
+    </Dialog>
+
+    {/* confirmação destrutiva */}
+    <Dialog open={open==="confirm"} onClose={close} size="sm"
+      title="Excluir Contábil Silva & Cia?"
+      description="Esta ação é permanente. 248 conciliações históricas serão preservadas, mas o cliente não receberá novos fluxos."
+      footer={<><Button variant="ghost" onClick={close}>Cancelar</Button><Button variant="destructive" leftIcon="trash" onClick={close}>Sim, excluir</Button></>}>
+    </Dialog>
+
+    {/* formulário */}
+    <Dialog open={open==="form"} onClose={close} size="md" title="Novo agente" description="Configure um agente para conciliar uma fonte específica."
+      footer={<><Button variant="ghost" onClick={close}>Cancelar</Button><Button variant="accent" onClick={close}>Criar agente</Button></>}>
+      <div style={{display:"flex",flexDirection:"column",gap:14}}>
+        <div><Label required>Nome do agente</Label><Input placeholder="Ex: Bia · Conciliação Bancária" /></div>
+        <div><Label>Fonte primária</Label><Input leftIcon="database" placeholder="Banco Inter · CNPJ 12.345..." /></div>
+        <div><Label description="O agente só executa dentro dessa janela">Horário de operação</Label>
+          <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:10}}>
+            <Input prefix="De" defaultValue="08:00" />
+            <Input prefix="Até" defaultValue="20:00" />
+          </div>
+        </div>
+      </div>
+    </Dialog>
+
+    {/* info */}
+    <Dialog open={open==="info"} onClose={close} size="md" title="Como funciona a conciliação automática"
+      footer={<Button onClick={close}>Entendi</Button>}>
+      <div style={{display:"flex",flexDirection:"column",gap:10,fontSize:13,lineHeight:1.6,color:"var(--gray-700)"}}>
+        <p style={{margin:0}}>A Bia compara cada lançamento bancário com lançamentos contábeis em até 3 dimensões: valor exato, janela de datas (±3d) e similaridade textual.</p>
+        <p style={{margin:0}}>Matches com confiança ≥ 95% são auto-aprovados (se você ativar o autopilot). Os demais vão para sua fila de revisão.</p>
+      </div>
+    </Dialog>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Dialog"]) || "render(<div>Sem exemplo para Dialog</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>open</code></td><td>boolean</td><td>—</td><td class="desc">Controla visibilidade</td></tr>
+  <tr><td><code>onClose</code></td><td>() =&gt; void</td><td>—</td><td class="desc">Obrigatório · chamado em ESC, backdrop e X</td></tr>
+  <tr><td><code>title</code>/<code>description</code></td><td>ReactNode</td><td>—</td><td class="desc">Cabeçalho</td></tr>
+  <tr><td><code>children</code></td><td>ReactNode</td><td>—</td><td class="desc">Corpo do modal</td></tr>
+  <tr><td><code>footer</code></td><td>ReactNode</td><td>—</td><td class="desc">Área de ações à direita</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>closeOnBackdrop</code></td><td>boolean</td><td>true</td><td class="desc">Click no backdrop fecha</td></tr>
+  <tr><td><code>showClose</code></td><td>boolean</td><td>true</td><td class="desc">Exibe X no cabeçalho</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Confirmação de ação irreversível (excluir cliente, enviar para SEFAZ).</li>
+      <li>Um foco de ação; botão primário à direita, cancelar como ghost.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Formulários longos — use <code>Drawer</code>.</li>
+      <li>Dialogs aninhados.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Dialog/index.css
+++ b/ux_references/ui_kits/components/Dialog/index.css
@@ -1,0 +1,58 @@
+
+.grd-dlg-backdrop {
+  position: fixed; inset: 0; z-index: 1000;
+  background: color-mix(in oklab, var(--violet-900) 65%, transparent);
+  display: flex; align-items: center; justify-content: center;
+  padding: 20px;
+  animation: grd-dlg-fade 160ms var(--ease-out);
+}
+@keyframes grd-dlg-fade { from { opacity: 0; } to { opacity: 1; } }
+.grd-dlg {
+  background: var(--surface);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xl);
+  width: 100%;
+  max-height: calc(100vh - 40px);
+  display: flex; flex-direction: column;
+  font-family: var(--font-sans);
+  animation: grd-dlg-in 180ms var(--ease-out);
+  overflow: hidden;
+}
+@keyframes grd-dlg-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+.grd-dlg-sm { max-width: 380px; }
+.grd-dlg-md { max-width: 520px; }
+.grd-dlg-lg { max-width: 720px; }
+
+.grd-dlg-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+  padding: 18px 20px 12px;
+}
+.grd-dlg-titlewrap { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.grd-dlg-title {
+  font-size: 17px; font-weight: 600; color: var(--fg);
+  margin: 0; line-height: 1.35;
+}
+.grd-dlg-desc {
+  font-size: 13.5px; color: var(--fg-muted);
+  margin: 0; line-height: 1.5;
+}
+.grd-dlg-close {
+  width: 28px; height: 28px; border-radius: var(--radius-md);
+  border: 0; background: transparent; color: var(--fg-muted); cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+.grd-dlg-close:hover { background: var(--gray-100); color: var(--fg); }
+
+.grd-dlg-body {
+  padding: 4px 20px 20px;
+  overflow-y: auto;
+  font-size: 14px; color: var(--fg); line-height: 1.55;
+}
+.grd-dlg-foot {
+  display: flex; justify-content: flex-end; gap: 8px;
+  padding: 14px 20px; border-top: 1px solid var(--border);
+  background: var(--gray-50);
+}

--- a/ux_references/ui_kits/components/Dialog/index.tsx
+++ b/ux_references/ui_kits/components/Dialog/index.tsx
@@ -1,0 +1,64 @@
+
+/**
+ * Dialog — modal centrado. Usar para decisões críticas ou fluxos curtos que exigem foco total.
+ * Props: open, onClose, title, description, children, footer, size.
+ * Não montar sem onClose; sempre fechável por ESC + backdrop.
+ */
+
+interface DialogProps {
+  open: boolean;
+  onClose: () => void;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  children?: React.ReactNode;
+  footer?: React.ReactNode;
+  size?: "sm" | "md" | "lg";
+  closeOnBackdrop?: boolean;
+  showClose?: boolean;
+}
+
+function Dialog({
+  open, onClose, title, description, children, footer,
+  size = "md", closeOnBackdrop = true, showClose = true,
+}: DialogProps) {
+  const IconCmp = (window as any).Icon;
+
+  React.useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.removeEventListener("keydown", onKey); document.body.style.overflow = prev; };
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return ReactDOM.createPortal(
+    <div className="grd-dlg-backdrop" onClick={() => closeOnBackdrop && onClose()}>
+      <div
+        className={`grd-dlg grd-dlg-${size}`}
+        role="dialog" aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {(title || showClose) && (
+          <div className="grd-dlg-head">
+            <div className="grd-dlg-titlewrap">
+              {title && <h2 className="grd-dlg-title">{title}</h2>}
+              {description && <p className="grd-dlg-desc">{description}</p>}
+            </div>
+            {showClose && IconCmp && (
+              <button className="grd-dlg-close" onClick={onClose} aria-label="Fechar">
+                <IconCmp name="x" size={16} />
+              </button>
+            )}
+          </div>
+        )}
+        {children && <div className="grd-dlg-body">{children}</div>}
+        {footer && <div className="grd-dlg-foot">{footer}</div>}
+      </div>
+    </div>,
+    document.body
+  );
+}
+Dialog.displayName = "Dialog";
+(window as any).Dialog = Dialog;

--- a/ux_references/ui_kits/components/Drawer/Drawer.playground.html
+++ b/ux_references/ui_kits/components/Drawer/Drawer.playground.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Drawer · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="../Label/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">OVERLAY · PAINEL LATERAL</div>
+  <h1 class="pg-title">Drawer</h1>
+  <span class="pg-codename">import Drawer from "ui_kits/components/Drawer"</span>
+  <p class="pg-desc">Painel lateral para detalhes, filtros ou formulários secundários sem tirar o usuário da tela principal. Fecha com ESC, backdrop ou X.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Input/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Label/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{gap:14,padding:32,flexWrap:"wrap"}}>{children}</div></div>);
+}
+function App() {
+  const [open, setOpen] = React.useState<null | "sm" | "md" | "lg" | "left">(null);
+  return (<>
+    <Sec title="Tamanhos (lado direito)">
+      <button className="grd-btn grd-btn-secondary" onClick={() => setOpen("sm")}>Abrir sm</button>
+      <button className="grd-btn grd-btn-secondary" onClick={() => setOpen("md")}>Abrir md</button>
+      <button className="grd-btn grd-btn-secondary" onClick={() => setOpen("lg")}>Abrir lg</button>
+    </Sec>
+    <Sec title="Lado esquerdo">
+      <button className="grd-btn grd-btn-secondary" onClick={() => setOpen("left")}>Abrir à esquerda</button>
+    </Sec>
+
+    <Drawer
+      open={open === "sm" || open === "md" || open === "lg"}
+      onClose={() => setOpen(null)}
+      size={open === "sm" ? "sm" : open === "lg" ? "lg" : "md"}
+      title="Detalhes da empresa"
+      description="Alfa Comércio LTDA · CNPJ 42.110.877/0001-55"
+      footer={<>
+        <button className="grd-btn grd-btn-ghost" onClick={() => setOpen(null)}>Cancelar</button>
+        <button className="grd-btn grd-btn-primary">Salvar alterações</button>
+      </>}
+    >
+      <div style={{display:"flex",flexDirection:"column",gap:14}}>
+        <div>
+          <Label>Razão social</Label>
+          <Input defaultValue="Alfa Comércio LTDA" />
+        </div>
+        <div>
+          <Label>Nome fantasia</Label>
+          <Input defaultValue="Alfa" />
+        </div>
+        <div>
+          <Label>Regime tributário</Label>
+          <Input defaultValue="Simples Nacional" />
+        </div>
+        <div>
+          <Label>E-mail do responsável</Label>
+          <Input type="email" defaultValue="contato@alfa.com.br" />
+        </div>
+        <div style={{fontSize:13,color:"var(--gray-600)",lineHeight:1.6,padding:"10px 12px",background:"var(--orange-50)",border:"1px solid var(--orange-100)",borderRadius:"var(--radius-md)"}}>
+          Alterações feitas aqui são propagadas para todas as integrações ativas em até 2 minutos.
+        </div>
+      </div>
+    </Drawer>
+
+    <Drawer
+      open={open === "left"}
+      onClose={() => setOpen(null)}
+      side="left"
+      title="Filtros avançados"
+      footer={<>
+        <button className="grd-btn grd-btn-ghost" onClick={() => setOpen(null)}>Limpar tudo</button>
+        <button className="grd-btn grd-btn-primary">Aplicar filtros</button>
+      </>}
+    >
+      <div style={{fontSize:14,color:"var(--gray-700)",lineHeight:1.6}}>
+        Drawers de filtro normalmente ficam à esquerda, junto da navegação principal, e mantêm a lista de resultados visível à direita.
+      </div>
+    </Drawer>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Drawer"]) || "render(<div>Sem exemplo para Drawer</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>open</code> · <code>onClose</code></td><td>boolean · fn</td><td>—</td><td class="desc">Controle</td></tr>
+  <tr><td><code>side</code></td><td>string</td><td>"right"</td><td class="desc">right · left</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>title</code> · <code>description</code></td><td>node</td><td>—</td><td class="desc">Cabeçalho</td></tr>
+  <tr><td><code>footer</code></td><td>node</td><td>—</td><td class="desc">Barra fixa no rodapé</td></tr>
+  <tr><td><code>showClose</code></td><td>boolean</td><td>true</td><td class="desc">Botão X no cabeçalho</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Detalhamento e edição sem perder contexto da lista (abrir lançamento, editar cliente).</li>
+      <li>Largura 480-640px; header sticky com título e ações.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Fluxos com múltiplas etapas — use página dedicada.</li>
+      <li>Drawer sobre drawer.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Drawer/index.css
+++ b/ux_references/ui_kits/components/Drawer/index.css
@@ -1,0 +1,43 @@
+
+.grd-drw-backdrop {
+  position: fixed; inset: 0; z-index: 1000;
+  background: color-mix(in oklab, var(--violet-900) 60%, transparent);
+  animation: grd-drw-fade 160ms var(--ease-out);
+}
+@keyframes grd-drw-fade { from { opacity: 0; } to { opacity: 1; } }
+
+.grd-drw {
+  position: absolute; top: 0; bottom: 0;
+  background: var(--surface);
+  display: flex; flex-direction: column;
+  font-family: var(--font-sans);
+  box-shadow: var(--shadow-xl);
+  width: 100%;
+}
+.grd-drw-sm { max-width: 360px; }
+.grd-drw-md { max-width: 480px; }
+.grd-drw-lg { max-width: 640px; }
+
+.grd-drw-right { right: 0; animation: grd-drw-slide-r 220ms var(--ease-out); }
+.grd-drw-left  { left: 0;  animation: grd-drw-slide-l 220ms var(--ease-out); }
+@keyframes grd-drw-slide-r { from { transform: translateX(100%); } to { transform: none; } }
+@keyframes grd-drw-slide-l { from { transform: translateX(-100%); } to { transform: none; } }
+
+.grd-drw-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+  padding: 18px 20px 14px; border-bottom: 1px solid var(--border);
+}
+.grd-drw-titlewrap { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.grd-drw-title { font-size: 17px; font-weight: 600; color: var(--fg); margin: 0; line-height: 1.35; }
+.grd-drw-desc { font-size: 13.5px; color: var(--fg-muted); margin: 0; line-height: 1.5; }
+.grd-drw-close {
+  width: 28px; height: 28px; border-radius: var(--radius-md); border: 0; background: transparent; color: var(--fg-muted); cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+.grd-drw-close:hover { background: var(--gray-100); color: var(--fg); }
+.grd-drw-body { flex: 1; overflow-y: auto; padding: 18px 20px; font-size: 14px; color: var(--fg); line-height: 1.55; }
+.grd-drw-foot {
+  display: flex; justify-content: flex-end; gap: 8px;
+  padding: 14px 20px; border-top: 1px solid var(--border);
+  background: var(--gray-50);
+}

--- a/ux_references/ui_kits/components/Drawer/index.tsx
+++ b/ux_references/ui_kits/components/Drawer/index.tsx
@@ -1,0 +1,63 @@
+
+/**
+ * Drawer — painel lateral. Ideal para detalhes, filtros, formulários secundários.
+ * Mantém contexto da tela principal. Props: side (right|left), size, open, onClose, title, children, footer.
+ */
+
+interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  children?: React.ReactNode;
+  footer?: React.ReactNode;
+  side?: "right" | "left";
+  size?: "sm" | "md" | "lg";
+  showClose?: boolean;
+}
+
+function Drawer({
+  open, onClose, title, description, children, footer,
+  side = "right", size = "md", showClose = true,
+}: DrawerProps) {
+  const IconCmp = (window as any).Icon;
+
+  React.useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.removeEventListener("keydown", onKey); document.body.style.overflow = prev; };
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return ReactDOM.createPortal(
+    <div className="grd-drw-backdrop" onClick={onClose}>
+      <aside
+        className={`grd-drw grd-drw-${side} grd-drw-${size}`}
+        role="dialog" aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {(title || showClose) && (
+          <div className="grd-drw-head">
+            <div className="grd-drw-titlewrap">
+              {title && <h2 className="grd-drw-title">{title}</h2>}
+              {description && <p className="grd-drw-desc">{description}</p>}
+            </div>
+            {showClose && IconCmp && (
+              <button className="grd-drw-close" onClick={onClose} aria-label="Fechar">
+                <IconCmp name="x" size={16} />
+              </button>
+            )}
+          </div>
+        )}
+        {children && <div className="grd-drw-body">{children}</div>}
+        {footer && <div className="grd-drw-foot">{footer}</div>}
+      </aside>
+    </div>,
+    document.body
+  );
+}
+Drawer.displayName = "Drawer";
+(window as any).Drawer = Drawer;

--- a/ux_references/ui_kits/components/EmptyState/EmptyState.playground.html
+++ b/ux_references/ui_kits/components/EmptyState/EmptyState.playground.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>EmptyState · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FEEDBACK · ESTADO VAZIO</div>
+  <h1 class="pg-title">EmptyState</h1>
+  <span class="pg-codename">import EmptyState from "ui_kits/components/EmptyState"</span>
+  <p class="pg-desc">Orientação quando não há nada a mostrar: nenhuma busca, lista vazia, caixa limpa. Sempre acompanhe de uma <b>ação clara</b> — nunca deixe o usuário sem próximo passo.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",gap:12}}>{children}</div></div>);
+}
+function Frame({ children }: any) {
+  return <div style={{background:"#fff",border:"1px solid var(--border)",borderRadius:"var(--radius-md)",padding:"8px"}}>{children}</div>;
+}
+function App() {
+  return (<>
+    <Sec title="Tamanhos">
+      <Frame><EmptyState size="sm" icon="inbox" title="Nada por aqui" description="Quando houver lançamentos, eles aparecem nessa lista." /></Frame>
+      <Frame><EmptyState size="md" icon="inbox" title="Caixa de entrada vazia" description="Todos os lançamentos foram processados pela Guardia." /></Frame>
+      <Frame><EmptyState size="lg" icon="inbox" title="Tudo em dia" description="Nenhum item pendente de revisão neste período." /></Frame>
+    </Sec>
+
+    <Sec title="Com ação primária">
+      <Frame>
+        <EmptyState
+          icon="building-2"
+          title="Nenhuma empresa conectada ainda"
+          description="Conecte seu primeiro cliente para começar a receber lançamentos automaticamente."
+          action={<button className="grd-btn grd-btn-primary">+ Conectar empresa</button>}
+        />
+      </Frame>
+    </Sec>
+
+    <Sec title="Sem resultado de busca">
+      <Frame>
+        <EmptyState
+          icon="search-x"
+          title={<>Nenhum resultado para <b style={{color:"var(--violet-500)"}}>"NF 4891"</b></>}
+          description="Verifique a ortografia ou tente buscar por CNPJ, fornecedor ou valor."
+          action={<button className="grd-btn grd-btn-ghost">Limpar filtros</button>}
+        />
+      </Frame>
+    </Sec>
+
+    <Sec title="Erro / integração">
+      <Frame>
+        <EmptyState
+          icon="plug-2"
+          title="Integração não conectada"
+          description="Não encontramos um certificado A1 ativo para esta empresa. Configure para habilitar o envio de notas fiscais."
+          action={
+            <div style={{display:"flex",gap:8,justifyContent:"center"}}>
+              <button className="grd-btn grd-btn-primary">Configurar certificado</button>
+              <button className="grd-btn grd-btn-ghost">Saber mais</button>
+            </div>
+          }
+        />
+      </Frame>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["EmptyState"]) || "render(<div>Sem exemplo para EmptyState</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>icon</code></td><td>string</td><td>"inbox"</td><td class="desc">Nome Lucide central</td></tr>
+  <tr><td><code>title</code></td><td>node</td><td>—</td><td class="desc">Título em destaque</td></tr>
+  <tr><td><code>description</code></td><td>node</td><td>—</td><td class="desc">Texto de apoio</td></tr>
+  <tr><td><code>action</code></td><td>node</td><td>—</td><td class="desc">Botão/grupo de ações — idealmente obrigatório</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Primeira-vez, sem resultados de filtro, ou estado pós-conclusão.</li>
+      <li>Ilustração/ícone + título + descrição curta + ação concreta ("Criar primeiro cliente").</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Apenas "Nenhum resultado" sem próximo passo.</li>
+      <li>Ilustrações decorativas sem relação com o contexto.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/EmptyState/index.css
+++ b/ux_references/ui_kits/components/EmptyState/index.css
@@ -1,0 +1,25 @@
+
+.grd-empty {
+  display: flex; flex-direction: column; align-items: center;
+  text-align: center;
+  font-family: var(--font-sans);
+  color: var(--fg);
+  gap: 6px;
+}
+.grd-empty-sm { padding: 24px 16px; }
+.grd-empty-md { padding: 40px 24px; }
+.grd-empty-lg { padding: 64px 32px; }
+
+.grd-empty-ic {
+  width: 56px; height: 56px; border-radius: var(--radius-2xl);
+  background: var(--violet-50); color: var(--violet-500);
+  display: inline-flex; align-items: center; justify-content: center;
+  margin-bottom: 6px;
+}
+.grd-empty-sm .grd-empty-ic { width: 42px; height: 42px; border-radius: var(--radius-xl); }
+.grd-empty-lg .grd-empty-ic { width: 72px; height: 72px; border-radius: var(--radius-2xl); }
+
+.grd-empty-title { font-size: 15px; font-weight: 600; color: var(--fg); }
+.grd-empty-lg .grd-empty-title { font-size: 18px; }
+.grd-empty-desc { font-size: 13.5px; color: var(--fg-muted); max-width: 400px; line-height: 1.5; }
+.grd-empty-action { margin-top: 10px; }

--- a/ux_references/ui_kits/components/EmptyState/index.tsx
+++ b/ux_references/ui_kits/components/EmptyState/index.tsx
@@ -1,0 +1,32 @@
+
+/**
+ * EmptyState — tela vazia com ilustração de ícone e CTA.
+ * Props: icon, title, description, action, size.
+ */
+
+interface EmptyStateProps {
+  icon?: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+function EmptyState({ icon = "inbox", title, description, action, size = "md", className = "" }: EmptyStateProps) {
+  const IconCmp = (window as any).Icon;
+  const cls = ["grd-empty", `grd-empty-${size}`, className].filter(Boolean).join(" ");
+  const iconSize = size === "sm" ? 22 : size === "lg" ? 36 : 28;
+  return (
+    <div className={cls}>
+      {IconCmp && (
+        <div className="grd-empty-ic"><IconCmp name={icon} size={iconSize} /></div>
+      )}
+      <div className="grd-empty-title">{title}</div>
+      {description && <div className="grd-empty-desc">{description}</div>}
+      {action && <div className="grd-empty-action">{action}</div>}
+    </div>
+  );
+}
+EmptyState.displayName = "EmptyState";
+(window as any).EmptyState = EmptyState;

--- a/ux_references/ui_kits/components/FileUpload/FileUpload.playground.html
+++ b/ux_references/ui_kits/components/FileUpload/FileUpload.playground.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>FileUpload · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORM · UPLOAD</div>
+  <h1 class="pg-title">FileUpload</h1>
+  <span class="pg-codename">import FileUpload from "ui_kits/components/FileUpload"</span>
+  <p class="pg-desc">Dropzone com seleção por clique, lista de arquivos e progresso.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=3"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,flexDirection:"column",alignItems:"stretch",gap:10,maxWidth:620}}>{children}</div></div>);
+}
+
+function App() {
+  const [files, setFiles] = React.useState<any[]>([
+    { name: "NF_4891_alfa.pdf",      size: 284_120, status: "done" },
+    { name: "NF_4892_alfa.xml",      size: 12_380,  status: "done" },
+    { name: "recibo_outubro.pdf",    size: 1_240_500, status: "uploading", progress: 64 },
+    { name: "planilha_razao.xlsx",   size: 2_860_000, status: "error", error: "Formato não suportado" },
+  ]);
+  function onFiles(fl: File[]) {
+    const mapped = fl.map(f => ({ name: f.name, size: f.size, status: "done" as const }));
+    setFiles(prev => [...prev, ...mapped]);
+  }
+  function onRemove(i: number) {
+    setFiles(prev => prev.filter((_, j) => j !== i));
+  }
+  return (<>
+    <Sec title="Com arquivos e estados (done, uploading, error)">
+      <FileUpload
+        multiple
+        accept=".pdf,.xml,.xlsx,.csv"
+        maxSize={10 * 1024 * 1024}
+        hint="PDF, XML, XLSX ou CSV · até 10MB por arquivo"
+        files={files}
+        onFiles={onFiles}
+        onRemove={onRemove}
+      />
+    </Sec>
+    <Sec title="Compacto (single)">
+      <FileUpload
+        compact
+        accept="image/*"
+        hint="PNG ou JPG — logo da empresa"
+      />
+    </Sec>
+    <Sec title="Desabilitado">
+      <FileUpload disabled hint="Aguardando liberação" />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["FileUpload"]) || "render(<div>Sem exemplo para FileUpload</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>accept</code></td><td>string</td><td>—</td><td class="desc">Extensões ou MIME (ex.: <code>.pdf,.xml</code>)</td></tr>
+  <tr><td><code>multiple</code></td><td>boolean</td><td>false</td><td class="desc">Múltiplos arquivos</td></tr>
+  <tr><td><code>maxSize</code></td><td>number (bytes)</td><td>—</td><td class="desc">Exibe na hint; validação do host</td></tr>
+  <tr><td><code>files</code></td><td>UploadFile[]</td><td>[]</td><td class="desc">{`{name,size,status,progress?,error?}`}</td></tr>
+  <tr><td><code>onFiles</code> · <code>onRemove</code></td><td>fn</td><td>—</td><td class="desc">Seleção e remoção</td></tr>
+  <tr><td><code>compact</code></td><td>boolean</td><td>false</td><td class="desc">Dropzone reduzido</td></tr>
+  <tr><td><code>hint</code></td><td>node</td><td>—</td><td class="desc">Texto auxiliar</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Upload de NFe/XML, balancete, OFX — aceita drag-and-drop e múltiplos arquivos.</li>
+      <li>Validação de extensão e tamanho antes de enviar; progresso por arquivo.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Upload silencioso sem feedback de progresso.</li>
+      <li>Sem lista de tipos aceitos visível.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/FileUpload/index.css
+++ b/ux_references/ui_kits/components/FileUpload/index.css
@@ -1,0 +1,68 @@
+
+.grd-fu { font-family: var(--font-sans); display: flex; flex-direction: column; gap: 10px; }
+
+.grd-fu-drop {
+  display: flex; align-items: center; gap: 14px;
+  padding: 20px 20px;
+  background: var(--gray-50);
+  border: 1.5px dashed var(--border-strong);
+  border-radius: var(--radius-xl);
+  cursor: pointer; position: relative;
+  transition: background 140ms, border-color 140ms;
+}
+.grd-fu-drop:hover { background: var(--violet-50); border-color: var(--violet-300); }
+.grd-fu-drag .grd-fu-drop { background: var(--violet-50); border-color: var(--violet-500); }
+.grd-fu-disabled .grd-fu-drop { opacity: 0.55; cursor: not-allowed; pointer-events: none; }
+
+.grd-fu-compact .grd-fu-drop { padding: 12px 14px; gap: 10px; }
+
+.grd-fu-icon {
+  width: 40px; height: 40px; flex-shrink: 0;
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--violet-500);
+  border: 1px solid var(--border);
+}
+.grd-fu-compact .grd-fu-icon { width: 32px; height: 32px; }
+
+.grd-fu-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.grd-fu-title { font-size: 13.5px; color: var(--fg); line-height: 1.45; }
+.grd-fu-link { color: var(--violet-600); font-weight: 600; text-decoration: underline; text-underline-offset: 2px; }
+.grd-fu-hint { font-size: 12px; color: var(--fg-muted); }
+
+.grd-fu-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
+.grd-fu-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 12px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+}
+.grd-fu-item-ic {
+  width: 28px; height: 28px; flex-shrink: 0;
+  border-radius: var(--radius-md);
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--gray-100); color: var(--fg-muted);
+}
+.grd-fu-item-done  .grd-fu-item-ic { background: var(--success-soft); color: var(--signal-green); }
+.grd-fu-item-error .grd-fu-item-ic { background: var(--danger-soft); color: var(--signal-red); }
+.grd-fu-item-uploading .grd-fu-item-ic { background: var(--violet-50); color: var(--violet-500); }
+
+.grd-fu-item-body { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.grd-fu-item-name { font-size: 13.5px; font-weight: 500; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.grd-fu-item-meta { font-size: 12px; color: var(--fg-muted); }
+.grd-fu-item-error .grd-fu-item-meta { color: var(--signal-red); }
+.grd-fu-item-bar {
+  display: block; width: 100%; height: 3px; margin-top: 4px;
+  background: var(--gray-200); border-radius: var(--radius-pill); overflow: hidden;
+}
+.grd-fu-item-bar span {
+  display: block; height: 100%; background: var(--violet-500);
+  transition: width 200ms var(--ease-standard);
+}
+
+.grd-fu-item-rm {
+  width: 24px; height: 24px; border-radius: 50%;
+  border: 0; background: transparent; color: var(--gray-500); cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.grd-fu-item-rm:hover { background: var(--gray-100); color: var(--fg); }

--- a/ux_references/ui_kits/components/FileUpload/index.tsx
+++ b/ux_references/ui_kits/components/FileUpload/index.tsx
@@ -1,0 +1,135 @@
+
+/**
+ * FileUpload — dropzone + botão, com lista de arquivos e progresso.
+ * Props:
+ *   accept, multiple, maxSize (bytes), onFiles(files)
+ *   files: arquivos controlados (opcional) — [{ name, size, status, progress? }]
+ *   hint: texto abaixo do dropzone
+ */
+
+interface UploadFile {
+  name: string;
+  size: number;
+  status?: "uploading" | "done" | "error";
+  progress?: number;
+  error?: string;
+}
+
+interface FileUploadProps {
+  accept?: string;
+  multiple?: boolean;
+  maxSize?: number;
+  hint?: string;
+  files?: UploadFile[];
+  onFiles?: (files: File[]) => void;
+  onRemove?: (index: number) => void;
+  disabled?: boolean;
+  compact?: boolean;
+  className?: string;
+}
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function FileUpload({
+  accept,
+  multiple = false,
+  maxSize,
+  hint,
+  files = [],
+  onFiles,
+  onRemove,
+  disabled = false,
+  compact = false,
+  className = "",
+}: FileUploadProps) {
+  const IconCmp = (window as any).Icon;
+  const [drag, setDrag] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  function handleFiles(fl: FileList | null) {
+    if (!fl) return;
+    const arr = Array.from(fl);
+    onFiles?.(arr);
+  }
+
+  const cls = [
+    "grd-fu",
+    compact && "grd-fu-compact",
+    drag && "grd-fu-drag",
+    disabled && "grd-fu-disabled",
+    className,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <div className={cls}>
+      <label
+        className="grd-fu-drop"
+        onDragEnter={(e) => { e.preventDefault(); if (!disabled) setDrag(true); }}
+        onDragOver={(e) => { e.preventDefault(); }}
+        onDragLeave={() => setDrag(false)}
+        onDrop={(e) => {
+          e.preventDefault(); setDrag(false);
+          if (disabled) return;
+          handleFiles(e.dataTransfer.files);
+        }}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          multiple={multiple}
+          disabled={disabled}
+          onChange={(e) => handleFiles(e.target.files)}
+          style={{ position: "absolute", width: 1, height: 1, opacity: 0, pointerEvents: "none" }}
+        />
+        <div className="grd-fu-icon">
+          {IconCmp && <IconCmp name="cloud-upload" size={compact ? 20 : 24} />}
+        </div>
+        <div className="grd-fu-text">
+          <span className="grd-fu-title">
+            Arraste arquivos aqui ou <span className="grd-fu-link">clique para escolher</span>
+          </span>
+          {hint && <span className="grd-fu-hint">{hint}</span>}
+          {!hint && maxSize && <span className="grd-fu-hint">Máx. {fmtBytes(maxSize)}</span>}
+        </div>
+      </label>
+
+      {files.length > 0 && (
+        <ul className="grd-fu-list">
+          {files.map((f, i) => (
+            <li key={i} className={`grd-fu-item grd-fu-item-${f.status ?? "done"}`}>
+              <span className="grd-fu-item-ic">
+                {IconCmp && <IconCmp
+                  name={f.status === "done" ? "circle-check" : f.status === "error" ? "circle-x" : "file"}
+                  size={15} />}
+              </span>
+              <span className="grd-fu-item-body">
+                <span className="grd-fu-item-name">{f.name}</span>
+                <span className="grd-fu-item-meta">
+                  {f.status === "error" && f.error
+                    ? f.error
+                    : `${fmtBytes(f.size)}${f.status === "uploading" && f.progress !== undefined ? ` • ${f.progress}%` : ""}`
+                  }
+                </span>
+                {f.status === "uploading" && (
+                  <span className="grd-fu-item-bar"><span style={{ width: `${f.progress ?? 0}%` }} /></span>
+                )}
+              </span>
+              {onRemove && (
+                <button type="button" className="grd-fu-item-rm" onClick={() => onRemove(i)} aria-label="Remover">
+                  {IconCmp && <IconCmp name="x" size={14} />}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+FileUpload.displayName = "FileUpload";
+(window as any).FileUpload = FileUpload;

--- a/ux_references/ui_kits/components/FormLayout/FormLayout.playground.html
+++ b/ux_references/ui_kits/components/FormLayout/FormLayout.playground.html
@@ -1,0 +1,638 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>FormLayout · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=1">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="../Textarea/index.css">
+<link rel="stylesheet" href="../Select/index.css">
+<link rel="stylesheet" href="../Combobox/index.css">
+<link rel="stylesheet" href="../Checkbox/index.css">
+<link rel="stylesheet" href="../Radio/index.css">
+<link rel="stylesheet" href="../Switch/index.css">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../Badge/index.css">
+<link rel="stylesheet" href="../Alert/index.css">
+<link rel="stylesheet" href="../DatePicker/index.css">
+<link rel="stylesheet" href="../Separator/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORMS · ESQUELETO DE FORMULÁRIO</div>
+  <h1 class="pg-title">FormLayout</h1>
+  <span class="pg-codename">import FormLayout from "ui_kits/components/FormLayout"</span>
+  <p class="pg-desc">Estrutura para compor cadastros, filtros, settings e wizards com hierarquia consistente. Orquestra seções, grid de 12 colunas, labels com obrigatório/opcional, hints, erros inline e footer de ações sticky. Três variantes (<code>stacked</code>, <code>split</code>, <code>inline</code>) × duas densidades (<code>comfy</code>, <code>compact</code>).</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Input/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Textarea/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Select/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Combobox/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Checkbox/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Radio/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Switch/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Alert/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../DatePicker/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=1"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="pg-sec">
+      <p className="pg-sec-title">{title}</p>
+      <div className="pg-stage" style={{padding:28, alignItems:"stretch", flexDirection:"column", gap:24}}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Frame({ children, label, maxWidth = 880 }: { children: React.ReactNode; label?: string; maxWidth?: number }) {
+  return (
+    <div>
+      {label && (
+        <div style={{ fontSize: 11.5, color: "var(--fg-muted)", marginBottom: 10, fontWeight: 600, letterSpacing: ".04em", textTransform: "uppercase" }}>
+          {label}
+        </div>
+      )}
+      <div style={{
+        background: "var(--surface)",
+        border: "1px solid var(--gray-200)",
+        borderRadius: "var(--radius-lg)",
+        padding: "28px 28px 24px",
+        maxWidth,
+      }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/* ============================================================ */
+/* 1. Cadastro de cliente — split + comfy                       */
+/* ============================================================ */
+
+function CadastroCliente() {
+  const [cnpj, setCnpj] = React.useState("");
+  const [razao, setRazao] = React.useState("Verona Logística Ltda");
+  const [regime, setRegime] = React.useState("presumido");
+  const [responsavel, setResponsavel] = React.useState("");
+  const [notas, setNotas] = React.useState("");
+
+  return (
+    <FormLayout variant="split" density="comfy">
+      <FormLayout.Header
+        title="Novo cliente"
+        description="Dados básicos para abrir a operação contábil. Você completa enquadramento, plano de contas e integrações depois."
+        actions={
+          <>
+            <Button variant="ghost" size="sm" leftIcon="help-circle">Ajuda</Button>
+            <Badge tone="violet" variant="soft">Rascunho</Badge>
+          </>
+        }
+      />
+
+      <FormLayout.Section
+        title="Identificação"
+        description="Empresa cadastrada na Receita Federal. CNPJ valida contra o ERP."
+      >
+        <FormLayout.Row>
+          <FormLayout.Field
+            label="CNPJ"
+            required
+            span={5}
+            hint="Validaremos na Receita Federal ao salvar."
+          >
+            <Input
+              placeholder="00.000.000/0000-00"
+              value={cnpj}
+              onChange={(e) => setCnpj(e.target.value)}
+              leftIcon="building"
+            />
+          </FormLayout.Field>
+          <FormLayout.Field label="Razão social" required span={7}>
+            <Input value={razao} onChange={(e) => setRazao(e.target.value)} />
+          </FormLayout.Field>
+        </FormLayout.Row>
+
+        <FormLayout.Row>
+          <FormLayout.Field label="Nome fantasia" optional span={7}>
+            <Input placeholder="Nome público da empresa" />
+          </FormLayout.Field>
+          <FormLayout.Field label="Abertura" span={5}>
+            <DatePicker placeholder="dd/mm/aaaa" />
+          </FormLayout.Field>
+        </FormLayout.Row>
+      </FormLayout.Section>
+
+      <FormLayout.Section
+        title="Enquadramento"
+        description="Regime tributário e responsável interno. Pode ser alterado antes do primeiro fechamento."
+        aside={<a href="#" style={{ color: "var(--violet-500)", fontSize: 12, fontWeight: 500, textDecoration: "none" }}>Comparar regimes ↗</a>}
+      >
+        <FormLayout.Field label="Regime tributário" required>
+          <Select
+            value={regime}
+            onChange={(e) => setRegime(e.target.value)}
+            options={[
+              { value: "simples",    label: "Simples Nacional" },
+              { value: "presumido",  label: "Lucro Presumido" },
+              { value: "real",       label: "Lucro Real" },
+              { value: "mei",        label: "MEI" },
+            ]}
+          />
+        </FormLayout.Field>
+
+        <FormLayout.Row>
+          <FormLayout.Field label="Responsável interno" required span={6}>
+            <Combobox
+              value={responsavel}
+              onChange={setResponsavel}
+              placeholder="Quem assina pareceres"
+              leftIcon="user"
+              options={[
+                { value: "luana",     label: "Luana Ribeiro",   meta: "Sócia contábil" },
+                { value: "thiago",    label: "Thiago Matos",    meta: "Gerente tributário" },
+                { value: "carolina",  label: "Carolina Duarte", meta: "Supervisora fiscal" },
+              ]}
+            />
+          </FormLayout.Field>
+          <FormLayout.Field label="Plano contratado" span={6}>
+            <Select
+              defaultValue="pro"
+              options={[
+                { value: "basico",    label: "Básico — até 500 lanç./mês" },
+                { value: "essencial", label: "Essencial — até 5k lanç./mês" },
+                { value: "pro",       label: "Pro — ilimitado" },
+              ]}
+            />
+          </FormLayout.Field>
+        </FormLayout.Row>
+
+        <FormLayout.Field
+          label="Notas internas"
+          optional
+          hint="Visível apenas para a equipe da Guardia. Não aparece em relatórios ao cliente."
+          labelAside={`${notas.length} / 280`}
+        >
+          <Textarea
+            value={notas}
+            onChange={(e) => setNotas(e.target.value)}
+            maxLength={280}
+            rows={3}
+            placeholder="Contexto do relacionamento, sazonalidade, pontos de atenção…"
+          />
+        </FormLayout.Field>
+      </FormLayout.Section>
+
+      <FormLayout.Section
+        title="Automação"
+        description="Como os agentes operam este cliente por padrão. Ajustável por área depois."
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <Switch
+            defaultChecked
+            label="Conciliação bancária automática"
+            description="Agentes cruzam extratos com lançamentos do ERP em tempo real."
+          />
+          <Switch
+            defaultChecked
+            label="Sugestão de classificação contábil"
+            description="Agente sugere conta e centro de custo; humano aprova acima de 95% de confiança."
+          />
+          <Switch
+            label="Envio automático de obrigações acessórias"
+            description="DCTF, SPED e GIAs transmitidos sem revisão humana. Requer certificado A1."
+          />
+        </div>
+      </FormLayout.Section>
+
+      <FormLayout.Actions align="between" sticky>
+        <Button variant="ghost" leftIcon="trash-2">Descartar</Button>
+        <div style={{ display: "flex", gap: 8 }}>
+          <Button variant="secondary">Salvar rascunho</Button>
+          <Button variant="primary" rightIcon="arrow-right">Criar cliente</Button>
+        </div>
+      </FormLayout.Actions>
+    </FormLayout>
+  );
+}
+
+/* ============================================================ */
+/* 2. Filtros — stacked + compact, dentro de barra              */
+/* ============================================================ */
+
+function FiltrosLancamentos() {
+  const [status, setStatus] = React.useState("todos");
+  const [cliente, setCliente] = React.useState("");
+
+  return (
+    <FormLayout as="div" variant="stacked" density="compact">
+      <FormLayout.Header
+        title="Filtros de lançamentos"
+        description="Resultados atualizados ao aplicar."
+      />
+      <FormLayout.Row cols={12}>
+        <FormLayout.Field label="Período" span={4}>
+          <DatePicker placeholder="01/04/2026 — 30/04/2026" />
+        </FormLayout.Field>
+        <FormLayout.Field label="Status" span={3}>
+          <Select
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            options={[
+              { value: "todos",     label: "Todos" },
+              { value: "aprovado",  label: "Aprovado" },
+              { value: "revisao",   label: "Em revisão" },
+              { value: "rejeitado", label: "Rejeitado" },
+            ]}
+          />
+        </FormLayout.Field>
+        <FormLayout.Field label="Cliente" span={5}>
+          <Combobox
+            value={cliente}
+            onChange={setCliente}
+            placeholder="Todos os clientes"
+            leftIcon="building"
+            options={[
+              { value: "verona",    label: "Verona Logística" },
+              { value: "padaria",   label: "Padaria da Esquina" },
+              { value: "flor",      label: "Mercearia Flor" },
+              { value: "cafe",      label: "Café Central" },
+            ]}
+          />
+        </FormLayout.Field>
+      </FormLayout.Row>
+      <FormLayout.Row cols={12}>
+        <FormLayout.Field label="Valor mínimo" span={3}>
+          <Input prefix="R$" placeholder="0,00" />
+        </FormLayout.Field>
+        <FormLayout.Field label="Valor máximo" span={3}>
+          <Input prefix="R$" placeholder="Sem limite" />
+        </FormLayout.Field>
+        <FormLayout.Field label="Confiança do agente" span={3}>
+          <Select
+            defaultValue="todos"
+            options={[
+              { value: "todos", label: "Qualquer nível" },
+              { value: "alta",  label: "Alta (≥ 95%)" },
+              { value: "media", label: "Média (75–95%)" },
+              { value: "baixa", label: "Baixa (< 75%)" },
+            ]}
+          />
+        </FormLayout.Field>
+        <FormLayout.Field label="Responsável" span={3}>
+          <Select
+            defaultValue="qualquer"
+            options={[
+              { value: "qualquer", label: "Qualquer" },
+              { value: "luana",    label: "Luana Ribeiro" },
+              { value: "thiago",   label: "Thiago Matos" },
+            ]}
+          />
+        </FormLayout.Field>
+      </FormLayout.Row>
+
+      <FormLayout.Actions align="between">
+        <Button variant="ghost" size="sm" leftIcon="x">Limpar filtros</Button>
+        <div style={{ display: "flex", gap: 8 }}>
+          <Button variant="secondary" size="sm" leftIcon="bookmark">Salvar visão</Button>
+          <Button variant="primary" size="sm" leftIcon="filter">Aplicar</Button>
+        </div>
+      </FormLayout.Actions>
+    </FormLayout>
+  );
+}
+
+/* ============================================================ */
+/* 3. Settings — inline + compact                               */
+/* ============================================================ */
+
+function Settings() {
+  const [limiar, setLimiar] = React.useState("85");
+  const [idioma, setIdioma] = React.useState("pt-BR");
+
+  return (
+    <FormLayout variant="stacked" density="compact">
+      <FormLayout.Header
+        title="Preferências do workspace"
+        description="Aplicadas a todos os usuários desta organização."
+      />
+
+      <FormLayout.Section title="Identidade">
+        <FormLayout.Field label="Nome da organização" htmlFor="org">
+          <Input id="org" defaultValue="Guardia Demo · Contábil & Fiscal" />
+        </FormLayout.Field>
+        <FormLayout.Field label="Fuso horário">
+          <Select
+            defaultValue="sp"
+            options={[
+              { value: "sp",  label: "America/São_Paulo (GMT-03)" },
+              { value: "ma",  label: "America/Manaus (GMT-04)" },
+              { value: "rn",  label: "America/Rio_Branco (GMT-05)" },
+            ]}
+          />
+        </FormLayout.Field>
+        <FormLayout.Field label="Idioma da interface" hint="Mensagens de erro, labels e e-mails automáticos.">
+          <Select
+            value={idioma}
+            onChange={(e) => setIdioma(e.target.value)}
+            options={[
+              { value: "pt-BR", label: "Português (Brasil)" },
+              { value: "en-US", label: "English (US)" },
+              { value: "es",    label: "Español" },
+            ]}
+          />
+        </FormLayout.Field>
+      </FormLayout.Section>
+
+      <FormLayout.Divider />
+
+      <FormLayout.Section
+        title="Comportamento dos agentes"
+        description="Define o limiar de auto-aprovação e o que aciona revisão humana."
+      >
+        <FormLayout.Field
+          label="Limiar de auto-aprovação"
+          hint="Matches acima deste valor de confiança vão direto para aprovado. Abaixo, para Revisão."
+        >
+          <Input
+            type="number"
+            min={50}
+            max={99}
+            value={limiar}
+            onChange={(e) => setLimiar(e.target.value)}
+            suffix="%"
+          />
+        </FormLayout.Field>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <Switch defaultChecked label="Notificar por e-mail ao exceder exceções/dia"
+                  description="Envia resumo para o responsável quando passar de 15 exceções no dia." />
+          <Switch label="Exigir segundo aprovador em valores ≥ R$ 50.000"
+                  description="Bloqueia aprovação única acima do limite. Sugerido para operações financeiras." />
+          <Switch defaultChecked label="Pausar agentes no fechamento mensal"
+                  description="Entre os dias 25 e 05 de cada ciclo, agentes ficam em modo somente-sugestão." />
+        </div>
+      </FormLayout.Section>
+
+      <FormLayout.Actions align="end">
+        <Button variant="ghost">Cancelar</Button>
+        <Button variant="primary">Salvar alterações</Button>
+      </FormLayout.Actions>
+    </FormLayout>
+  );
+}
+
+/* ============================================================ */
+/* 4. Estados de erro — validação inline                        */
+/* ============================================================ */
+
+function FormComErros() {
+  const [cnpj, setCnpj] = React.useState("12.345.678");
+  const [email, setEmail] = React.useState("operacoes@");
+  const [senha, setSenha] = React.useState("123");
+  const [submitted, setSubmitted] = React.useState(true);
+
+  const cnpjErr = submitted && cnpj.replace(/\D/g,"").length !== 14 ? "CNPJ deve ter 14 dígitos." : null;
+  const emailErr = submitted && !email.includes(".") ? "Inclua um domínio válido." : null;
+  const senhaErr = submitted && senha.length < 8 ? "Mínimo de 8 caracteres." : null;
+
+  return (
+    <FormLayout variant="stacked" density="comfy">
+      <FormLayout.Header
+        title="Validação inline"
+        description="Mensagem de erro substitui o hint. Campo ganha borda vermelha e aria-invalid automaticamente."
+      />
+
+      {submitted && (
+        <Alert type="danger" title="3 campos precisam de atenção">
+          Revise os itens destacados e reenvie.
+        </Alert>
+      )}
+
+      <FormLayout.Row>
+        <FormLayout.Field
+          label="CNPJ"
+          required
+          span={6}
+          error={cnpjErr}
+          hint="Formato 00.000.000/0000-00."
+        >
+          <Input value={cnpj} onChange={(e) => setCnpj(e.target.value)} leftIcon="building" />
+        </FormLayout.Field>
+        <FormLayout.Field
+          label="E-mail de operações"
+          required
+          span={6}
+          error={emailErr}
+          hint="Recebe notificações de exceções e fechamento."
+        >
+          <Input value={email} onChange={(e) => setEmail(e.target.value)} leftIcon="mail" type="email" />
+        </FormLayout.Field>
+      </FormLayout.Row>
+
+      <FormLayout.Field
+        label="Senha temporária"
+        required
+        error={senhaErr}
+        hint="O responsável trocará no primeiro acesso."
+      >
+        <Input type="password" value={senha} onChange={(e) => setSenha(e.target.value)} />
+      </FormLayout.Field>
+
+      <FormLayout.Actions align="between">
+        <Button variant="ghost" onClick={() => { setSubmitted(false); setCnpj("12.345.678/0001-90"); setEmail("operacoes@verona.com.br"); setSenha("GuardiaDemo1!"); }}>
+          Preencher como válido
+        </Button>
+        <Button variant="primary" onClick={() => setSubmitted(true)}>Validar</Button>
+      </FormLayout.Actions>
+    </FormLayout>
+  );
+}
+
+/* ============================================================ */
+/* 5. Inline — lista de toggles densa                           */
+/* ============================================================ */
+
+function Notificacoes() {
+  return (
+    <FormLayout variant="stacked" density="compact">
+      <FormLayout.Header
+        title="Notificações"
+        description="Canal por tipo de evento. Silêncio afeta apenas e-mail — webhooks seguem ativos."
+      />
+
+      <FormLayout.Section title="E-mail">
+        <FormLayout.Field label="Exceções em conciliação" hint="Quando um match fica abaixo do limiar." className="grd-form-field-inline">
+          <Select defaultValue="resumo" options={[
+            { value: "off",    label: "Desativado" },
+            { value: "resumo", label: "Resumo diário" },
+            { value: "instant",label: "A cada ocorrência" },
+          ]}/>
+        </FormLayout.Field>
+        <FormLayout.Field label="Fechamento mensal" className="grd-form-field-inline">
+          <Select defaultValue="instant" options={[
+            { value: "off",     label: "Desativado" },
+            { value: "resumo",  label: "Resumo diário" },
+            { value: "instant", label: "A cada ocorrência" },
+          ]}/>
+        </FormLayout.Field>
+        <FormLayout.Field label="Resposta à fiscalização" className="grd-form-field-inline">
+          <Select defaultValue="instant" options={[
+            { value: "resumo",  label: "Resumo diário" },
+            { value: "instant", label: "A cada ocorrência" },
+          ]}/>
+        </FormLayout.Field>
+      </FormLayout.Section>
+
+      <FormLayout.Divider />
+
+      <FormLayout.Section title="Dispositivo">
+        <FormLayout.Field label="Push no navegador" className="grd-form-field-inline">
+          <Switch defaultChecked />
+        </FormLayout.Field>
+        <FormLayout.Field label="App mobile" hint="Disponível em iOS e Android a partir de maio." className="grd-form-field-inline">
+          <Switch disabled />
+        </FormLayout.Field>
+        <FormLayout.Field label="Som em novas exceções" className="grd-form-field-inline">
+          <Switch defaultChecked />
+        </FormLayout.Field>
+      </FormLayout.Section>
+
+      <FormLayout.Actions align="end">
+        <Button variant="primary">Salvar</Button>
+      </FormLayout.Actions>
+    </FormLayout>
+  );
+}
+
+/* ============================================================ */
+
+function App() {
+  return (<>
+    <Sec title="Cadastro de cliente — split + comfy, seção com aside, actions sticky">
+      <Frame maxWidth={980}>
+        <CadastroCliente />
+      </Frame>
+    </Sec>
+
+    <Sec title="Filtros — stacked + compact, 12-col, ações com limpar">
+      <Frame maxWidth={980}>
+        <FiltrosLancamentos />
+      </Frame>
+    </Sec>
+
+    <Sec title="Settings — stacked + compact, dividers entre seções">
+      <Frame maxWidth={720}>
+        <Settings />
+      </Frame>
+    </Sec>
+
+    <Sec title="Validação inline — error substitui hint, aria-invalid propaga">
+      <Frame maxWidth={820}>
+        <FormComErros />
+      </Frame>
+    </Sec>
+
+    <Sec title="Inline — label à esquerda, denso (classe .grd-form-field-inline por campo)">
+      <Frame maxWidth={720}>
+        <Notificacoes />
+      </Frame>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["FormLayout"]) || "render(<div>Sem exemplo para FormLayout</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><th colspan="4" style="background:var(--violet-100);color:var(--violet-700);font-weight:600;">FormLayout (root)</th></tr>
+  <tr><td><code>variant</code></td><td><code>"stacked" | "split" | "inline"</code></td><td><code>"stacked"</code></td><td class="desc">Disposição das seções</td></tr>
+  <tr><td><code>density</code></td><td><code>"comfy" | "compact"</code></td><td><code>"comfy"</code></td><td class="desc">Ajusta gaps entre seções, rows e campos</td></tr>
+  <tr><td><code>as</code></td><td><code>"form" | "div"</code></td><td><code>"form"</code></td><td class="desc">Tag raiz. Use <code>"div"</code> para filtros controlados externamente</td></tr>
+
+  <tr><th colspan="4" style="background:var(--violet-100);color:var(--violet-700);font-weight:600;">FormLayout.Header</th></tr>
+  <tr><td><code>title</code> · <code>description</code></td><td>ReactNode</td><td>—</td><td class="desc">Cabeçalho do formulário</td></tr>
+  <tr><td><code>actions</code></td><td>ReactNode</td><td>—</td><td class="desc">Ações no canto superior direito</td></tr>
+
+  <tr><th colspan="4" style="background:var(--violet-100);color:var(--violet-700);font-weight:600;">FormLayout.Section</th></tr>
+  <tr><td><code>title</code> · <code>description</code></td><td>ReactNode</td><td>—</td><td class="desc">Cabeçalho da seção (em <code>split</code> vira coluna esquerda sticky)</td></tr>
+  <tr><td><code>aside</code></td><td>ReactNode</td><td>—</td><td class="desc">Conteúdo à direita do título (link, badge)</td></tr>
+
+  <tr><th colspan="4" style="background:var(--violet-100);color:var(--violet-700);font-weight:600;">FormLayout.Row</th></tr>
+  <tr><td><code>cols</code></td><td><code>2 | 3 | 4 | 6 | 12</code></td><td><code>12</code></td><td class="desc">Nº de colunas do grid. Use 12 quando precisar de <code>span</code> fino</td></tr>
+  <tr><td><code>gap</code></td><td>number</td><td>—</td><td class="desc">Override em px; default segue a densidade</td></tr>
+
+  <tr><th colspan="4" style="background:var(--violet-100);color:var(--violet-700);font-weight:600;">FormLayout.Field</th></tr>
+  <tr><td><code>label</code></td><td>ReactNode</td><td>—</td><td class="desc">Rótulo do campo</td></tr>
+  <tr><td><code>required</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Mostra asterisco vermelho</td></tr>
+  <tr><td><code>optional</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Sufixo "(opcional)". Não combina com <code>required</code></td></tr>
+  <tr><td><code>hint</code></td><td>ReactNode</td><td>—</td><td class="desc">Texto auxiliar abaixo do campo</td></tr>
+  <tr><td><code>error</code></td><td>ReactNode</td><td>—</td><td class="desc">Mensagem de erro — substitui o hint e propaga <code>invalid</code> + <code>aria-invalid</code> ao controle filho</td></tr>
+  <tr><td><code>labelAside</code></td><td>ReactNode</td><td>—</td><td class="desc">Texto à direita do label (ex: contador de caracteres)</td></tr>
+  <tr><td><code>span</code></td><td>number</td><td>—</td><td class="desc">Colspan dentro de <code>Row</code></td></tr>
+  <tr><td><code>htmlFor</code></td><td>string</td><td>—</td><td class="desc">Wire com o <code>id</code> do input filho</td></tr>
+
+  <tr><th colspan="4" style="background:var(--violet-100);color:var(--violet-700);font-weight:600;">FormLayout.Actions</th></tr>
+  <tr><td><code>align</code></td><td><code>"start" | "center" | "end" | "between"</code></td><td><code>"end"</code></td><td class="desc">Alinhamento horizontal</td></tr>
+  <tr><td><code>sticky</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Fixa no rodapé com blur. Recomendado em formulários longos</td></tr>
+
+  <tr><th colspan="4" style="background:var(--violet-100);color:var(--violet-700);font-weight:600;">FormLayout.Divider</th></tr>
+  <tr><td>—</td><td>—</td><td>—</td><td class="desc">Linha fina entre seções</td></tr>
+</table>
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Cadastros longos (clientes, empresas, usuários) com seções claras — <code>variant="split"</code> para descrição visível lado a lado com os campos.</li>
+      <li>Filtros de tabelas e listas — <code>density="compact"</code> com <code>Row cols=12</code> e <code>span</code> por campo.</li>
+      <li>Páginas de settings — divisores entre seções; ações do rodapé em <code>align="end"</code>.</li>
+      <li>Wizards — uma seção por etapa, ações sempre sticky.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Campos sem label (placeholder não substitui label — veja <code>Input</code>).</li>
+      <li>Mais de 3 colunas na mesma Row em densidade comfy — fica apertado em 1280px.</li>
+      <li>Actions não sticky em formulário &gt; 1 tela de altura — o usuário perde de vista o botão Salvar.</li>
+      <li><code>variant="split"</code> em larguras menores que 760px — colapsa automaticamente, mas prefira <code>stacked</code> se souber antes.</li>
+    </ul>
+  </div>
+</div>
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/FormLayout/index.css
+++ b/ux_references/ui_kits/components/FormLayout/index.css
@@ -1,0 +1,291 @@
+
+/* ─────────────────────────────────────────────────────────
+   FormLayout — esqueleto de formulários
+   Prefixo: grd-form-
+   ───────────────────────────────────────────────────────── */
+
+.grd-form {
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-sans);
+  color: var(--fg);
+  width: 100%;
+}
+
+/* ─── Densidade ─────────────────────────────────────────── */
+
+.grd-form-comfy   { gap: 32px; }
+.grd-form-compact { gap: 20px; }
+
+/* ─── Header ────────────────────────────────────────────── */
+
+.grd-form-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+.grd-form-header-text { min-width: 0; flex: 1; }
+.grd-form-header-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+.grd-form-header-desc {
+  margin: 6px 0 0;
+  font-size: 13.5px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+  max-width: 680px;
+  text-wrap: pretty;
+}
+.grd-form-header-actions {
+  display: flex; gap: 8px; flex-shrink: 0;
+}
+
+/* ─── Section ───────────────────────────────────────────── */
+
+.grd-form-section {
+  display: flex; flex-direction: column;
+}
+.grd-form-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.grd-form-section-head-text { min-width: 0; flex: 1; }
+.grd-form-section-title {
+  margin: 0;
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: -0.005em;
+}
+.grd-form-section-desc {
+  margin: 6px 0 0;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+.grd-form-section-aside {
+  flex-shrink: 0;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+}
+
+/* stacked: título em cima, campos abaixo */
+.grd-form-section-stacked {
+  gap: 14px;
+}
+.grd-form-comfy   .grd-form-section-stacked { gap: 18px; }
+.grd-form-compact .grd-form-section-stacked { gap: 12px; }
+
+/* split: título à esquerda, campos à direita (desktop) */
+.grd-form-section-split {
+  display: grid;
+  grid-template-columns: minmax(180px, 280px) minmax(0, 1fr);
+  gap: 40px;
+  align-items: start;
+}
+.grd-form-section-split .grd-form-section-head {
+  flex-direction: column;
+  align-items: stretch;
+  position: sticky;
+  top: 16px;
+}
+.grd-form-section-split .grd-form-section-desc { max-width: 260px; }
+.grd-form-section-split .grd-form-section-body {
+  display: flex; flex-direction: column;
+}
+.grd-form-comfy   .grd-form-section-split .grd-form-section-body { gap: 18px; }
+.grd-form-compact .grd-form-section-split .grd-form-section-body { gap: 12px; }
+
+/* inline: labels à esquerda, denso */
+.grd-form-section-inline {
+  gap: 12px;
+}
+
+/* body padrão (stacked/inline) */
+.grd-form-section-stacked > .grd-form-section-body,
+.grd-form-section-inline  > .grd-form-section-body {
+  display: flex; flex-direction: column;
+}
+.grd-form-comfy   .grd-form-section-stacked > .grd-form-section-body { gap: 18px; }
+.grd-form-compact .grd-form-section-stacked > .grd-form-section-body { gap: 12px; }
+.grd-form-section-inline > .grd-form-section-body { gap: 10px; }
+
+/* responsive: split vira stacked em telas menores */
+@media (max-width: 760px) {
+  .grd-form-section-split {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+  .grd-form-section-split .grd-form-section-head { position: static; }
+}
+
+/* ─── Row (grid) ────────────────────────────────────────── */
+
+.grd-form-row {
+  display: grid;
+  gap: 16px;
+}
+.grd-form-compact .grd-form-row { gap: 12px; }
+
+/* responsive: colunas colapsam em telas pequenas */
+@media (max-width: 640px) {
+  .grd-form-row {
+    grid-template-columns: 1fr !important;
+  }
+  .grd-form-field[style*="grid-column"] {
+    grid-column: span 1 !important;
+  }
+}
+
+/* ─── Field ─────────────────────────────────────────────── */
+
+.grd-form-field {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.grd-form-field-labelrow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.grd-form-field-label {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: -0.005em;
+  line-height: 1.3;
+}
+.grd-form-field-required {
+  color: var(--signal-red);
+  font-weight: 600;
+  margin-left: 1px;
+}
+.grd-form-field-optional {
+  color: var(--gray-500);
+  font-weight: 400;
+  font-size: 11.5px;
+  margin-left: 4px;
+}
+.grd-form-field-aside {
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  font-weight: 400;
+}
+.grd-form-field-control {
+  display: flex;
+  min-width: 0;
+}
+.grd-form-field-control > * {
+  flex: 1;
+  min-width: 0;
+}
+.grd-form-field-hint,
+.grd-form-field-error-msg {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+.grd-form-field-hint { color: var(--fg-muted); }
+.grd-form-field-error-msg {
+  color: var(--signal-red);
+  font-weight: 500;
+  display: flex; align-items: flex-start; gap: 5px;
+}
+.grd-form-field-error-msg::before {
+  content: "";
+  flex-shrink: 0;
+  width: 4px; height: 4px;
+  margin-top: 7px;
+  border-radius: var(--radius-pill);
+  background: var(--signal-red);
+}
+
+/* inline variant: label à esquerda, controle à direita */
+.grd-form-field-inline {
+  display: grid;
+  grid-template-columns: minmax(140px, 200px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+}
+.grd-form-field-inline .grd-form-field-labelrow {
+  margin-bottom: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+.grd-form-field-inline .grd-form-field-hint,
+.grd-form-field-inline .grd-form-field-error-msg {
+  grid-column: 2;
+}
+@media (max-width: 640px) {
+  .grd-form-field-inline {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+  .grd-form-field-inline .grd-form-field-hint,
+  .grd-form-field-inline .grd-form-field-error-msg {
+    grid-column: 1;
+  }
+}
+
+/* ─── Actions ───────────────────────────────────────────── */
+
+.grd-form-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-top: 20px;
+  border-top: 1px solid var(--gray-100);
+}
+.grd-form-compact .grd-form-actions { padding-top: 14px; }
+.grd-form-actions-start   { justify-content: flex-start; }
+.grd-form-actions-center  { justify-content: center; }
+.grd-form-actions-end     { justify-content: flex-end; }
+.grd-form-actions-between { justify-content: space-between; }
+
+.grd-form-actions-sticky {
+  position: sticky;
+  bottom: 0;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  backdrop-filter: saturate(140%) blur(6px);
+  -webkit-backdrop-filter: saturate(140%) blur(6px);
+  padding: 14px 16px;
+  margin: 0 -16px -16px;
+  border-top: 1px solid var(--gray-200);
+  z-index: 2;
+}
+
+/* ─── Divider ───────────────────────────────────────────── */
+
+.grd-form-divider {
+  border: 0;
+  border-top: 1px solid var(--gray-100);
+  margin: 0;
+}
+
+/* ─── Dark mode — ajustes finos ─────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  .grd-form-actions {
+    border-top-color: var(--gray-800, var(--gray-200));
+  }
+  .grd-form-actions-sticky {
+    border-top-color: var(--gray-800, var(--gray-200));
+  }
+  .grd-form-divider {
+    border-top-color: var(--gray-800, var(--gray-100));
+  }
+}

--- a/ux_references/ui_kits/components/FormLayout/index.tsx
+++ b/ux_references/ui_kits/components/FormLayout/index.tsx
@@ -1,0 +1,270 @@
+
+/**
+ * FormLayout — esqueleto de formulários da Guardia.
+ *
+ * Compõe cadastros, filtros, settings e wizards com consistência:
+ *   <FormLayout variant="split" density="comfy">
+ *     <FormLayout.Header title="…" description="…" actions={…} />
+ *     <FormLayout.Section title="…" description="…">
+ *       <FormLayout.Row>
+ *         <FormLayout.Field label="CNPJ" required span={6}>
+ *           <Input placeholder="…" />
+ *         </FormLayout.Field>
+ *         <FormLayout.Field label="Razão social" span={6}>
+ *           <Input />
+ *         </FormLayout.Field>
+ *       </FormLayout.Row>
+ *     </FormLayout.Section>
+ *     <FormLayout.Actions align="end" sticky>
+ *       <Button variant="ghost">Cancelar</Button>
+ *       <Button variant="primary">Salvar</Button>
+ *     </FormLayout.Actions>
+ *   </FormLayout>
+ *
+ * Variantes:
+ *   stacked (default) — label em cima, descrição de seção acima dos campos.
+ *   split              — título + descrição da seção em uma coluna, campos em outra (desktop apenas).
+ *   inline             — label à esquerda do campo, compacto. Bom para settings.
+ *
+ * Densidade:
+ *   comfy  (default) — espaçamento generoso para cadastros.
+ *   compact          — denso, para filtros e tabelas de configuração.
+ */
+
+type FormVariant = "stacked" | "split" | "inline";
+type FormDensity = "comfy" | "compact";
+
+interface FormLayoutCtx {
+  variant: FormVariant;
+  density: FormDensity;
+}
+const FormLayoutContext = React.createContext<FormLayoutCtx>({ variant: "stacked", density: "comfy" });
+
+/* ─── Root ────────────────────────────────────────────────── */
+
+interface FormLayoutProps extends React.FormHTMLAttributes<HTMLFormElement> {
+  variant?: FormVariant;
+  density?: FormDensity;
+  /** renderiza como <div> (default <form>), útil para filtros ou settings controlados externamente */
+  as?: "form" | "div";
+}
+function FormLayout({
+  variant = "stacked",
+  density = "comfy",
+  as = "form",
+  className = "",
+  children,
+  ...rest
+}: FormLayoutProps) {
+  const Tag: any = as;
+  const cls = [
+    "grd-form",
+    `grd-form-${variant}`,
+    `grd-form-${density}`,
+    className,
+  ].filter(Boolean).join(" ");
+  return (
+    <FormLayoutContext.Provider value={{ variant, density }}>
+      <Tag className={cls} {...rest}>{children}</Tag>
+    </FormLayoutContext.Provider>
+  );
+}
+FormLayout.displayName = "FormLayout";
+
+/* ─── Header ──────────────────────────────────────────────── */
+
+interface HeaderProps {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+  children?: React.ReactNode;
+}
+function FormHeader({ title, description, actions, className = "", children }: HeaderProps) {
+  return (
+    <header className={["grd-form-header", className].filter(Boolean).join(" ")}>
+      <div className="grd-form-header-text">
+        {title && <h2 className="grd-form-header-title">{title}</h2>}
+        {description && <p className="grd-form-header-desc">{description}</p>}
+        {children}
+      </div>
+      {actions && <div className="grd-form-header-actions">{actions}</div>}
+    </header>
+  );
+}
+FormHeader.displayName = "FormLayout.Header";
+
+/* ─── Section ─────────────────────────────────────────────── */
+
+interface SectionProps {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  /** canto superior direito da seção (link, badge, action secundária) */
+  aside?: React.ReactNode;
+  className?: string;
+  children?: React.ReactNode;
+}
+function FormSection({ title, description, aside, className = "", children }: SectionProps) {
+  const { variant } = React.useContext(FormLayoutContext);
+  const hasHead = title || description || aside;
+  return (
+    <section className={["grd-form-section", `grd-form-section-${variant}`, className].filter(Boolean).join(" ")}>
+      {hasHead && (
+        <div className="grd-form-section-head">
+          <div className="grd-form-section-head-text">
+            {title && <h3 className="grd-form-section-title">{title}</h3>}
+            {description && <p className="grd-form-section-desc">{description}</p>}
+          </div>
+          {aside && <div className="grd-form-section-aside">{aside}</div>}
+        </div>
+      )}
+      <div className="grd-form-section-body">
+        {children}
+      </div>
+    </section>
+  );
+}
+FormSection.displayName = "FormLayout.Section";
+
+/* ─── Row (grid 12-col) ───────────────────────────────────── */
+
+interface RowProps {
+  /** número de colunas (default 12). Use 2/3/4 para grids simétricos */
+  cols?: 2 | 3 | 4 | 6 | 12;
+  /** gap em px (default 16px no comfy, 12px no compact) */
+  gap?: number;
+  className?: string;
+  children?: React.ReactNode;
+}
+function FormRow({ cols = 12, gap, className = "", children }: RowProps) {
+  const style: React.CSSProperties = { gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` };
+  if (gap !== undefined) style.gap = gap;
+  return (
+    <div
+      className={["grd-form-row", `grd-form-row-${cols}`, className].filter(Boolean).join(" ")}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+FormRow.displayName = "FormLayout.Row";
+
+/* ─── Field ───────────────────────────────────────────────── */
+
+interface FieldProps {
+  label?: React.ReactNode;
+  /** sufixo opcional no label (ex: "(opcional)") */
+  optional?: boolean;
+  required?: boolean;
+  /** dica abaixo do campo */
+  hint?: React.ReactNode;
+  /** mensagem de erro — sobrescreve o hint quando presente */
+  error?: React.ReactNode;
+  /** texto à direita do label (ex: "Máx. 80 caracteres") */
+  labelAside?: React.ReactNode;
+  /** colspan dentro de <Row>. default auto (1 coluna) */
+  span?: number;
+  /** id do input para wire automático do htmlFor */
+  htmlFor?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+function FormField({
+  label,
+  optional,
+  required,
+  hint,
+  error,
+  labelAside,
+  span,
+  htmlFor,
+  className = "",
+  children,
+}: FieldProps) {
+  const { variant } = React.useContext(FormLayoutContext);
+  const style: React.CSSProperties | undefined = span ? { gridColumn: `span ${span}` } : undefined;
+  const errId = React.useId();
+  const hintId = React.useId();
+
+  /* Se houver um único child que seja input-like, injetamos aria-describedby/invalid */
+  const child = React.Children.count(children) === 1 ? React.Children.only(children) : null;
+  let enhancedChildren: React.ReactNode = children;
+  if (child && React.isValidElement(child)) {
+    const describedBy = [
+      error ? errId : null,
+      hint && !error ? hintId : null,
+      (child.props as any)["aria-describedby"],
+    ].filter(Boolean).join(" ") || undefined;
+    enhancedChildren = React.cloneElement(child as any, {
+      id: (child.props as any).id ?? htmlFor,
+      "aria-describedby": describedBy,
+      "aria-invalid": error ? true : (child.props as any)["aria-invalid"],
+      invalid: error ? true : (child.props as any).invalid,
+    });
+  }
+
+  return (
+    <div
+      className={["grd-form-field", `grd-form-field-${variant}`, error && "grd-form-field-error", className].filter(Boolean).join(" ")}
+      style={style}
+    >
+      {(label || labelAside) && (
+        <div className="grd-form-field-labelrow">
+          {label && (
+            <label className="grd-form-field-label" htmlFor={htmlFor}>
+              {label}
+              {required && <span className="grd-form-field-required" aria-hidden>*</span>}
+              {optional && !required && <span className="grd-form-field-optional">(opcional)</span>}
+            </label>
+          )}
+          {labelAside && <span className="grd-form-field-aside">{labelAside}</span>}
+        </div>
+      )}
+      <div className="grd-form-field-control">{enhancedChildren}</div>
+      {error ? (
+        <p id={errId} className="grd-form-field-error-msg" role="alert">{error}</p>
+      ) : hint ? (
+        <p id={hintId} className="grd-form-field-hint">{hint}</p>
+      ) : null}
+    </div>
+  );
+}
+FormField.displayName = "FormLayout.Field";
+
+/* ─── Actions ────────────────────────────────────────────── */
+
+interface ActionsProps {
+  align?: "start" | "center" | "end" | "between";
+  sticky?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+}
+function FormActions({ align = "end", sticky = false, className = "", children }: ActionsProps) {
+  const cls = [
+    "grd-form-actions",
+    `grd-form-actions-${align}`,
+    sticky && "grd-form-actions-sticky",
+    className,
+  ].filter(Boolean).join(" ");
+  return <div className={cls}>{children}</div>;
+}
+FormActions.displayName = "FormLayout.Actions";
+
+/* ─── Divider ────────────────────────────────────────────── */
+
+function FormDivider({ className = "" }: { className?: string }) {
+  return <hr className={["grd-form-divider", className].filter(Boolean).join(" ")} aria-hidden />;
+}
+FormDivider.displayName = "FormLayout.Divider";
+
+/* ─── Compound ───────────────────────────────────────────── */
+
+FormLayout.Header  = FormHeader;
+FormLayout.Section = FormSection;
+FormLayout.Row     = FormRow;
+FormLayout.Field   = FormField;
+FormLayout.Actions = FormActions;
+FormLayout.Divider = FormDivider;
+
+(window as any).FormLayout = FormLayout;

--- a/ux_references/ui_kits/components/IconButton/IconButton.playground.html
+++ b/ux_references/ui_kits/components/IconButton/IconButton.playground.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>IconButton · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · AÇÃO</div>
+  <h1 class="pg-title">IconButton</h1>
+  <span class="pg-codename">import IconButton from "ui_kits/components/IconButton"</span>
+  <p class="pg-desc">Botão apenas com ícone para toolbars, cabeçalhos de tabela e ações compactas. 5 variantes, 3 tamanhos, 2 shapes. <b>Sempre</b> receber <code>aria-label</code> — acessibilidade obrigatória.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage">{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Variantes">
+      <IconButton icon="plus" variant="primary"     aria-label="Adicionar" />
+      <IconButton icon="arrow-right" variant="accent" aria-label="Continuar" />
+      <IconButton icon="settings" variant="outline" aria-label="Configurações" />
+      <IconButton icon="more-vertical" variant="ghost" aria-label="Mais opções" />
+      <IconButton icon="trash" variant="destructive" aria-label="Excluir" />
+    </Sec>
+    <Sec title="Tamanhos">
+      <IconButton icon="search" size="sm" variant="outline" aria-label="Buscar" />
+      <IconButton icon="search" size="md" variant="outline" aria-label="Buscar" />
+      <IconButton icon="search" size="lg" variant="outline" aria-label="Buscar" />
+    </Sec>
+    <Sec title="Shape · circle">
+      <IconButton icon="user" shape="circle" variant="primary" aria-label="Perfil" />
+      <IconButton icon="bell" shape="circle" variant="outline" aria-label="Notificações" />
+      <IconButton icon="x" shape="circle" variant="ghost" aria-label="Fechar" />
+    </Sec>
+    <Sec title="Estados">
+      <IconButton icon="refresh" aria-label="Atualizar" />
+      <IconButton icon="refresh" aria-label="Atualizar" disabled />
+    </Sec>
+    <Sec title="Em toolbar (uso real)">
+      <div style={{display:"flex",gap:2,padding:4,background:"#fff",border:"1px solid var(--border)",borderRadius:"var(--radius-sm)"}}>
+        <IconButton icon="bold" size="sm" aria-label="Negrito" />
+        <IconButton icon="italic" size="sm" aria-label="Itálico" />
+        <IconButton icon="underline" size="sm" aria-label="Sublinhado" />
+        <span style={{width:1,background:"var(--border)",margin:"4px 2px"}} />
+        <IconButton icon="align-left" size="sm" aria-label="Alinhar esquerda" />
+        <IconButton icon="align-center" size="sm" aria-label="Centralizar" />
+        <IconButton icon="align-right" size="sm" aria-label="Alinhar direita" />
+      </div>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["IconButton"]) || "render(<div>Sem exemplo para IconButton</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>icon</code></td><td>IconName</td><td>—</td><td class="desc">Nome do glifo (obrigatório)</td></tr>
+  <tr><td><code>aria-label</code></td><td>string</td><td>—</td><td class="desc">Obrigatório — descrição para leitores de tela</td></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"ghost"</td><td class="desc">primary · accent · outline · ghost · destructive</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm (28) · md (36) · lg (44)</td></tr>
+  <tr><td><code>shape</code></td><td>string</td><td>"square"</td><td class="desc">square · circle</td></tr>
+  <tr><td><code>disabled</code></td><td>boolean</td><td>false</td><td class="desc">Bloqueia interação</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Ação secundária em toolbars densas onde o ícone é autoexplicativo (editar, mais opções, fechar).</li>
+      <li>Sempre com <code>aria-label</code> descritivo.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Ações ambíguas sem <code>Tooltip</code>.</li>
+      <li>Botão icônico como CTA principal de uma tela.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/IconButton/index.css
+++ b/ux_references/ui_kits/components/IconButton/index.css
@@ -1,0 +1,45 @@
+/* IconButton */
+.grd-iconbtn {
+  --grd-ib-bg: transparent;
+  --grd-ib-fg: var(--violet-500);
+  --grd-ib-bd: transparent;
+  --grd-ib-bg-hover: var(--violet-100);
+
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--grd-ib-bg); color: var(--grd-ib-fg);
+  border: 1px solid var(--grd-ib-bd);
+  cursor: pointer; padding: 0;
+  transition: background 160ms var(--ease-standard),
+              color 160ms var(--ease-standard),
+              border-color 160ms var(--ease-standard);
+}
+.grd-iconbtn:hover:not(:disabled) { background: var(--grd-ib-bg-hover); }
+.grd-iconbtn:focus-visible { outline: none; box-shadow: var(--focus-ring-accent); }
+.grd-iconbtn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* Sizes */
+.grd-iconbtn-sm { width: 28px; height: 28px; border-radius: var(--radius-sm); }
+.grd-iconbtn-md { width: 36px; height: 36px; border-radius: var(--radius-md); }
+.grd-iconbtn-lg { width: 44px; height: 44px; border-radius: var(--radius-lg); }
+
+/* Shape */
+.grd-iconbtn-circle.grd-iconbtn-sm,
+.grd-iconbtn-circle.grd-iconbtn-md,
+.grd-iconbtn-circle.grd-iconbtn-lg { border-radius: var(--radius-pill); }
+
+/* Variants */
+.grd-iconbtn-primary {
+  --grd-ib-bg: var(--violet-500); --grd-ib-fg: #fff; --grd-ib-bg-hover: var(--violet-700);
+}
+.grd-iconbtn-accent {
+  --grd-ib-bg: var(--orange-500); --grd-ib-fg: #fff; --grd-ib-bg-hover: var(--orange-700);
+}
+.grd-iconbtn-outline {
+  --grd-ib-bg: #fff; --grd-ib-fg: var(--violet-500); --grd-ib-bd: var(--border-strong); --grd-ib-bg-hover: var(--violet-100);
+}
+.grd-iconbtn-ghost {
+  --grd-ib-bg: transparent; --grd-ib-fg: var(--violet-500); --grd-ib-bg-hover: var(--violet-100);
+}
+.grd-iconbtn-destructive {
+  --grd-ib-bg: transparent; --grd-ib-fg: var(--signal-red); --grd-ib-bg-hover: color-mix(in oklab, var(--signal-red) 10%, transparent);
+}

--- a/ux_references/ui_kits/components/IconButton/index.tsx
+++ b/ux_references/ui_kits/components/IconButton/index.tsx
@@ -1,0 +1,49 @@
+/**
+ * IconButton — botão de ícone-único (sem label)
+ * ---------------------------------------------
+ * Usado em toolbars, linhas de tabela, headers compactos.
+ * Precisa SEMPRE de `aria-label` (acessibilidade).
+ *
+ * Variantes: primary · accent · outline · ghost · destructive
+ * Tamanhos: sm (28) · md (36) · lg (44)
+ * Shape: square (default) · circle
+ */
+
+type IconButtonVariant = "primary" | "accent" | "outline" | "ghost" | "destructive";
+type IconButtonSize = "sm" | "md" | "lg";
+type IconButtonShape = "square" | "circle";
+
+interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: string;
+  variant?: IconButtonVariant;
+  size?: IconButtonSize;
+  shape?: IconButtonShape;
+  "aria-label": string;
+}
+
+function IconButton({
+  icon,
+  variant = "ghost",
+  size = "md",
+  shape = "square",
+  className = "",
+  ...rest
+}: IconButtonProps) {
+  const IconCmp = (window as any).Icon;
+  const cls = [
+    "grd-iconbtn",
+    `grd-iconbtn-${variant}`,
+    `grd-iconbtn-${size}`,
+    `grd-iconbtn-${shape}`,
+    className,
+  ].filter(Boolean).join(" ");
+  const iconSize = size === "sm" ? 14 : size === "lg" ? 20 : 16;
+  return (
+    <button className={cls} {...rest}>
+      {IconCmp && <IconCmp name={icon} size={iconSize} />}
+    </button>
+  );
+}
+
+IconButton.displayName = "IconButton";
+(window as any).IconButton = IconButton;

--- a/ux_references/ui_kits/components/Input/Input.playground.html
+++ b/ux_references/ui_kits/components/Input/Input.playground.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Input · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORMS · ENTRADA DE TEXTO</div>
+  <h1 class="pg-title">Input</h1>
+  <span class="pg-codename">import Input from "ui_kits/components/Input"</span>
+  <p class="pg-desc">Campo de texto de linha única. Suporta ícones à esquerda/direita, affix textual (R$, @, %), três tamanhos e três estados semânticos (default, erro, sucesso).</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, variant }: { title: string; children: React.ReactNode; variant?: string }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className={"pg-stage col "+(variant||"")}>{children}</div></div>);
+}
+function App() {
+  const [busca, setBusca] = React.useState("");
+  return (<>
+    <Sec title="Tamanhos">
+      <Input size="sm" placeholder="Small — 32px" />
+      <Input size="md" placeholder="Medium — 38px (default)" />
+      <Input size="lg" placeholder="Large — 46px" />
+    </Sec>
+    <Sec title="Com ícones">
+      <Input leftIcon="search" placeholder="Buscar clientes..." />
+      <Input rightIcon="calendar" placeholder="Selecione uma data" />
+      <Input leftIcon="mail" rightIcon="check" placeholder="seu@email.com" />
+    </Sec>
+    <Sec title="Affix (prefix/suffix)">
+      <Input prefix="R$" placeholder="0,00" />
+      <Input prefix="@" placeholder="usuário" />
+      <Input suffix="%" placeholder="10" />
+      <Input prefix="https://" suffix=".com.br" placeholder="minha-empresa" />
+    </Sec>
+    <Sec title="Estados">
+      <Input placeholder="Default — foco violeta" />
+      <Input state="error" defaultValue="cnpj-invalido" rightIcon="circle-x" />
+      <Input state="success" defaultValue="12.345.678/0001-90" rightIcon="check" />
+      <Input disabled defaultValue="Desabilitado" />
+    </Sec>
+    <Sec title="Controlado · busca ao vivo">
+      <Input leftIcon="search" placeholder="Digite para filtrar..." value={busca} onChange={(e) => setBusca(e.target.value)} />
+      <p style={{fontSize: 12, color: 'var(--gray-500)', margin: 0}}>
+        Valor atual: <code style={{background:'var(--violet-100)',color:'var(--violet-700)',padding:'1px 6px',borderRadius: "var(--radius-sm)",fontFamily:'var(--font-mono)',fontSize:11}}>{busca || "(vazio)"}</code>
+      </p>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+function ExampleApp() {
+  const code = `
+function FormularioEmpresa() {
+  const [cnpj, setCnpj] = React.useState("");
+  const invalido = cnpj.length > 0 && cnpj.length < 14;
+  const state = invalido ? "error" : cnpj.length >= 14 ? "success" : "default";
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, width: 320 }}>
+      <Input
+        leftIcon="building"
+        placeholder="00.000.000/0000-00"
+        value={cnpj}
+        onChange={(e) => setCnpj(e.target.value)}
+        state={state}
+        rightIcon={state === "success" ? "check" : state === "error" ? "circle-x" : undefined}
+      />
+      <Input prefix="R$" placeholder="Faturamento mensal" />
+    </div>
+  );
+}
+
+render(<FormularioEmpresa />);
+`;
+  return <LiveCode code={code} />;
+}
+ReactDOM.createRoot(document.getElementById('example-root')!).render(<ExampleApp />);
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>size</code></td><td>string</td><td><code>"md"</code></td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>state</code></td><td>string</td><td><code>"default"</code></td><td class="desc">default · error · success</td></tr>
+  <tr><td><code>invalid</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Atalho para <code>state="error"</code></td></tr>
+  <tr><td><code>leftIcon</code></td><td>IconName</td><td>—</td><td class="desc">Glifo à esquerda do campo</td></tr>
+  <tr><td><code>rightIcon</code></td><td>IconName</td><td>—</td><td class="desc">Glifo à direita do campo</td></tr>
+  <tr><td><code>prefix</code></td><td>ReactNode</td><td>—</td><td class="desc">Texto afixado no início (R$, @, etc.)</td></tr>
+  <tr><td><code>suffix</code></td><td>ReactNode</td><td>—</td><td class="desc">Texto afixado no fim (%, .com.br)</td></tr>
+  <tr><td><code>disabled</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Desabilita interação</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Campos de texto livre, busca, numéricos financeiros com máscara.</li>
+      <li>Label sempre visível; hint abaixo para formato; erro inline vermelho.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Placeholder como substituto de label.</li>
+      <li>Mensagens de erro genéricas ("Inválido").</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Input/index.css
+++ b/ux_references/ui_kits/components/Input/index.css
@@ -1,0 +1,42 @@
+
+/* Input */
+.grd-input {
+  display: inline-flex; align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  transition: border-color 140ms var(--ease-standard),
+              box-shadow 140ms var(--ease-standard);
+  width: 100%;
+}
+.grd-input input {
+  font-family: inherit; border: 0; background: transparent; outline: none;
+  color: var(--fg); width: 100%; padding: 0; margin: 0;
+}
+.grd-input input::placeholder { color: var(--gray-400); }
+
+/* Sizes */
+.grd-input-sm { padding: 6px 10px; font-size: 13px; height: 32px; }
+.grd-input-sm input { font-size: 13px; }
+.grd-input-md { padding: 8px 12px; font-size: 14px; height: 38px; }
+.grd-input-md input { font-size: 14px; }
+.grd-input-lg { padding: 10px 14px; font-size: 15px; height: 46px; }
+.grd-input-lg input { font-size: 15px; }
+
+/* States */
+.grd-input-default:focus-within { border-color: var(--violet-500); box-shadow: var(--focus-ring); }
+.grd-input-error   { border-color: var(--signal-red); }
+.grd-input-error:focus-within { box-shadow: var(--focus-ring-error); }
+.grd-input-success { border-color: var(--signal-green); }
+.grd-input-success:focus-within { box-shadow: var(--focus-ring-success); }
+.grd-input-disabled { background: var(--gray-100); opacity: 0.7; cursor: not-allowed; }
+.grd-input-disabled input { cursor: not-allowed; }
+
+/* Adornments */
+.grd-input-ic { color: var(--gray-500); display: inline-flex; flex-shrink: 0; }
+.grd-input-ic-l { margin-right: 8px; }
+.grd-input-ic-r { margin-left: 8px; }
+.grd-input-afx { color: var(--gray-500); font-size: 0.95em; font-weight: 500; flex-shrink: 0; }
+.grd-input-afx-l { margin-right: 8px; padding-right: 8px; border-right: 1px solid var(--border); }
+.grd-input-afx-r { margin-left: 8px; padding-left: 8px; border-left: 1px solid var(--border); }

--- a/ux_references/ui_kits/components/Input/index.tsx
+++ b/ux_references/ui_kits/components/Input/index.tsx
@@ -1,0 +1,60 @@
+
+/**
+ * Input — campo de texto de linha única.
+ * Props:
+ *   size:   sm · md (default) · lg
+ *   state:  default · error · success
+ *   leftIcon, rightIcon
+ *   prefix, suffix (ex: R$ / @)
+ *   invalid (boolean) — shortcut para state=error
+ */
+
+type InputSize = "sm" | "md" | "lg";
+type InputState = "default" | "error" | "success";
+
+interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
+  size?: InputSize;
+  state?: InputState;
+  invalid?: boolean;
+  leftIcon?: string;
+  rightIcon?: string;
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
+}
+
+function Input({
+  size = "md",
+  state = "default",
+  invalid,
+  leftIcon,
+  rightIcon,
+  prefix,
+  suffix,
+  className = "",
+  disabled,
+  ...rest
+}: InputProps) {
+  const IconCmp = (window as any).Icon;
+  const effectiveState = invalid ? "error" : state;
+  const wrapCls = [
+    "grd-input",
+    `grd-input-${size}`,
+    `grd-input-${effectiveState}`,
+    disabled && "grd-input-disabled",
+    (leftIcon || prefix) && "grd-input-has-left",
+    (rightIcon || suffix) && "grd-input-has-right",
+    className,
+  ].filter(Boolean).join(" ");
+  const iconSize = size === "sm" ? 13 : size === "lg" ? 18 : 15;
+  return (
+    <div className={wrapCls}>
+      {leftIcon && IconCmp && <span className="grd-input-ic grd-input-ic-l"><IconCmp name={leftIcon} size={iconSize} /></span>}
+      {prefix && <span className="grd-input-afx grd-input-afx-l">{prefix}</span>}
+      <input disabled={disabled} {...rest} />
+      {suffix && <span className="grd-input-afx grd-input-afx-r">{suffix}</span>}
+      {rightIcon && IconCmp && <span className="grd-input-ic grd-input-ic-r"><IconCmp name={rightIcon} size={iconSize} /></span>}
+    </div>
+  );
+}
+Input.displayName = "Input";
+(window as any).Input = Input;

--- a/ux_references/ui_kits/components/Kanban/Kanban.playground.html
+++ b/ux_references/ui_kits/components/Kanban/Kanban.playground.html
@@ -1,0 +1,429 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Kanban · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=1">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="../Badge/index.css">
+<link rel="stylesheet" href="../Avatar/index.css">
+<link rel="stylesheet" href="../Button/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">DATA · FLUXO</div>
+  <h1 class="pg-title">Kanban</h1>
+  <span class="pg-codename">import Kanban from "ui_kits/components/Kanban"</span>
+  <p class="pg-desc">Board de colunas com cards arrastáveis. Suporta reordenação dentro da coluna, swimlanes, colunas colapsáveis, filtro, adicionar card no rodapé, totais por coluna e indicador de confiança do agente. Cards customizáveis via <code>renderCard</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Input/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Avatar/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=1"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,alignItems:"stretch",flexDirection:"column",gap:24}}>{children}</div></div>);
+}
+function Frame({ children, label }: { children: React.ReactNode; label?: string }) {
+  return (
+    <div>
+      {label && <div style={{ fontSize: 11.5, color: "var(--fg-muted)", marginBottom: 10, fontWeight: 600, letterSpacing: ".04em", textTransform: "uppercase" }}>{label}</div>}
+      <div style={{ background: "var(--surface)", border: "1px solid var(--gray-200)", borderRadius: "var(--radius-lg)", padding: "18px 20px" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* Dados — equipe contábil                                            */
+/* ---------------------------------------------------------------- */
+
+const BRL = (n) => "R$ " + n.toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+const COLUMNS = [
+  { id: "backlog", title: "Backlog",      color: "var(--gray-400)" },
+  { id: "todo",    title: "A fazer",      color: "var(--blue-500)" },
+  { id: "doing",   title: "Em andamento", color: "var(--signal-yellow)" },
+  { id: "review",  title: "Revisão",      color: "var(--violet-500)" },
+  { id: "done",    title: "Concluído",    color: "var(--signal-green)" },
+];
+
+const INITIAL_CARDS = [
+  { id: "c1", columnId: "backlog", laneId: "urgente",
+    displayId: "TSK-2418", priority: "high",
+    title: "Apurar ICMS-ST de Verona SP — 04/2026",
+    description: "Revisar NF-es de fornecedores e calcular substituição tributária.",
+    tags: [{ label: "ICMS", tone: "red" }, { label: "Verona SP", tone: "violet" }],
+    assignee: { name: "Luana Ribeiro" },
+    dueDate: "30 abr",
+    dueStatus: "warn",
+    value: BRL(24890.50),
+    confidence: 0.62,
+    commentsCount: 3,
+    attachmentsCount: 2,
+  },
+  { id: "c2", columnId: "backlog", laneId: "normal",
+    displayId: "TSK-2419", priority: "med",
+    title: "Fechar folha de pagamento — abril",
+    description: "Integrar SST e revisar rubricas com departamento pessoal.",
+    tags: [{ label: "Folha", tone: "blue" }, { label: "Domínio", tone: "neutral" }],
+    assignee: { name: "Marcos Aoki" },
+    dueDate: "05 mai",
+    dueStatus: "ok",
+    value: BRL(186420.00),
+    commentsCount: 1,
+  },
+  { id: "c3", columnId: "todo", laneId: "normal",
+    displayId: "TSK-2420", priority: "med",
+    title: "Conciliar Itaú — 04/2026",
+    tags: [{ label: "Conciliação", tone: "violet" }],
+    assignee: { name: "Bianca Silva" },
+    dueDate: "02 mai", dueStatus: "ok",
+    progress: 0.35,
+    confidence: 0.97,
+  },
+  { id: "c4", columnId: "todo", laneId: "urgente",
+    displayId: "TSK-2421", priority: "high",
+    title: "Resposta à Receita — cliente Padaria da Esquina",
+    description: "Responder intimação 04893-2026 sobre divergência de COFINS.",
+    tags: [{ label: "Fisco", tone: "red" }, { label: "Urgente", tone: "red" }],
+    assignee: { name: "Luana Ribeiro" },
+    dueDate: "28 abr", dueStatus: "danger",
+    commentsCount: 8,
+  },
+  { id: "c5", columnId: "doing", laneId: "normal",
+    displayId: "TSK-2410", priority: "med",
+    title: "Regras de plano de contas — grupo Verona",
+    description: "Mapear 87 novas contas do grupo e validar hierarquia.",
+    tags: [{ label: "Contas", tone: "neutral" }],
+    assignee: { name: "Thiago Matos" },
+    dueDate: "03 mai", dueStatus: "ok",
+    progress: 0.68,
+    attachmentsCount: 1,
+  },
+  { id: "c6", columnId: "doing", laneId: "urgente",
+    displayId: "TSK-2415", priority: "high",
+    title: "DCTF de março — 12 clientes pendentes",
+    tags: [{ label: "Obrig. acessórias", tone: "amber" }],
+    assignee: { name: "Carolina Duarte" },
+    dueDate: "25 abr", dueStatus: "danger",
+    progress: 0.40,
+    confidence: 0.88,
+  },
+  { id: "c7", columnId: "review", laneId: "normal",
+    displayId: "TSK-2401", priority: "low",
+    title: "DRE abril — Mercearia Flor",
+    description: "Agente gerou automaticamente; aguardando revisão humana.",
+    tags: [{ label: "DRE", tone: "green" }],
+    assignee: { name: "Bianca Silva" },
+    dueDate: "02 mai",
+    dueStatus: "ok",
+    confidence: 0.98,
+    value: BRL(42310.00),
+  },
+  { id: "c8", columnId: "review", laneId: "urgente",
+    displayId: "TSK-2402", priority: "high",
+    title: "Parecer — Verona Logística (Simples → Lucro Presumido)",
+    description: "Enquadramento tributário expirou prazo.",
+    tags: [{ label: "Tributário", tone: "red" }, { label: "Parecer", tone: "violet" }],
+    assignee: { name: "Thiago Matos" },
+    dueDate: "01 mai", dueStatus: "warn",
+    confidence: 0.71,
+    commentsCount: 4,
+  },
+  { id: "c9", columnId: "done", laneId: "normal",
+    displayId: "TSK-2389", priority: "med",
+    title: "Conciliação Bradesco — março",
+    tags: [{ label: "Conciliação", tone: "violet" }],
+    assignee: { name: "Bianca Silva" },
+    dueDate: "01 abr", dueStatus: "ok",
+    progress: 1.0,
+    confidence: 0.99,
+    value: BRL(312400.55),
+  },
+  { id: "c10", columnId: "done", laneId: "normal",
+    displayId: "TSK-2390", priority: "low",
+    title: "SPED Contribuições — março",
+    assignee: { name: "Carolina Duarte" },
+    dueDate: "10 abr", dueStatus: "ok",
+    progress: 1.0,
+    confidence: 1.0,
+  },
+  { id: "c11", columnId: "backlog", laneId: "normal",
+    displayId: "TSK-2430", priority: "low",
+    title: "Levantar inconsistências — Café Central",
+    tags: [{ label: "Diagnóstico", tone: "neutral" }],
+    assignee: { name: "Marcos Aoki" },
+    dueDate: "15 mai", dueStatus: "ok",
+  },
+];
+
+const SWIMLANES = [
+  { id: "urgente", title: "Urgente (≤ 7 dias ou em atraso)" },
+  { id: "normal",  title: "Normal" },
+];
+
+/* ---------------------------------------------------------------- */
+/* Exemplo principal                                                 */
+/* ---------------------------------------------------------------- */
+
+function KanbanExample() {
+  const [cards, setCards] = React.useState(INITIAL_CARDS);
+
+  const handleMove = (cardId, toColumnId, toLaneId, toIndex) => {
+    setCards((prev) => {
+      const moving = prev.find((c) => c.id === cardId);
+      if (!moving) return prev;
+      const remaining = prev.filter((c) => c.id !== cardId);
+      const updated = { ...moving, columnId: toColumnId, laneId: toLaneId ?? moving.laneId };
+
+      /* Reinsere na posição correta: conta o índice dentro do grupo (columnId + laneId) */
+      const newList = [];
+      let placed = false;
+      let laneColIdx = 0;
+      for (const c of remaining) {
+        const inSameBucket = c.columnId === toColumnId && (toLaneId ? c.laneId === toLaneId : c.laneId === moving.laneId);
+        if (inSameBucket && laneColIdx === toIndex && !placed) {
+          newList.push(updated);
+          placed = true;
+        }
+        newList.push(c);
+        if (inSameBucket) laneColIdx++;
+      }
+      if (!placed) newList.push(updated);
+      return newList;
+    });
+  };
+
+  const columnsWithAdd = COLUMNS.map((c, i) => ({
+    ...c,
+    onAdd: i < COLUMNS.length - 1 ? () => alert(`Adicionar card em "${c.title}"`) : undefined,
+    showTotals: c.id === "review" || c.id === "done",
+    sumValue: (card) => {
+      if (!card.value) return 0;
+      const n = parseFloat(String(card.value).replace(/[^\d,.-]/g, "").replace(/\./g, "").replace(",", "."));
+      return isNaN(n) ? 0 : n;
+    },
+    sumFormat: (s) => BRL(s),
+    emptyState: c.id === "backlog" ? "Nada no backlog — 🎉" : c.id === "done" ? "Ainda sem concluídos" : undefined,
+  }));
+
+  return (
+    <Kanban
+      title="Tarefas da equipe"
+      columns={columnsWithAdd}
+      cards={cards}
+      swimlanes={SWIMLANES}
+      searchable
+      onCardMove={handleMove}
+    />
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* Exemplo minimal                                                   */
+/* ---------------------------------------------------------------- */
+function KanbanMinimal() {
+  const [cards, setCards] = React.useState([
+    { id: "m1", columnId: "c1", title: "Importar OFX do Itaú" },
+    { id: "m2", columnId: "c1", title: "Validar SPED março" },
+    { id: "m3", columnId: "c2", title: "Conciliar cartão Nubank" },
+    { id: "m4", columnId: "c3", title: "Fechar DRE abril" },
+  ]);
+  const cols = [
+    { id: "c1", title: "Backlog" },
+    { id: "c2", title: "Em andamento" },
+    { id: "c3", title: "Revisão" },
+    { id: "c4", title: "Pronto" },
+  ];
+  return (
+    <Kanban
+      columns={cols}
+      cards={cards}
+      onCardMove={(id, toCol, _lane, idx) => {
+        setCards((prev) => {
+          const moving = prev.find((c) => c.id === id);
+          if (!moving) return prev;
+          const rest = prev.filter((c) => c.id !== id);
+          const out = [];
+          let placed = false;
+          let bucketIdx = 0;
+          for (const c of rest) {
+            if (c.columnId === toCol && bucketIdx === idx && !placed) {
+              out.push({ ...moving, columnId: toCol });
+              placed = true;
+            }
+            out.push(c);
+            if (c.columnId === toCol) bucketIdx++;
+          }
+          if (!placed) out.push({ ...moving, columnId: toCol });
+          return out;
+        });
+      }}
+    />
+  );
+}
+
+/* ---------------------------------------------------------------- */
+/* Custom renderCard                                                  */
+/* ---------------------------------------------------------------- */
+function KanbanCustom() {
+  const [cards, setCards] = React.useState([
+    { id: "x1", columnId: "triage",  title: "Padaria da Esquina", raw: { cnpj: "12.345.678/0001-90", lanc: 41 } },
+    { id: "x2", columnId: "triage",  title: "Mercearia Flor",     raw: { cnpj: "98.765.432/0001-01", lanc: 28 } },
+    { id: "x3", columnId: "ready",   title: "Café Central",       raw: { cnpj: "11.222.333/0001-55", lanc: 12 } },
+    { id: "x4", columnId: "done",    title: "Verona Logística",   raw: { cnpj: "45.892.100/0001-33", lanc: 187 } },
+  ]);
+  const cols = [
+    { id: "triage", title: "Triagem",   color: "var(--gray-400)" },
+    { id: "ready",  title: "Pronto",    color: "var(--violet-500)" },
+    { id: "done",   title: "Enviado",   color: "var(--signal-green)" },
+  ];
+  return (
+    <Kanban
+      title="Fechamento mensal por cliente"
+      columns={cols}
+      cards={cards}
+      onCardMove={(id, toCol, _l, idx) => {
+        setCards((prev) => {
+          const moving = prev.find((c) => c.id === id);
+          if (!moving) return prev;
+          const rest = prev.filter((c) => c.id !== id);
+          const out = [];
+          let placed = false;
+          let bucketIdx = 0;
+          for (const c of rest) {
+            if (c.columnId === toCol && bucketIdx === idx && !placed) {
+              out.push({ ...moving, columnId: toCol });
+              placed = true;
+            }
+            out.push(c);
+            if (c.columnId === toCol) bucketIdx++;
+          }
+          if (!placed) out.push({ ...moving, columnId: toCol });
+          return out;
+        });
+      }}
+      renderCard={(card) => (
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <Avatar name={card.title} size="sm" />
+          <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
+            <span style={{ fontSize: 13, fontWeight: 600, color: "var(--fg)" }}>{card.title}</span>
+            <span style={{ fontSize: 11, color: "var(--fg-muted)" }}>CNPJ {card.raw.cnpj}</span>
+          </div>
+          <Badge tone="violet" variant="soft" size="xs" style={{ marginLeft: "auto" }}>{card.raw.lanc} lanç.</Badge>
+        </div>
+      )}
+    />
+  );
+}
+
+function App() {
+  return (<>
+    <Sec title="Tarefas da equipe contábil — D&D completo, swimlanes, busca, totais, confiança">
+      <Frame>
+        <KanbanExample />
+      </Frame>
+    </Sec>
+
+    <Sec title="Minimal — só título, sem metadata">
+      <Frame>
+        <KanbanMinimal />
+      </Frame>
+    </Sec>
+
+    <Sec title="Card customizado (renderCard) — fechamento por cliente">
+      <Frame>
+        <KanbanCustom />
+      </Frame>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Kanban"]) || "render(<div>Sem exemplo para Kanban</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>title</code></td><td>string</td><td>—</td><td class="desc">Título no header + contador total</td></tr>
+  <tr><td><code>columns</code></td><td>KanbanColumn[]</td><td>—</td><td class="desc">Colunas do board</td></tr>
+  <tr><td><code>cards</code></td><td>KanbanCard[]</td><td>—</td><td class="desc">Lista plana; cada card tem columnId (e opcional laneId)</td></tr>
+  <tr><td><code>swimlanes</code></td><td>Swimlane[]</td><td>—</td><td class="desc">Agrupamentos horizontais; se omitido, tudo fica numa lane única</td></tr>
+  <tr><td><code>searchable</code></td><td>bool</td><td>false</td><td class="desc">Filtro por título, tag, responsável, displayId</td></tr>
+  <tr><td><code>onCardMove</code></td><td>(id, col, lane, idx) ⇒ void</td><td>—</td><td class="desc">Disparado ao soltar um card. Você atualiza o estado</td></tr>
+  <tr><td><code>onCardClick</code></td><td>(card) ⇒ void</td><td>—</td><td class="desc">Clique em um card</td></tr>
+  <tr><td><code>renderCard</code></td><td>(card, ctx) ⇒ node</td><td>—</td><td class="desc">Substitui o card padrão por completo</td></tr>
+  <tr><td><code>defaultCollapsedColumns</code></td><td>string[]</td><td>—</td><td class="desc">Colunas colapsadas ao montar</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">KanbanColumn</th></tr>
+  <tr><td><code>id</code> · <code>title</code></td><td>string</td><td>—</td><td class="desc">Obrigatórios</td></tr>
+  <tr><td><code>color</code></td><td>string</td><td>—</td><td class="desc">Dot no header; qualquer CSS color ou var(--...)</td></tr>
+  <tr><td><code>onAdd</code></td><td>fn</td><td>—</td><td class="desc">Se informado, mostra botão "+ Adicionar card" no rodapé</td></tr>
+  <tr><td><code>emptyState</code></td><td>node</td><td>—</td><td class="desc">Conteúdo quando a coluna está vazia</td></tr>
+  <tr><td><code>showTotals</code> + <code>sumValue</code> + <code>sumFormat</code></td><td>bool + fns</td><td>—</td><td class="desc">Soma e formata um valor numérico a partir dos cards</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">KanbanCard (default renderer)</th></tr>
+  <tr><td><code>id</code> · <code>columnId</code> · <code>laneId?</code></td><td>string</td><td>—</td><td class="desc">Identidade e posição</td></tr>
+  <tr><td><code>title</code> · <code>description</code></td><td>node</td><td>—</td><td class="desc">Texto principal</td></tr>
+  <tr><td><code>displayId</code></td><td>string</td><td>—</td><td class="desc">Ex: "TSK-248"</td></tr>
+  <tr><td><code>priority</code></td><td>string</td><td>—</td><td class="desc">low · med · high (dot colorido)</td></tr>
+  <tr><td><code>tags</code></td><td>{label,tone}[]</td><td>—</td><td class="desc">Badges</td></tr>
+  <tr><td><code>assignee</code></td><td>{name,avatar?}</td><td>—</td><td class="desc">Avatar no rodapé</td></tr>
+  <tr><td><code>dueDate</code> + <code>dueStatus</code></td><td>string + ok/warn/danger</td><td>—</td><td class="desc">Data de vencimento com cor</td></tr>
+  <tr><td><code>value</code></td><td>node</td><td>—</td><td class="desc">Valor à direita (ex: "R$ 12.430,00")</td></tr>
+  <tr><td><code>confidence</code></td><td>number 0..1</td><td>—</td><td class="desc">Indicador do agente (≥95% verde, ≥75% amarelo, &lt; 75% vermelho)</td></tr>
+  <tr><td><code>progress</code></td><td>number 0..1</td><td>—</td><td class="desc">Barra fina no rodapé</td></tr>
+  <tr><td><code>commentsCount</code> · <code>attachmentsCount</code></td><td>number</td><td>—</td><td class="desc">Ícones no rodapé</td></tr>
+</table>
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Fluxos com estados bem definidos (≥3 colunas) e movimento frequente de itens entre eles.</li>
+      <li>Tarefas da equipe contábil, pendências por cliente, pipeline de revisão.</li>
+      <li>Swimlanes quando um segundo eixo (urgência, cliente, responsável) precisa de destaque visual.</li>
+      <li>Totais por coluna em contextos financeiros (soma do valor em Revisão e Concluído).</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Dados lineares sem fluxo — use <code>DataTable</code> ou lista simples.</li>
+      <li>Mais que 6 colunas — vira scroll horizontal inoperante.</li>
+      <li>Cards com 15+ campos — mova detalhes para <code>Drawer</code> ao clicar.</li>
+    </ul>
+  </div>
+</div>
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Kanban/index.css
+++ b/ux_references/ui_kits/components/Kanban/index.css
@@ -1,0 +1,420 @@
+
+/* ===================================================================
+ * Kanban — colunas com cards arrastáveis, swimlanes, colapsável
+ * ================================================================= */
+
+.grd-kb {
+  font-family: var(--font-sans);
+  color: var(--fg);
+  --kb-gap: 12px;
+  --kb-col-w: 280px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* -------- Header (filtro + busca) -------- */
+.grd-kb-hdr {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 0 14px 0;
+  border-bottom: 1px solid var(--gray-100);
+  margin-bottom: 14px;
+}
+.grd-kb-hdr-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+.grd-kb-hdr-count {
+  font-size: 12px;
+  color: var(--fg-muted);
+  font-feature-settings: "tnum";
+}
+.grd-kb-hdr-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.grd-kb-hdr-search { min-width: 240px; }
+
+/* -------- Board (scroll horizontal) -------- */
+.grd-kb-board {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  min-height: 0;
+}
+.grd-kb-lane {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+}
+.grd-kb-lane-hdr {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 4px;
+  cursor: pointer;
+  user-select: none;
+}
+.grd-kb-lane-caret {
+  width: 14px; height: 14px;
+  color: var(--fg-muted);
+  transition: transform 160ms;
+}
+.grd-kb-lane-caret-open { transform: rotate(90deg); }
+.grd-kb-lane-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.grd-kb-lane-count {
+  font-size: 11px;
+  color: var(--fg-muted);
+  background: var(--gray-100);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-feature-settings: "tnum";
+}
+.grd-kb-lane-body {
+  display: flex;
+  gap: var(--kb-gap);
+  overflow-x: auto;
+  padding: 4px 2px 14px 2px;
+  scroll-snap-type: x proximity;
+}
+.grd-kb-lane-body::-webkit-scrollbar { height: 8px; }
+.grd-kb-lane-body::-webkit-scrollbar-thumb {
+  background: var(--gray-200);
+  border-radius: 999px;
+}
+.grd-kb-lane-body::-webkit-scrollbar-track { background: transparent; }
+
+/* -------- Coluna -------- */
+.grd-kb-col {
+  flex: 0 0 var(--kb-col-w);
+  width: var(--kb-col-w);
+  display: flex;
+  flex-direction: column;
+  background: var(--gray-50);
+  border: 1px solid var(--gray-100);
+  border-radius: var(--radius-lg);
+  min-height: 220px;
+  max-height: 680px;
+  scroll-snap-align: start;
+  transition: background 140ms, border-color 140ms;
+}
+.grd-kb-col-collapsed {
+  flex: 0 0 44px;
+  width: 44px;
+  min-height: 0;
+}
+.grd-kb-col-hdr {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px 10px 12px;
+  cursor: pointer;
+  user-select: none;
+  border-bottom: 1px solid transparent;
+}
+.grd-kb-col-hdr-chip {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--gray-400);
+}
+.grd-kb-col-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--fg);
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.grd-kb-col-count {
+  font-size: 11px;
+  color: var(--fg-muted);
+  background: var(--surface);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-feature-settings: "tnum";
+  border: 1px solid var(--gray-200);
+}
+.grd-kb-col-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 2px;
+}
+.grd-kb-col-act {
+  width: 22px; height: 22px;
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+.grd-kb-col-act:hover { background: var(--gray-100); color: var(--fg); }
+
+.grd-kb-col-totals {
+  padding: 0 12px 8px 12px;
+  font-size: 11px;
+  color: var(--fg-muted);
+  display: flex;
+  justify-content: space-between;
+  font-feature-settings: "tnum";
+}
+.grd-kb-col-totals strong { color: var(--fg); font-weight: 600; }
+
+.grd-kb-col-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 8px 8px 8px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 60px;
+}
+.grd-kb-col-body::-webkit-scrollbar { width: 6px; }
+.grd-kb-col-body::-webkit-scrollbar-thumb { background: var(--gray-200); border-radius: 999px; }
+
+.grd-kb-col-empty {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 18px 14px;
+  font-size: 12px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+}
+
+.grd-kb-col-add {
+  padding: 6px 8px 10px 8px;
+}
+.grd-kb-col-add-btn {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 10px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--fg-muted);
+  background: transparent;
+  border: 1px dashed var(--gray-300);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 120ms, color 120ms, border-color 120ms;
+}
+.grd-kb-col-add-btn:hover {
+  background: var(--surface);
+  color: var(--violet-700);
+  border-color: var(--violet-400);
+  border-style: solid;
+}
+
+/* -------- Coluna colapsada -------- */
+.grd-kb-col-collapsed .grd-kb-col-hdr {
+  flex-direction: column;
+  padding: 10px 4px;
+  gap: 8px;
+  height: 100%;
+  border-bottom: 0;
+}
+.grd-kb-col-collapsed .grd-kb-col-title {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 12px;
+}
+.grd-kb-col-collapsed .grd-kb-col-body,
+.grd-kb-col-collapsed .grd-kb-col-add,
+.grd-kb-col-collapsed .grd-kb-col-totals { display: none; }
+
+/* -------- Drag over (coluna destino) -------- */
+.grd-kb-col-over {
+  background: var(--violet-50);
+  border-color: var(--violet-400);
+  box-shadow: inset 0 0 0 1.5px var(--violet-400);
+}
+
+/* =========================================================
+ * Card
+ * ========================================================= */
+.grd-kb-card {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-md);
+  padding: 12px 12px 10px 12px;
+  cursor: grab;
+  box-shadow: var(--shadow-xs);
+  transition: box-shadow 140ms, border-color 140ms, transform 120ms, opacity 140ms;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.grd-kb-card:hover {
+  border-color: var(--gray-300);
+  box-shadow: var(--shadow-sm);
+}
+.grd-kb-card:active { cursor: grabbing; }
+.grd-kb-card-dragging {
+  opacity: .5;
+  transform: rotate(1.5deg);
+  box-shadow: var(--shadow-md);
+}
+
+.grd-kb-card-topbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  min-height: 18px;
+}
+.grd-kb-card-id {
+  font-size: 10.5px;
+  color: var(--fg-muted);
+  font-weight: 500;
+  font-feature-settings: "tnum";
+  letter-spacing: .02em;
+}
+.grd-kb-card-prio {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.grd-kb-card-prio-high   { background: var(--signal-red);    box-shadow: 0 0 0 2px var(--danger-soft); }
+.grd-kb-card-prio-med    { background: var(--signal-yellow); box-shadow: 0 0 0 2px var(--yellow-100); }
+.grd-kb-card-prio-low    { background: var(--gray-400); }
+
+.grd-kb-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  line-height: 1.4;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.grd-kb-card-desc {
+  font-size: 12px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.grd-kb-card-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.grd-kb-card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+}
+.grd-kb-card-meta-l,
+.grd-kb-card-meta-r {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.grd-kb-card-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-feature-settings: "tnum";
+}
+.grd-kb-card-meta-item.is-danger { color: var(--signal-red); font-weight: 600; }
+.grd-kb-card-meta-item.is-warn   { color: var(--yellow-900); font-weight: 600; }
+
+.grd-kb-card-value {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--fg);
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+}
+
+/* Confiança do agente */
+.grd-kb-card-conf {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 10.5px;
+  font-weight: 600;
+  font-feature-settings: "tnum";
+}
+.grd-kb-card-conf-high { background: var(--success-soft); color: var(--signal-green); }
+.grd-kb-card-conf-mid  { background: var(--yellow-100);   color: var(--yellow-900); }
+.grd-kb-card-conf-low  { background: var(--danger-soft);  color: var(--signal-red); }
+.grd-kb-card-conf-dot  { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+.grd-kb-card-progress {
+  height: 3px;
+  background: var(--gray-100);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-top: 2px;
+}
+.grd-kb-card-progress-fill {
+  height: 100%;
+  background: var(--violet-500);
+  transition: width 260ms;
+}
+
+/* Drop-indicator entre cards (dentro da coluna) */
+.grd-kb-card-drop {
+  height: 2px;
+  background: transparent;
+  border-radius: 2px;
+  margin: -3px 4px;
+  transition: background 100ms;
+}
+.grd-kb-card-drop.is-active {
+  background: var(--violet-500);
+  box-shadow: 0 0 0 4px var(--violet-100);
+}
+
+/* =========================================================
+ * Mobile: stack vertical
+ * ========================================================= */
+@media (max-width: 720px) {
+  .grd-kb-lane-body {
+    flex-direction: column;
+    overflow-x: hidden;
+  }
+  .grd-kb-col {
+    flex: 1 1 auto;
+    width: 100%;
+    max-height: none;
+  }
+}

--- a/ux_references/ui_kits/components/Kanban/index.tsx
+++ b/ux_references/ui_kits/components/Kanban/index.tsx
@@ -1,0 +1,443 @@
+
+/**
+ * Kanban — board com colunas, cards arrastáveis, swimlanes e colunas colapsáveis.
+ *
+ * Uso típico na Guardia: tarefas da equipe contábil, pipeline de revisão,
+ * gestão de pendências com clientes.
+ *
+ * Arquitetura:
+ *   columns[]:   estrutura fixa das colunas (id, title, color, onAdd?…)
+ *   cards[]:     lista plana de cards (cada card tem columnId e opcionalmente laneId)
+ *   swimlanes?:  agrupamentos horizontais (se omitido, tudo vai pra lane "default")
+ *
+ * Drag and drop:
+ *   onCardMove(cardId, toColumnId, toLaneId, toIndex)
+ *   — reordenar dentro da coluna (mesma columnId, toIndex diferente)
+ *   — mover entre colunas (columnId diferente)
+ *
+ * Render customizado:
+ *   renderCard(card) ⇒ ReactNode  substitui o card padrão por completo
+ */
+
+interface KanbanTag {
+  label: string;
+  tone?: "violet" | "green" | "amber" | "red" | "blue" | "neutral";
+}
+
+interface KanbanCardData {
+  id: string;
+  columnId: string;
+  laneId?: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /* Meta */
+  displayId?: string;                // ex: "TSK-248"
+  priority?: "low" | "med" | "high";
+  tags?: KanbanTag[];
+  assignee?: { name: string; avatar?: string };
+  dueDate?: string;
+  dueStatus?: "ok" | "warn" | "danger";    // colore a data
+  value?: React.ReactNode;           // valor monetário ou numérico à direita
+  confidence?: number;               // 0..1 — indicador do agente
+  progress?: number;                 // 0..1 — barra fina no rodapé
+  commentsCount?: number;
+  attachmentsCount?: number;
+  raw?: any;                         // payload livre pra passar ao renderCard
+}
+
+interface KanbanColumn {
+  id: string;
+  title: string;
+  color?: string;                    // dot no header; aceita qualquer CSS color ou var(--...)
+  onAdd?: () => void;
+  emptyState?: React.ReactNode;
+  showTotals?: boolean;              // mostra contagem + soma de "value" no header
+  sumValue?: (card: KanbanCardData) => number; // como extrair valor numérico do card
+  sumFormat?: (sum: number) => string;         // como formatar a soma total
+}
+
+interface KanbanSwimlane {
+  id: string;
+  title: string;
+  defaultCollapsed?: boolean;
+}
+
+interface KanbanProps {
+  title?: string;
+  columns: KanbanColumn[];
+  cards: KanbanCardData[];
+  swimlanes?: KanbanSwimlane[];
+  searchable?: boolean;
+  onCardMove?: (cardId: string, toColumnId: string, toLaneId: string | undefined, toIndex: number) => void;
+  onCardClick?: (card: KanbanCardData) => void;
+  renderCard?: (card: KanbanCardData, ctx: { dragging: boolean }) => React.ReactNode;
+  /* Colunas colapsáveis */
+  defaultCollapsedColumns?: string[];
+  className?: string;
+}
+
+/* --------------------------------------------------------- */
+/* Helpers                                                    */
+/* --------------------------------------------------------- */
+
+function cardMatches(card: KanbanCardData, q: string): boolean {
+  if (!q) return true;
+  const lc = q.toLowerCase();
+  const haystack = [
+    String(card.title ?? ""),
+    String(card.description ?? ""),
+    card.displayId ?? "",
+    card.assignee?.name ?? "",
+    ...(card.tags ?? []).map((t) => t.label),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(lc);
+}
+
+function confidenceBucket(c: number): "high" | "mid" | "low" {
+  if (c >= 0.95) return "high";
+  if (c >= 0.75) return "mid";
+  return "low";
+}
+
+/* --------------------------------------------------------- */
+/* Default card renderer                                      */
+/* --------------------------------------------------------- */
+
+function DefaultCard({ card }: { card: KanbanCardData }) {
+  const IconCmp = (window as any).Icon;
+  const AvatarCmp = (window as any).Avatar;
+  const BadgeCmp = (window as any).Badge;
+
+  const hasTopBar =
+    card.displayId || card.priority;
+  const hasMeta =
+    card.assignee || card.dueDate || card.value || card.confidence !== undefined ||
+    card.commentsCount || card.attachmentsCount;
+
+  return (
+    <>
+      {hasTopBar && (
+        <div className="grd-kb-card-topbar">
+          {card.priority && (
+            <span
+              className={`grd-kb-card-prio grd-kb-card-prio-${card.priority}`}
+              aria-label={`prioridade ${card.priority}`}
+            />
+          )}
+          {card.displayId && <span className="grd-kb-card-id">{card.displayId}</span>}
+          {card.confidence !== undefined && (
+            <span className={`grd-kb-card-conf grd-kb-card-conf-${confidenceBucket(card.confidence)}`} style={{ marginLeft: "auto" }}>
+              <span className="grd-kb-card-conf-dot" />
+              {Math.round(card.confidence * 100)}%
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="grd-kb-card-title">{card.title}</div>
+      {card.description && <div className="grd-kb-card-desc">{card.description}</div>}
+
+      {card.tags && card.tags.length > 0 && (
+        <div className="grd-kb-card-tags">
+          {card.tags.map((t, i) =>
+            BadgeCmp
+              ? <BadgeCmp key={i} variant="soft" tone={t.tone ?? "neutral"} size="xs">{t.label}</BadgeCmp>
+              : <span key={i} style={{ fontSize: 10.5, color: "var(--fg-muted)" }}>{t.label}</span>
+          )}
+        </div>
+      )}
+
+      {typeof card.progress === "number" && (
+        <div className="grd-kb-card-progress">
+          <div className="grd-kb-card-progress-fill" style={{ width: `${Math.min(100, Math.max(0, card.progress * 100))}%` }} />
+        </div>
+      )}
+
+      {hasMeta && (
+        <div className="grd-kb-card-meta">
+          <div className="grd-kb-card-meta-l">
+            {card.assignee && AvatarCmp && (
+              <AvatarCmp name={card.assignee.name} src={card.assignee.avatar} size="xs" />
+            )}
+            {card.dueDate && (
+              <span className={`grd-kb-card-meta-item ${card.dueStatus === "danger" ? "is-danger" : card.dueStatus === "warn" ? "is-warn" : ""}`}>
+                {IconCmp && <IconCmp name="calendar" size={11} />}
+                {card.dueDate}
+              </span>
+            )}
+            {typeof card.commentsCount === "number" && card.commentsCount > 0 && (
+              <span className="grd-kb-card-meta-item">
+                {IconCmp && <IconCmp name="message-circle" size={11} />}
+                {card.commentsCount}
+              </span>
+            )}
+            {typeof card.attachmentsCount === "number" && card.attachmentsCount > 0 && (
+              <span className="grd-kb-card-meta-item">
+                {IconCmp && <IconCmp name="paperclip" size={11} />}
+                {card.attachmentsCount}
+              </span>
+            )}
+          </div>
+          <div className="grd-kb-card-meta-r">
+            {card.value !== undefined && <span className="grd-kb-card-value">{card.value}</span>}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+/* --------------------------------------------------------- */
+/* Kanban principal                                           */
+/* --------------------------------------------------------- */
+
+function Kanban({
+  title,
+  columns,
+  cards,
+  swimlanes,
+  searchable = false,
+  onCardMove,
+  onCardClick,
+  renderCard,
+  defaultCollapsedColumns,
+  className = "",
+}: KanbanProps) {
+  const IconCmp = (window as any).Icon;
+  const InputCmp = (window as any).Input;
+
+  const [q, setQ] = React.useState("");
+  const [collapsed, setCollapsed] = React.useState<Set<string>>(() => new Set(defaultCollapsedColumns ?? []));
+  const [collapsedLanes, setCollapsedLanes] = React.useState<Set<string>>(() => {
+    const s = new Set<string>();
+    swimlanes?.forEach((l) => l.defaultCollapsed && s.add(l.id));
+    return s;
+  });
+
+  /* ---- DnD state ---- */
+  const [draggingId, setDraggingId] = React.useState<string | null>(null);
+  const [dropTarget, setDropTarget] = React.useState<{ columnId: string; laneId: string | undefined; index: number } | null>(null);
+
+  const toggleCol = (id: string) => {
+    const next = new Set(collapsed);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    setCollapsed(next);
+  };
+  const toggleLane = (id: string) => {
+    const next = new Set(collapsedLanes);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    setCollapsedLanes(next);
+  };
+
+  /* Filtro + agrupamento */
+  const visibleCards = React.useMemo(
+    () => cards.filter((c) => cardMatches(c, q)),
+    [cards, q]
+  );
+  const totalCount = visibleCards.length;
+
+  const lanes: KanbanSwimlane[] = swimlanes && swimlanes.length > 0
+    ? swimlanes
+    : [{ id: "__default", title: "" }];
+
+  const cardsByLaneColumn = React.useMemo(() => {
+    const map: Record<string, Record<string, KanbanCardData[]>> = {};
+    for (const lane of lanes) map[lane.id] = Object.fromEntries(columns.map((c) => [c.id, []]));
+    for (const card of visibleCards) {
+      const laneId = card.laneId && map[card.laneId] ? card.laneId : lanes[0].id;
+      const colMap = map[laneId] ?? map[lanes[0].id];
+      if (colMap[card.columnId]) colMap[card.columnId].push(card);
+    }
+    return map;
+  }, [visibleCards, columns, lanes]);
+
+  /* ---- Handlers DnD ---- */
+  const handleDragStart = (e: React.DragEvent, cardId: string) => {
+    setDraggingId(cardId);
+    e.dataTransfer.effectAllowed = "move";
+    try { e.dataTransfer.setData("text/plain", cardId); } catch { /* noop */ }
+  };
+  const handleDragEnd = () => {
+    setDraggingId(null);
+    setDropTarget(null);
+  };
+  const handleDrop = (columnId: string, laneId: string | undefined, index: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!draggingId) return;
+    onCardMove?.(draggingId, columnId, laneId === "__default" ? undefined : laneId, index);
+    setDraggingId(null);
+    setDropTarget(null);
+  };
+
+  /* ---- Render ---- */
+  return (
+    <div className={`grd-kb ${className}`}>
+      {(title || searchable) && (
+        <div className="grd-kb-hdr">
+          {title && <h3 className="grd-kb-hdr-title">{title}</h3>}
+          {typeof totalCount === "number" && <span className="grd-kb-hdr-count">· {totalCount} cards</span>}
+          <div className="grd-kb-hdr-actions">
+            {searchable && InputCmp && (
+              <div className="grd-kb-hdr-search">
+                <InputCmp size="sm" leftIcon="search" placeholder="Buscar por título, tag, responsável…" value={q} onChange={(e: any) => setQ(e.target.value)} />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="grd-kb-board">
+        {lanes.map((lane) => {
+          const laneIsCollapsed = collapsedLanes.has(lane.id);
+          const laneCardCount = columns.reduce(
+            (sum, col) => sum + (cardsByLaneColumn[lane.id]?.[col.id]?.length ?? 0), 0
+          );
+          const showLaneHdr = lane.id !== "__default";
+
+          return (
+            <div key={lane.id} className="grd-kb-lane">
+              {showLaneHdr && (
+                <div className="grd-kb-lane-hdr" onClick={() => toggleLane(lane.id)}>
+                  <span className={`grd-kb-lane-caret ${!laneIsCollapsed ? "grd-kb-lane-caret-open" : ""}`}>
+                    {IconCmp ? <IconCmp name="chevron-right" size={13} /> : "›"}
+                  </span>
+                  <span className="grd-kb-lane-title">{lane.title}</span>
+                  <span className="grd-kb-lane-count">{laneCardCount}</span>
+                </div>
+              )}
+              {!laneIsCollapsed && (
+                <div className="grd-kb-lane-body">
+                  {columns.map((col) => {
+                    const list = cardsByLaneColumn[lane.id]?.[col.id] ?? [];
+                    const isColCollapsed = collapsed.has(col.id);
+                    const isOver = dropTarget?.columnId === col.id && dropTarget?.laneId === lane.id;
+                    const sumTotal = col.showTotals && col.sumValue
+                      ? list.reduce((acc, c) => acc + col.sumValue!(c), 0)
+                      : null;
+                    return (
+                      <div
+                        key={col.id}
+                        className={`grd-kb-col ${isColCollapsed ? "grd-kb-col-collapsed" : ""} ${isOver ? "grd-kb-col-over" : ""}`}
+                        onDragOver={(e) => {
+                          if (!draggingId || isColCollapsed) return;
+                          e.preventDefault();
+                          e.dataTransfer.dropEffect = "move";
+                          if (!dropTarget || dropTarget.columnId !== col.id || dropTarget.laneId !== lane.id) {
+                            setDropTarget({ columnId: col.id, laneId: lane.id, index: list.length });
+                          }
+                        }}
+                        onDrop={handleDrop(col.id, lane.id, list.length)}
+                      >
+                        <div className="grd-kb-col-hdr" onClick={() => toggleCol(col.id)}>
+                          <span className="grd-kb-col-hdr-chip" style={col.color ? { background: col.color } : undefined} />
+                          <span className="grd-kb-col-title">{col.title}</span>
+                          {!isColCollapsed && <span className="grd-kb-col-count">{list.length}</span>}
+                          {!isColCollapsed && (
+                            <div className="grd-kb-col-actions">
+                              <button
+                                type="button"
+                                className="grd-kb-col-act"
+                                aria-label="Colapsar coluna"
+                                onClick={(e) => { e.stopPropagation(); toggleCol(col.id); }}
+                              >
+                                {IconCmp ? <IconCmp name="minimize-2" size={13} /> : "–"}
+                              </button>
+                            </div>
+                          )}
+                        </div>
+
+                        {!isColCollapsed && col.showTotals && sumTotal !== null && (
+                          <div className="grd-kb-col-totals">
+                            <span>Total</span>
+                            <strong>{col.sumFormat ? col.sumFormat(sumTotal) : sumTotal}</strong>
+                          </div>
+                        )}
+
+                        {!isColCollapsed && (
+                          <div className="grd-kb-col-body">
+                            {list.length === 0 ? (
+                              <div className="grd-kb-col-empty">
+                                {col.emptyState ?? "Sem cards por aqui"}
+                              </div>
+                            ) : (
+                              list.map((card, idx) => {
+                                const isDrop =
+                                  dropTarget?.columnId === col.id &&
+                                  dropTarget?.laneId === lane.id &&
+                                  dropTarget?.index === idx;
+                                return (
+                                  <React.Fragment key={card.id}>
+                                    <div
+                                      className={`grd-kb-card-drop ${isDrop ? "is-active" : ""}`}
+                                      onDragOver={(e) => {
+                                        if (!draggingId) return;
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                        setDropTarget({ columnId: col.id, laneId: lane.id, index: idx });
+                                      }}
+                                      onDrop={handleDrop(col.id, lane.id, idx)}
+                                    />
+                                    <div
+                                      className={`grd-kb-card ${draggingId === card.id ? "grd-kb-card-dragging" : ""}`}
+                                      draggable
+                                      onDragStart={(e) => handleDragStart(e, card.id)}
+                                      onDragEnd={handleDragEnd}
+                                      onClick={() => onCardClick?.(card)}
+                                    >
+                                      {renderCard
+                                        ? renderCard(card, { dragging: draggingId === card.id })
+                                        : <DefaultCard card={card} />}
+                                    </div>
+                                  </React.Fragment>
+                                );
+                              })
+                            )}
+                            {/* drop zone final */}
+                            {list.length > 0 && (
+                              <div
+                                className={`grd-kb-card-drop ${
+                                  dropTarget?.columnId === col.id &&
+                                  dropTarget?.laneId === lane.id &&
+                                  dropTarget?.index === list.length
+                                    ? "is-active" : ""
+                                }`}
+                                onDragOver={(e) => {
+                                  if (!draggingId) return;
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  setDropTarget({ columnId: col.id, laneId: lane.id, index: list.length });
+                                }}
+                                onDrop={handleDrop(col.id, lane.id, list.length)}
+                              />
+                            )}
+                          </div>
+                        )}
+
+                        {!isColCollapsed && col.onAdd && (
+                          <div className="grd-kb-col-add">
+                            <button
+                              type="button"
+                              className="grd-kb-col-add-btn"
+                              onClick={col.onAdd}
+                            >
+                              {IconCmp && <IconCmp name="plus" size={13} />}
+                              Adicionar card
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+Kanban.displayName = "Kanban";
+(window as any).Kanban = Kanban;

--- a/ux_references/ui_kits/components/Label/Label.playground.html
+++ b/ux_references/ui_kits/components/Label/Label.playground.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Label · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · FORMULÁRIO</div>
+  <h1 class="pg-title">Label</h1>
+  <span class="pg-codename">import Label from "ui_kits/components/Label"</span>
+  <p class="pg-desc">Rótulo semântico para campos de formulário. Suporta indicação de obrigatório (<code>*</code>) ou opcional. Sempre usar <code>htmlFor</code> apontando para o id do input.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Input/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch"}}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Variantes">
+      <Label htmlFor="f1">Razão social</Label>
+      <Label htmlFor="f2" required>CNPJ</Label>
+      <Label htmlFor="f3" optional>Inscrição Estadual</Label>
+    </Sec>
+    <Sec title="Com campo acoplado (uso real)">
+      <div>
+        <Label htmlFor="rs" required>Razão social</Label>
+        <Input id="rs" placeholder="Contábil Silva & Cia Ltda." />
+      </div>
+      <div>
+        <Label htmlFor="cnpj" required>CNPJ</Label>
+        <Input id="cnpj" placeholder="00.000.000/0000-00" />
+      </div>
+      <div>
+        <Label htmlFor="ie" optional>Inscrição Estadual</Label>
+        <Input id="ie" placeholder="Se houver" />
+      </div>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Label"]) || "render(<div>Sem exemplo para Label</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>htmlFor</code></td><td>string</td><td>—</td><td class="desc">Id do input associado (acessibilidade)</td></tr>
+  <tr><td><code>required</code></td><td>boolean</td><td>false</td><td class="desc">Mostra asterisco vermelho</td></tr>
+  <tr><td><code>optional</code></td><td>boolean</td><td>false</td><td class="desc">Mostra sufixo "(opcional)"</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Antecede cada input/select/textarea; clicável; indicador <em>*</em> para obrigatório.</li>
+      <li>Texto conciso, sentence case.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Labels em caixa alta ou longas demais.</li>
+      <li>Esconder label em nome de minimalismo.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Label/index.css
+++ b/ux_references/ui_kits/components/Label/index.css
@@ -1,0 +1,13 @@
+/* Label */
+.grd-label {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--font-sans);
+  font-size: 12.5px; font-weight: 600;
+  color: var(--fg);
+  letter-spacing: -0.005em;
+  margin-bottom: 6px;
+}
+.grd-label-required { color: var(--signal-red); font-weight: 600; }
+.grd-label-optional {
+  color: var(--gray-500); font-weight: 400; font-size: 11.5px;
+}

--- a/ux_references/ui_kits/components/Label/index.tsx
+++ b/ux_references/ui_kits/components/Label/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * Label — rótulo de campo de formulário.
+ * Props: required (estrela), optional (sufixo).
+ * Renderiza <label>; precisa `htmlFor` apontando pro input.
+ */
+
+interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  required?: boolean;
+  optional?: boolean;
+}
+
+function Label({ required, optional, className = "", children, ...rest }: LabelProps) {
+  const cls = ["grd-label", className].filter(Boolean).join(" ");
+  return (
+    <label className={cls} {...rest}>
+      {children}
+      {required && <span className="grd-label-required" aria-hidden>*</span>}
+      {optional && <span className="grd-label-optional">(opcional)</span>}
+    </label>
+  );
+}
+Label.displayName = "Label";
+(window as any).Label = Label;

--- a/ux_references/ui_kits/components/Logo/Logo.playground.html
+++ b/ux_references/ui_kits/components/Logo/Logo.playground.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Logo · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<style>
+  .lg-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; width: 100%; }
+  .lg-tile { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: #fff; position: relative; }
+  .lg-stage { height: 140px; display: flex; align-items: center; justify-content: center; padding: 18px; }
+  .lg-bg-light  { background: #FDFDFD; }
+  .lg-bg-dark   { background: var(--violet-900); }
+  .lg-bg-violet { background: var(--violet-700); }
+  .lg-meta { padding: 10px 12px 12px; border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: 10.5px; color: var(--violet-700); line-height: 1.55; display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+  .lg-meta .lg-label { display: block; font-family: var(--font-sans); font-size: 12px; font-weight: 600; color: var(--violet-500); margin-bottom: 3px; }
+  .lg-dl { flex-shrink: 0; width: 26px; height: 26px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: #fff; color: var(--gray-500); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; transition: all 0.12s; text-decoration: none; }
+  .lg-dl:hover { background: var(--violet-100); border-color: var(--violet-300); color: var(--violet-500); }
+  .lg-sizes-row { display: flex; gap: 32px; align-items: flex-end; flex-wrap: wrap; padding: 24px !important; }
+  .lg-size-item { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+  .lg-size-item .lg-size-label { font-family: var(--font-mono); font-size: 10px; color: var(--gray-500); }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">BRAND · SÍMBOLO</div>
+  <h1 class="pg-title">Logo</h1>
+  <span class="pg-codename">import Logo from "ui_kits/components/Logo"</span>
+  <p class="pg-desc">Símbolo G isolado (sem a palavra "Guardia"). Usado em favicons, app icons, avatares, tiles compactos e assinaturas curtas. Oito variantes — quatro transparentes e quatro em container rounded. Clique no ícone de download em cada tile para baixar o SVG original.</p>
+</div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx">
+const FILE: Record<string,string> = {
+  "purple":                  "guardia-logo-purple-transparent.svg",
+  "orange":                  "guardia-logo-orange-transparent.svg",
+  "mono-black":              "guardia-logo-mono-black.svg",
+  "mono-white":              "guardia-logo-mono-white.svg",
+  "rounded-purple":          "guardia-logo-purple-rounded.svg",
+  "rounded-orange":          "guardia-logo-orange-rounded.svg",
+  "rounded-bicolor-purple":  "guardia-logo-orange-and-purple.svg",
+  "rounded-bicolor-orange":  "guardia-logo-purple-and-orange.svg",
+};
+
+function Tile({ variant, bg, label, size = 56 }:{ variant: string; bg: string; label: string; size?: number }) {
+  const file = FILE[variant];
+  const href = `../../../assets/logo/${file}`;
+  return (
+    <div className="lg-tile">
+      <div className={"lg-stage " + bg}><Logo variant={variant as any} size={size} /></div>
+      <div className="lg-meta">
+        <div>
+          <span className="lg-label">{label}</span>
+          variant="{variant}"
+        </div>
+        <a className="lg-dl" href={href} download={file} title={`Baixar ${file}`} aria-label={`Baixar ${file}`}>
+          <Icon name="download" size={14} />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function Sec({ title, children }:{ title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="lg-grid">{children}</div></div>);
+}
+
+function App() {
+  return (<>
+    <Sec title="Transparentes — herdam o fundo da tela">
+      <Tile variant="purple"     bg="lg-bg-light"  label="Purple (default)" />
+      <Tile variant="orange"     bg="lg-bg-violet" label="Orange" />
+      <Tile variant="mono-black" bg="lg-bg-light"  label="Mono black" />
+      <Tile variant="mono-white" bg="lg-bg-dark"   label="Mono white" />
+    </Sec>
+
+    <Sec title="Rounded — container sólido, para app icons">
+      <Tile variant="rounded-purple"         bg="lg-bg-light" label="Rounded purple"         size={72} />
+      <Tile variant="rounded-orange"         bg="lg-bg-light" label="Rounded orange"         size={72} />
+      <Tile variant="rounded-bicolor-purple" bg="lg-bg-light" label="Rounded bicolor purple" size={72} />
+      <Tile variant="rounded-bicolor-orange" bg="lg-bg-light" label="Rounded bicolor orange" size={72} />
+    </Sec>
+
+    <div className="pg-sec">
+      <p className="pg-sec-title">Escala (size)</p>
+      <div className="pg-stage lg-sizes-row">
+        {[16, 24, 32, 48, 64, 96].map(s => (
+          <div key={s} className="lg-size-item">
+            <Logo size={s} />
+            <span className="lg-size-label">size={s}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Logo"]) || "render(<Logo size={48} />);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"purple"</td><td class="desc">Transparentes: purple · orange · mono-black · mono-white ·· Rounded: rounded-purple · rounded-orange · rounded-bicolor-purple · rounded-bicolor-orange</td></tr>
+  <tr><td><code>size</code></td><td>number</td><td>32</td><td class="desc">Largura e altura em px (símbolo quadrado)</td></tr>
+  <tr><td><code>alt</code></td><td>string</td><td>"Guardia"</td><td class="desc">Texto alternativo. Use "" quando decorativo e houver Logotipo ao lado.</td></tr>
+</table>
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Favicon, app icon, avatar, tile compacto onde a marca já é conhecida.</li>
+      <li>Rounded para app icons (container sólido); transparente para UI comum.</li>
+      <li>Mono-black em P&B; mono-white em fundos escuros saturados.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Abaixo de 16px — use favicon dedicado.</li>
+      <li>Orange transparente sobre fundos claros — baixo contraste.</li>
+      <li>Recriar o G em SVG inline — use sempre o arquivo oficial.</li>
+    </ul>
+  </div>
+</div>
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Logo/index.css
+++ b/ux_references/ui_kits/components/Logo/index.css
@@ -1,0 +1,6 @@
+/* Logo — símbolo G isolado */
+.grd-logo {
+  display: inline-block;
+  flex-shrink: 0;
+  object-fit: contain;
+}

--- a/ux_references/ui_kits/components/Logo/index.tsx
+++ b/ux_references/ui_kits/components/Logo/index.tsx
@@ -1,0 +1,64 @@
+/**
+ * Logo — símbolo G isolado (sem a palavra "Guardia").
+ *
+ * Uso: favicons, app icons, avatares, tiles compactos, loading
+ * spinners, assinaturas curtas e qualquer contexto onde a marca
+ * já esteja estabelecida pelo entorno.
+ *
+ * Variantes TRANSPARENTES (herdam o fundo da tela):
+ *   purple · orange · mono-black · mono-white
+ *
+ * Variantes ROUNDED (container com fundo sólido, para app icons):
+ *   rounded-purple · rounded-orange ·
+ *   rounded-bicolor-purple · rounded-bicolor-orange
+ */
+
+type LogoVariant =
+  | "purple" | "orange" | "mono-black" | "mono-white"
+  | "rounded-purple" | "rounded-orange"
+  | "rounded-bicolor-purple" | "rounded-bicolor-orange";
+
+interface LogoProps extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "src"> {
+  variant?: LogoVariant;
+  size?: number;
+  alt?: string;
+}
+
+const LOGO_SRC: Record<LogoVariant, string> = {
+  // transparentes
+  purple:       "../../../assets/logo/guardia-logo-purple-transparent.svg",
+  orange:       "../../../assets/logo/guardia-logo-orange-transparent.svg",
+  "mono-black": "../../../assets/logo/guardia-logo-mono-black.svg",
+  "mono-white": "../../../assets/logo/guardia-logo-mono-white.svg",
+  // rounded sólidos
+  "rounded-purple": "../../../assets/logo/guardia-logo-purple-rounded.svg",
+  "rounded-orange": "../../../assets/logo/guardia-logo-orange-rounded.svg",
+  // rounded bicolor
+  "rounded-bicolor-purple": "../../../assets/logo/guardia-logo-orange-and-purple.svg",
+  "rounded-bicolor-orange": "../../../assets/logo/guardia-logo-purple-and-orange.svg",
+};
+
+function Logo({
+  variant = "purple",
+  size = 32,
+  alt = "Guardia",
+  className = "",
+  style,
+  ...rest
+}: LogoProps) {
+  const src = LOGO_SRC[variant] || LOGO_SRC.purple;
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={size}
+      height={size}
+      className={["grd-logo", className].filter(Boolean).join(" ")}
+      style={{ width: size, height: size, ...style }}
+      {...rest}
+    />
+  );
+}
+Logo.displayName = "Logo";
+(window as any).Logo = Logo;
+(window as any).LOGO_SRC = LOGO_SRC;

--- a/ux_references/ui_kits/components/Logotipo/Logotipo.playground.html
+++ b/ux_references/ui_kits/components/Logotipo/Logotipo.playground.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Logotipo · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<style>
+  .lt-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; width: 100%; }
+  .lt-tile { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: #fff; }
+  .lt-stage { height: 160px; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .lt-bg-light  { background: #FDFDFD; }
+  .lt-bg-dark   { background: var(--violet-900); }
+  .lt-bg-violet { background: var(--violet-700); }
+  .lt-meta { padding: 12px 16px 14px; border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: 10.5px; color: var(--violet-700); line-height: 1.55; display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+  .lt-meta .lt-label { display: block; font-family: var(--font-sans); font-size: 13px; font-weight: 600; color: var(--violet-500); margin-bottom: 3px; }
+  .lt-meta .lt-use { display: block; font-family: var(--font-sans); font-size: 11px; color: var(--gray-500); margin-top: 4px; line-height: 1.45; max-width: 260px; }
+  .lt-dl { flex-shrink: 0; width: 26px; height: 26px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: #fff; color: var(--gray-500); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; transition: all 0.12s; text-decoration: none; }
+  .lt-dl:hover { background: var(--violet-100); border-color: var(--violet-300); color: var(--violet-500); }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">BRAND · ASSINATURA</div>
+  <h1 class="pg-title">Logotipo</h1>
+  <span class="pg-codename">import Logotipo from "ui_kits/components/Logotipo"</span>
+  <p class="pg-desc">Símbolo + palavra "Guardia" em tipografia Lastica. Usado em cabeçalhos, rodapés, landing pages, splash screens e qualquer contexto onde a marca precisa ser apresentada por extenso. Quatro variantes. Clique no ícone de download em cada tile para baixar o SVG original.</p>
+</div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx">
+const FILE: Record<string,string> = {
+  "purple":     "guardia-logotipo-purple.svg",
+  "orange":     "guardia-logotipo-orange.svg",
+  "mono-black": "guardia-logotipo-mono-black.svg",
+  "mono-white": "guardia-logotipo-mono-white.svg",
+};
+
+function Tile({ variant, bg, label, use }:{ variant: string; bg: string; label: string; use: string }) {
+  const file = FILE[variant];
+  const href = `../../../assets/logo/${file}`;
+  return (
+    <div className="lt-tile">
+      <div className={"lt-stage " + bg}><Logotipo variant={variant as any} height={56} /></div>
+      <div className="lt-meta">
+        <div>
+          <span className="lt-label">{label}</span>
+          variant="{variant}"
+          <span className="lt-use">{use}</span>
+        </div>
+        <a className="lt-dl" href={href} download={file} title={`Baixar ${file}`} aria-label={`Baixar ${file}`}>
+          <Icon name="download" size={14} />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  return (<>
+    <div className="pg-sec">
+      <p className="pg-sec-title">Variantes</p>
+      <div className="lt-grid">
+        <Tile variant="purple"     bg="lt-bg-light"  label="Principal · fundos claros" use="Padrão. Símbolo violeta com G laranja + palavra Guardia em Lastica violeta." />
+        <Tile variant="orange"     bg="lt-bg-violet" label="Secundário · fundos violeta" use="Reservado ao espectro do violeta. Símbolo laranja com G violeta + palavra Guardia em laranja." />
+        <Tile variant="mono-black" bg="lt-bg-light"  label="Mono preto" use="Impressões P&B, documentos oficiais, selos, gravações técnicas." />
+        <Tile variant="mono-white" bg="lt-bg-dark"   label="Mono branco" use="Fundos escuros ou saturados onde cor não garante contraste." />
+      </div>
+    </div>
+
+    <div className="pg-sec">
+      <p className="pg-sec-title">Escala (height)</p>
+      <div className="pg-stage" style={{gap:28, padding:28, alignItems:"flex-end", flexWrap:"wrap"}}>
+        {[20, 28, 40, 56, 72].map(h => (
+          <div key={h} style={{display:"flex", flexDirection:"column", alignItems:"center", gap:8}}>
+            <Logotipo height={h} />
+            <span style={{fontFamily:"var(--font-mono)", fontSize:10, color:"var(--gray-500)"}}>height={h}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Logotipo"]) || "render(<Logotipo height={40} />);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"purple"</td><td class="desc">purple · orange · mono-black · mono-white</td></tr>
+  <tr><td><code>height</code></td><td>number</td><td>32</td><td class="desc">Altura em px. Largura ajusta proporcionalmente.</td></tr>
+  <tr><td><code>alt</code></td><td>string</td><td>"Guardia"</td><td class="desc">Texto alternativo para acessibilidade</td></tr>
+</table>
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Cabeçalho principal, splash screen, rodapé institucional.</li>
+      <li>Primeira apresentação da marca em uma página ou documento.</li>
+      <li>Materiais impressos e e-mails transacionais.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Altura menor que 20px — palavra fica ilegível; use <code>&lt;Logo /&gt;</code>.</li>
+      <li>Variante purple sobre fundo violeta — use orange ou mono-white.</li>
+      <li>Cortar, distorcer ou recriar a palavra em outra fonte.</li>
+    </ul>
+  </div>
+</div>
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Logotipo/index.css
+++ b/ux_references/ui_kits/components/Logotipo/index.css
@@ -1,0 +1,6 @@
+/* Logotipo — símbolo + palavra "Guardia" */
+.grd-logotipo {
+  display: inline-block;
+  flex-shrink: 0;
+  object-fit: contain;
+}

--- a/ux_references/ui_kits/components/Logotipo/index.tsx
+++ b/ux_references/ui_kits/components/Logotipo/index.tsx
@@ -1,0 +1,51 @@
+/**
+ * Logotipo — símbolo + palavra "Guardia" em Lastica.
+ *
+ * Uso: cabeçalhos, rodapés, landing pages, splash screens,
+ * materiais impressos e qualquer contexto onde a marca ainda
+ * precisa ser apresentada por extenso.
+ *
+ * Variantes:
+ *   purple       principal — símbolo violeta com G laranja + palavra violeta
+ *   orange       secundário — para fundos no espectro violeta
+ *   mono-black   P&B, documentos oficiais, gravações técnicas
+ *   mono-white   fundos escuros ou saturados
+ */
+
+type LogotipoVariant = "purple" | "orange" | "mono-black" | "mono-white";
+
+interface LogotipoProps extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "src"> {
+  variant?: LogotipoVariant;
+  height?: number;
+  alt?: string;
+}
+
+const LOGOTIPO_SRC: Record<LogotipoVariant, string> = {
+  purple:       "../../../assets/logo/guardia-logotipo-purple.svg",
+  orange:       "../../../assets/logo/guardia-logotipo-orange.svg",
+  "mono-black": "../../../assets/logo/guardia-logotipo-mono-black.svg",
+  "mono-white": "../../../assets/logo/guardia-logotipo-mono-white.svg",
+};
+
+function Logotipo({
+  variant = "purple",
+  height = 32,
+  alt = "Guardia",
+  className = "",
+  style,
+  ...rest
+}: LogotipoProps) {
+  const src = LOGOTIPO_SRC[variant] || LOGOTIPO_SRC.purple;
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={["grd-logotipo", className].filter(Boolean).join(" ")}
+      style={{ height, width: "auto", ...style }}
+      {...rest}
+    />
+  );
+}
+Logotipo.displayName = "Logotipo";
+(window as any).Logotipo = Logotipo;
+(window as any).LOGOTIPO_SRC = LOGOTIPO_SRC;

--- a/ux_references/ui_kits/components/Menu/Menu.playground.html
+++ b/ux_references/ui_kits/components/Menu/Menu.playground.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Menu · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../IconButton/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">OVERLAY · MENU DE AÇÕES</div>
+  <h1 class="pg-title">Menu</h1>
+  <span class="pg-codename">import Menu from "ui_kits/components/Menu"</span>
+  <p class="pg-desc">Dropdown de ações. Suporta ícones, atalhos, itens destrutivos, separadores e cabeçalhos de grupo.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../IconButton/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{gap:18,padding:40,flexWrap:"wrap"}}>{children}</div></div>);
+}
+
+function App() {
+  return (<>
+    <Sec title="Menu simples">
+      <Menu
+        trigger={<button className="grd-btn grd-btn-secondary">Ações <Icon name="chevron-down" size={13} /></button>}
+        items={[
+          { label: "Aprovar", icon: "check", shortcut: "⌘↵", onClick: () => {} },
+          { label: "Rejeitar", icon: "x", onClick: () => {} },
+          { label: "Marcar para revisão", icon: "flag", onClick: () => {} },
+          { type: "separator" },
+          { label: "Excluir permanentemente", icon: "trash-2", destructive: true, onClick: () => {} },
+        ]}
+      />
+    </Sec>
+
+    <Sec title="Com grupos (label headers)">
+      <Menu
+        trigger={<button className="grd-btn grd-btn-secondary">Exportar <Icon name="chevron-down" size={13} /></button>}
+        minWidth={220}
+        items={[
+          { type: "label", label: "Formato de arquivo" },
+          { label: "PDF", icon: "file-text", onClick: () => {} },
+          { label: "Excel (.xlsx)", icon: "file-spreadsheet", onClick: () => {} },
+          { label: "CSV", icon: "file", onClick: () => {} },
+          { type: "separator" },
+          { type: "label", label: "Integração" },
+          { label: "Enviar para Domínio", icon: "plug-2", onClick: () => {} },
+          { label: "Enviar para Alterdata", icon: "plug-2", disabled: true },
+        ]}
+      />
+    </Sec>
+
+    <Sec title="Em icon-button (row action)">
+      <Menu
+        align="end"
+        trigger={<IconButton icon="more-horizontal" variant="ghost" />}
+        items={[
+          { label: "Ver detalhes", icon: "external-link", onClick: () => {} },
+          { label: "Duplicar", icon: "copy", shortcut: "⌘D", onClick: () => {} },
+          { label: "Renomear", icon: "edit-3", onClick: () => {} },
+          { type: "separator" },
+          { label: "Arquivar", icon: "archive", destructive: true, onClick: () => {} },
+        ]}
+      />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Menu"]) || "render(<div>Sem exemplo para Menu</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>trigger</code></td><td>element</td><td>—</td><td class="desc">Botão que abre o menu</td></tr>
+  <tr><td><code>items</code></td><td>array</td><td>—</td><td class="desc">Item, separator ou label (cabeçalho de grupo)</td></tr>
+  <tr><td><code>side</code></td><td>string</td><td>"bottom"</td><td class="desc">bottom · top</td></tr>
+  <tr><td><code>align</code></td><td>string</td><td>"start"</td><td class="desc">start · end</td></tr>
+  <tr><td><code>minWidth</code></td><td>number</td><td>180</td><td class="desc">Largura mínima do menu</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Ações secundárias agrupadas no <code>IconButton</code> "mais opções".</li>
+      <li>Separadores por grupo; ações destrutivas destacadas em vermelho no final.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Menus de navegação — use <code>SidebarNav</code>.</li>
+      <li>Mais de 8 itens sem agrupamento.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Menu/index.css
+++ b/ux_references/ui_kits/components/Menu/index.css
@@ -1,0 +1,45 @@
+
+.grd-mnu {
+  position: fixed; z-index: 850;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: 4px;
+  font-family: var(--font-sans);
+  animation: grd-mnu-in 120ms var(--ease-out);
+}
+@keyframes grd-mnu-in { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+.grd-mnu-top { transform: translateY(-100%); }
+.grd-mnu-al-end { transform: translateX(-100%); }
+.grd-mnu-top.grd-mnu-al-end { transform: translate(-100%, -100%); }
+
+.grd-mnu-item {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 7px 10px;
+  border: 0; background: transparent;
+  font-family: inherit; font-size: 13px; color: var(--fg);
+  text-align: left; cursor: pointer; border-radius: var(--radius-md);
+  transition: background 100ms;
+}
+.grd-mnu-item:hover:not(:disabled) { background: var(--violet-50); color: var(--violet-700); }
+.grd-mnu-item-dis { opacity: 0.5; cursor: not-allowed; }
+.grd-mnu-item-danger { color: var(--signal-red); }
+.grd-mnu-item-danger:hover:not(:disabled) { background: var(--danger-soft); color: var(--signal-red); }
+
+.grd-mnu-ic { display: inline-flex; color: var(--fg-muted); flex-shrink: 0; }
+.grd-mnu-item-danger .grd-mnu-ic { color: var(--signal-red); }
+.grd-mnu-item:hover .grd-mnu-ic { color: var(--violet-600); }
+.grd-mnu-lab { flex: 1; }
+.grd-mnu-sc {
+  font-size: 11px; font-weight: 500; color: var(--fg-muted);
+  letter-spacing: 0.02em;
+  font-family: var(--font-mono);
+}
+
+.grd-mnu-sep { height: 1px; background: var(--border); margin: 4px 0; }
+.grd-mnu-lbl {
+  padding: 6px 10px 4px;
+  font-size: 11px; font-weight: 600; color: var(--fg-muted);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}

--- a/ux_references/ui_kits/components/Menu/index.tsx
+++ b/ux_references/ui_kits/components/Menu/index.tsx
@@ -1,0 +1,105 @@
+
+/**
+ * Menu — dropdown de ações.
+ * Props:
+ *   trigger: React.ReactElement — botão que abre
+ *   items: MenuItem[]
+ * MenuItem:
+ *   { label, icon?, shortcut?, onClick, destructive?, disabled? }
+ *   { type: "separator" }
+ *   { type: "label", label }  (cabeçalho de grupo)
+ */
+
+type MenuItem =
+  | { type?: "item"; label: React.ReactNode; icon?: string; shortcut?: string; onClick?: () => void; destructive?: boolean; disabled?: boolean }
+  | { type: "separator" }
+  | { type: "label"; label: React.ReactNode };
+
+interface MenuProps {
+  trigger: React.ReactElement;
+  items: MenuItem[];
+  side?: "bottom" | "top";
+  align?: "start" | "end";
+  minWidth?: number;
+}
+
+function Menu({ trigger, items, side = "bottom", align = "start", minWidth = 180 }: MenuProps) {
+  const IconCmp = (window as any).Icon;
+  const [open, setOpen] = React.useState(false);
+  const [coords, setCoords] = React.useState<{ top: number; left: number } | null>(null);
+  const triggerRef = React.useRef<HTMLElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    const gap = 4;
+    const top = side === "bottom" ? r.bottom + gap : r.top - gap;
+    const left = align === "start" ? r.left : r.right;
+    setCoords({ top, left });
+  }, [open, side, align]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      const t = e.target as Node;
+      if (menuRef.current?.contains(t) || triggerRef.current?.contains(t)) return;
+      setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setOpen(false); }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const trig = React.cloneElement(trigger, {
+    ref: triggerRef,
+    onClick: (e: any) => { setOpen(o => !o); trigger.props.onClick?.(e); },
+    "aria-haspopup": "menu",
+    "aria-expanded": open,
+  });
+
+  return (<>
+    {trig}
+    {open && coords && ReactDOM.createPortal(
+      <div
+        ref={menuRef}
+        className={`grd-mnu grd-mnu-${side} grd-mnu-al-${align}`}
+        style={{ top: coords.top, left: coords.left, minWidth }}
+        role="menu"
+      >
+        {items.map((it, i) => {
+          if (it.type === "separator") return <div key={i} className="grd-mnu-sep" />;
+          if (it.type === "label")     return <div key={i} className="grd-mnu-lbl">{it.label}</div>;
+          const item = it as Extract<MenuItem, { onClick?: () => void }>;
+          return (
+            <button
+              key={i} role="menuitem" type="button"
+              className={[
+                "grd-mnu-item",
+                item.destructive && "grd-mnu-item-danger",
+                item.disabled && "grd-mnu-item-dis",
+              ].filter(Boolean).join(" ")}
+              disabled={item.disabled}
+              onClick={() => {
+                if (item.disabled) return;
+                item.onClick?.();
+                setOpen(false);
+              }}
+            >
+              {item.icon && IconCmp && <span className="grd-mnu-ic"><IconCmp name={item.icon} size={15} /></span>}
+              <span className="grd-mnu-lab">{item.label}</span>
+              {item.shortcut && <span className="grd-mnu-sc">{item.shortcut}</span>}
+            </button>
+          );
+        })}
+      </div>,
+      document.body
+    )}
+  </>);
+}
+Menu.displayName = "Menu";
+(window as any).Menu = Menu;

--- a/ux_references/ui_kits/components/MetricCard/MetricCard.playground.html
+++ b/ux_references/ui_kits/components/MetricCard/MetricCard.playground.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>MetricCard · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">KPI · MÉTRICA</div>
+  <h1 class="pg-title">MetricCard</h1>
+  <span class="pg-codename">import MetricCard from "ui_kits/components/MetricCard"</span>
+  <p class="pg-desc">KPI compacto com rótulo, valor e delta comparativo. O sinal do delta deriva automaticamente o tom (verde/vermelho); use <code>deltaType="neutral"</code> para silenciar.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{alignItems:"stretch",flexWrap:"wrap",gap:16}}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Grid de KPIs">
+      <div style={{display:"grid",gridTemplateColumns:"repeat(4, minmax(180px, 1fr))",gap:12,width:"100%"}}>
+        <MetricCard icon="file-text"       label="Lançamentos"       value="2.487" delta={12.4} caption="vs. 30d anteriores" />
+        <MetricCard icon="arrow-left-right" label="Conciliação"        value="96"    suffix="%" delta={2.1} />
+        <MetricCard icon="triangle-alert"  label="Pendências"         value="11"    delta={-18.2} caption="resolvidas essa semana" />
+        <MetricCard icon="bot"             label="Horas economizadas" value="32"    suffix="h" delta={8.7} />
+      </div>
+    </Sec>
+
+    <Sec title="Tamanhos">
+      <MetricCard size="sm" label="MRR" prefix="R$ " value="38.490" delta={4.2} />
+      <MetricCard size="md" label="MRR" prefix="R$ " value="38.490" delta={4.2} />
+      <MetricCard size="lg" label="MRR" prefix="R$ " value="38.490" delta={4.2} caption="vs. mês anterior" />
+    </Sec>
+
+    <Sec title="Deltas: up · down · neutral · string custom">
+      <MetricCard label="Conciliado" value="96" suffix="%" delta={2.1} />
+      <MetricCard label="Falhas"     value="3"  delta={-42.0} />
+      <MetricCard label="Estável"    value="1.000" deltaType="neutral" delta={0} />
+      <MetricCard label="vs. meta"   value="84" suffix="%" delta="atingido 84% do trimestre" deltaType="neutral" />
+    </Sec>
+
+    <Sec title="Sem delta (contexto)">
+      <MetricCard icon="building-2" label="Empresas ativas" value="38" caption="de 40 no plano" />
+      <MetricCard icon="bot"        label="Agentes rodando" value="6"  caption="em produção" />
+    </Sec>
+
+    <Sec title="Com prefix/suffix monetário">
+      <MetricCard icon="circle-dollar-sign" label="Receita processada" prefix="R$ " value="2,4" suffix=" mi" delta={5.8} />
+      <MetricCard icon="receipt-text"       label="Nota média"          prefix="R$ " value="487,20" delta={-3.1} />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["MetricCard"]) || "render(<div>Sem exemplo para MetricCard</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>label</code></td><td>node</td><td>—</td><td class="desc">Rótulo (pequeno, acima)</td></tr>
+  <tr><td><code>value</code></td><td>node</td><td>—</td><td class="desc">Número grande central</td></tr>
+  <tr><td><code>prefix</code> · <code>suffix</code></td><td>node</td><td>—</td><td class="desc">Ex.: "R$ ", " %", " h"</td></tr>
+  <tr><td><code>delta</code></td><td>number | string</td><td>—</td><td class="desc">Variação. Number ⇒ formatado com %; string ⇒ exibido como veio</td></tr>
+  <tr><td><code>deltaType</code></td><td>string</td><td>auto</td><td class="desc">up · down · neutral — sobrepõe o tom derivado do sinal</td></tr>
+  <tr><td><code>caption</code></td><td>node</td><td>—</td><td class="desc">Legenda complementar</td></tr>
+  <tr><td><code>icon</code></td><td>string</td><td>—</td><td class="desc">Ícone Lucide no canto superior direito</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>KPI de dashboard: valor, unidade, delta vs período anterior.</li>
+      <li>Ícone temático à esquerda; sparkline opcional.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Delta sem direção (↑/↓) ou contexto de período.</li>
+      <li>Mais de 4 MetricCards na mesma fila.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/MetricCard/index.css
+++ b/ux_references/ui_kits/components/MetricCard/index.css
@@ -1,0 +1,44 @@
+
+.grd-mc {
+  font-family: var(--font-sans);
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex; flex-direction: column; gap: 6px;
+}
+.grd-mc-sm { padding: 14px 16px; }
+.grd-mc-md { padding: 18px 20px; }
+.grd-mc-lg { padding: 22px 24px; }
+
+.grd-mc-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.grd-mc-label {
+  font-size: 12px; font-weight: 600;
+  color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.04em;
+}
+.grd-mc-ic {
+  width: 32px; height: 32px; border-radius: var(--radius-lg);
+  background: var(--violet-50); color: var(--violet-600);
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.grd-mc-value {
+  display: flex; align-items: baseline; gap: 4px;
+  color: var(--fg);
+  font-feature-settings: "tnum"; font-variant-numeric: tabular-nums;
+  font-family: var(--font-display);
+}
+.grd-mc-sm .grd-mc-value { font-size: 24px; }
+.grd-mc-md .grd-mc-value { font-size: 30px; }
+.grd-mc-lg .grd-mc-value { font-size: 36px; }
+.grd-mc-value { font-weight: 600; line-height: 1.1; }
+.grd-mc-afx { font-size: 0.6em; font-weight: 500; color: var(--fg-muted); }
+.grd-mc-afx-sfx { margin-left: 1px; }
+
+.grd-mc-foot { display: flex; align-items: center; gap: 8px; margin-top: 2px; flex-wrap: wrap; }
+.grd-mc-delta {
+  display: inline-flex; align-items: center; gap: 2px;
+  font-size: 12px; font-weight: 600;
+  padding: 2px 6px; border-radius: var(--radius-sm);
+}
+.grd-mc-delta-up      { color: color-mix(in oklab, var(--signal-green) 52%, black); background: var(--success-soft); }
+.grd-mc-delta-down    { color: color-mix(in oklab, var(--signal-red) 45%, black); background: var(--danger-soft); }
+.grd-mc-delta-neutral { color: var(--fg-muted); background: var(--gray-100); }
+.grd-mc-cap { font-size: 12px; color: var(--fg-muted); }

--- a/ux_references/ui_kits/components/MetricCard/index.tsx
+++ b/ux_references/ui_kits/components/MetricCard/index.tsx
@@ -1,0 +1,63 @@
+
+/**
+ * MetricCard — card de KPI com rótulo, valor e delta.
+ * Props: label, value, delta (signed number or string), deltaType (up|down|neutral auto), caption, icon, prefix, suffix, spark (array).
+ */
+
+interface MetricCardProps {
+  label: React.ReactNode;
+  value: React.ReactNode;
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
+  delta?: number | string;
+  deltaType?: "up" | "down" | "neutral";
+  caption?: React.ReactNode;
+  icon?: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+function deriveDelta(d?: number | string): "up" | "down" | "neutral" {
+  if (d === undefined) return "neutral";
+  const n = typeof d === "number" ? d : parseFloat(String(d).replace(",", "."));
+  if (isNaN(n) || n === 0) return "neutral";
+  return n > 0 ? "up" : "down";
+}
+
+function MetricCard({
+  label, value, prefix, suffix, delta, deltaType, caption, icon,
+  size = "md", className = "",
+}: MetricCardProps) {
+  const IconCmp = (window as any).Icon;
+  const dtype = deltaType ?? deriveDelta(delta);
+  const deltaStr = delta !== undefined ? (typeof delta === "number"
+    ? `${delta > 0 ? "+" : ""}${delta.toLocaleString("pt-BR", { maximumFractionDigits: 2 })}%`
+    : String(delta)) : null;
+  const cls = ["grd-mc", `grd-mc-${size}`, className].filter(Boolean).join(" ");
+  return (
+    <div className={cls}>
+      <div className="grd-mc-row">
+        <div className="grd-mc-label">{label}</div>
+        {icon && IconCmp && <div className="grd-mc-ic"><IconCmp name={icon} size={size === "lg" ? 18 : 16} /></div>}
+      </div>
+      <div className="grd-mc-value">
+        {prefix && <span className="grd-mc-afx">{prefix}</span>}
+        <span className="grd-mc-num">{value}</span>
+        {suffix && <span className="grd-mc-afx grd-mc-afx-sfx">{suffix}</span>}
+      </div>
+      {(deltaStr || caption) && (
+        <div className="grd-mc-foot">
+          {deltaStr && (
+            <span className={`grd-mc-delta grd-mc-delta-${dtype}`}>
+              {IconCmp && <IconCmp name={dtype === "up" ? "trending-up" : dtype === "down" ? "trending-down" : "minus"} size={12} />}
+              {deltaStr}
+            </span>
+          )}
+          {caption && <span className="grd-mc-cap">{caption}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+MetricCard.displayName = "MetricCard";
+(window as any).MetricCard = MetricCard;

--- a/ux_references/ui_kits/components/Pagination/Pagination.playground.html
+++ b/ux_references/ui_kits/components/Pagination/Pagination.playground.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Pagination · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">NAVEGAÇÃO · PAGINAÇÃO</div>
+  <h1 class="pg-title">Pagination</h1>
+  <span class="pg-codename">import Pagination from "ui_kits/components/Pagination"</span>
+  <p class="pg-desc">Paginação numérica controlada. Gera automaticamente as reticências em torno da página atual. Ative <code>showEdges</code> para saltos ao início/fim.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"flex-start",gap:12}}>{children}</div></div>);
+}
+function App() {
+  const [p1, setP1] = React.useState(3);
+  const [p2, setP2] = React.useState(12);
+  const [p3, setP3] = React.useState(1);
+  return (<>
+    <Sec title="Poucas páginas">
+      <Pagination page={p1} pageCount={7} onChange={setP1} />
+    </Sec>
+
+    <Sec title="Muitas páginas (com elipse)">
+      <Pagination page={p2} pageCount={42} onChange={setP2} />
+      <div style={{fontSize:13,color:"var(--gray-600)"}}>Página <b style={{color:"var(--orange-500)"}}>{p2}</b> de 42</div>
+    </Sec>
+
+    <Sec title="Com saltos ao início/fim (showEdges)">
+      <Pagination page={p2} pageCount={42} onChange={setP2} showEdges />
+    </Sec>
+
+    <Sec title="Tamanho sm">
+      <Pagination size="sm" page={p1} pageCount={7} onChange={setP1} />
+    </Sec>
+
+    <Sec title="siblingCount=2 (mais números visíveis)">
+      <Pagination page={p2} pageCount={42} onChange={setP2} siblingCount={2} />
+    </Sec>
+
+    <Sec title="Disabled boundaries (página 1 de 5)">
+      <Pagination page={p3} pageCount={5} onChange={setP3} />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Pagination"]) || "render(<div>Sem exemplo para Pagination</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>page</code></td><td>number</td><td>—</td><td class="desc">Página atual (1-based)</td></tr>
+  <tr><td><code>pageCount</code></td><td>number</td><td>—</td><td class="desc">Total de páginas</td></tr>
+  <tr><td><code>onChange</code></td><td>(p) ⇒ void</td><td>—</td><td class="desc">Callback</td></tr>
+  <tr><td><code>siblingCount</code></td><td>number</td><td>1</td><td class="desc">Páginas vizinhas visíveis</td></tr>
+  <tr><td><code>showEdges</code></td><td>boolean</td><td>false</td><td class="desc">Exibe botões "primeira" e "última"</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Listas com > 50 itens; mostra página atual + total de itens.</li>
+      <li>Seletor de "itens por página" ao lado.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Paginação em feeds infinitos — use scroll virtual.</li>
+      <li>Esconder o total de resultados.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Pagination/index.css
+++ b/ux_references/ui_kits/components/Pagination/index.css
@@ -1,0 +1,20 @@
+
+.grd-pag {
+  display: inline-flex; align-items: center; gap: 2px;
+  font-family: var(--font-sans);
+  font-feature-settings: "tnum"; font-variant-numeric: tabular-nums;
+}
+.grd-pag-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid transparent; background: transparent;
+  color: var(--fg); cursor: pointer; font-family: inherit; font-weight: 500;
+  border-radius: var(--radius-md);
+  transition: background 120ms, color 120ms, border-color 120ms;
+}
+.grd-pag-md .grd-pag-btn { min-width: 32px; height: 32px; padding: 0 8px; font-size: 13px; }
+.grd-pag-sm .grd-pag-btn { min-width: 28px; height: 28px; padding: 0 6px; font-size: 12px; }
+.grd-pag-btn:hover:not(:disabled) { background: var(--violet-50); color: var(--violet-700); }
+.grd-pag-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.grd-pag-btn-active,
+.grd-pag-btn-active:hover { background: var(--violet-500); color: #fff; }
+.grd-pag-ellipsis { padding: 0 4px; color: var(--fg-muted); user-select: none; }

--- a/ux_references/ui_kits/components/Pagination/index.tsx
+++ b/ux_references/ui_kits/components/Pagination/index.tsx
@@ -1,0 +1,73 @@
+
+/**
+ * Pagination — paginação numérica com prev/next.
+ * Props: page (1-based), pageCount, onChange, siblingCount.
+ */
+
+interface PaginationProps {
+  page: number;
+  pageCount: number;
+  onChange?: (p: number) => void;
+  siblingCount?: number;
+  size?: "sm" | "md";
+  showEdges?: boolean;
+  className?: string;
+}
+
+function Pagination({ page, pageCount, onChange, siblingCount = 1, size = "md", showEdges = false, className = "" }: PaginationProps) {
+  const IconCmp = (window as any).Icon;
+  if (pageCount <= 0) return null;
+
+  const range: (number | "…")[] = [];
+  const first = 1, last = pageCount;
+  const lo = Math.max(first + 1, page - siblingCount);
+  const hi = Math.min(last - 1, page + siblingCount);
+  range.push(first);
+  if (lo > first + 1) range.push("…");
+  for (let i = lo; i <= hi; i++) range.push(i);
+  if (hi < last - 1) range.push("…");
+  if (last > first) range.push(last);
+
+  const cls = ["grd-pag", `grd-pag-${size}`, className].filter(Boolean).join(" ");
+  const go = (p: number) => {
+    if (p < 1 || p > pageCount || p === page) return;
+    onChange?.(p);
+  };
+
+  return (
+    <nav className={cls} role="navigation" aria-label="Paginação">
+      {showEdges && IconCmp && (
+        <button className="grd-pag-btn" onClick={() => go(1)} disabled={page === 1} aria-label="Primeira">
+          <IconCmp name="chevrons-left" size={14} />
+        </button>
+      )}
+      <button className="grd-pag-btn" onClick={() => go(page - 1)} disabled={page === 1} aria-label="Anterior">
+        {IconCmp && <IconCmp name="chevron-left" size={14} />}
+      </button>
+      {range.map((n, i) =>
+        n === "…"
+          ? <span key={`e${i}`} className="grd-pag-ellipsis">…</span>
+          : (
+            <button
+              key={n}
+              className={`grd-pag-btn grd-pag-num ${n === page ? "grd-pag-btn-active" : ""}`}
+              onClick={() => go(n)}
+              aria-current={n === page ? "page" : undefined}
+            >
+              {n}
+            </button>
+          )
+      )}
+      <button className="grd-pag-btn" onClick={() => go(page + 1)} disabled={page === pageCount} aria-label="Próxima">
+        {IconCmp && <IconCmp name="chevron-right" size={14} />}
+      </button>
+      {showEdges && IconCmp && (
+        <button className="grd-pag-btn" onClick={() => go(pageCount)} disabled={page === pageCount} aria-label="Última">
+          <IconCmp name="chevrons-right" size={14} />
+        </button>
+      )}
+    </nav>
+  );
+}
+Pagination.displayName = "Pagination";
+(window as any).Pagination = Pagination;

--- a/ux_references/ui_kits/components/Popover/Popover.playground.html
+++ b/ux_references/ui_kits/components/Popover/Popover.playground.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Popover · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="../Checkbox/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">OVERLAY · POPOVER</div>
+  <h1 class="pg-title">Popover</h1>
+  <span class="pg-codename">import Popover from "ui_kits/components/Popover"</span>
+  <p class="pg-desc">Painel flutuante ancorado ao trigger. Para conteúdo pequeno e acionável: filtros, atalhos, mini-forms. Fecha em clique fora.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Checkbox/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{gap:20,padding:40,flexWrap:"wrap"}}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Filtro · form compacto">
+      <Popover width={260} trigger={<button className="grd-btn grd-btn-secondary">+ Filtro</button>}>
+        <div style={{padding:"12px 14px"}}>
+          <div style={{fontSize:11,letterSpacing:"0.12em",color:"var(--gray-500)",textTransform:"uppercase",fontWeight:600,marginBottom:8}}>Status</div>
+          <div style={{display:"flex",flexDirection:"column",gap:8}}>
+            <Checkbox label="Pendentes de revisão" defaultChecked />
+            <Checkbox label="Aprovados automaticamente" />
+            <Checkbox label="Rejeitados" />
+            <Checkbox label="Arquivados" />
+          </div>
+          <div style={{marginTop:12,display:"flex",justifyContent:"flex-end",gap:6}}>
+            <button className="grd-btn grd-btn-ghost grd-btn-sm">Limpar</button>
+            <button className="grd-btn grd-btn-primary grd-btn-sm">Aplicar</button>
+          </div>
+        </div>
+      </Popover>
+    </Sec>
+
+    <Sec title="Ajuda · dica com ação">
+      <Popover width={300} trigger={<button className="grd-btn grd-btn-ghost">?</button>}>
+        <div style={{padding:"12px 14px"}}>
+          <div style={{fontWeight:600,fontSize:13,color:"var(--fg)",marginBottom:4}}>O que é confiança?</div>
+          <div style={{fontSize:13,color:"var(--gray-700)",lineHeight:1.5}}>
+            Estimativa da Guardia sobre a chance do output ser correto. Acima de 95% aplicamos sozinhos; abaixo, pedimos sua revisão.
+          </div>
+          <a href="#" style={{display:"inline-block",marginTop:8,fontSize:13,color:"var(--violet-500)",fontWeight:500,textDecoration:"none"}}>Ajustar limiar →</a>
+        </div>
+      </Popover>
+    </Sec>
+
+    <Sec title="Lados e alinhamentos">
+      <Popover side="top" align="start" trigger={<button className="grd-btn grd-btn-secondary">top · start</button>}>
+        <div style={{padding:"10px 14px",fontSize:13}}>Popover no topo</div>
+      </Popover>
+      <Popover side="right" align="center" trigger={<button className="grd-btn grd-btn-secondary">right · center</button>}>
+        <div style={{padding:"10px 14px",fontSize:13}}>Popover à direita</div>
+      </Popover>
+      <Popover side="bottom" align="end" trigger={<button className="grd-btn grd-btn-secondary">bottom · end</button>}>
+        <div style={{padding:"10px 14px",fontSize:13}}>Popover em baixo</div>
+      </Popover>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Popover"]) || "render(<div>Sem exemplo para Popover</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>trigger</code></td><td>element</td><td>—</td><td class="desc">Elemento clicável que abre o popover</td></tr>
+  <tr><td><code>side</code></td><td>string</td><td>"bottom"</td><td class="desc">top · right · bottom · left</td></tr>
+  <tr><td><code>align</code></td><td>string</td><td>"start"</td><td class="desc">start · center · end</td></tr>
+  <tr><td><code>width</code></td><td>number | string</td><td>auto</td><td class="desc">Largura fixa (opcional)</td></tr>
+  <tr><td><code>closeOnOutside</code></td><td>boolean</td><td>true</td><td class="desc">Fecha ao clicar fora</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Detalhes sob demanda ligados a uma âncora: explicação de campo, preview de lançamento.</li>
+      <li>Fecha no clique fora ou <code>Esc</code>.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Conteúdo crítico que bloqueia fluxo — use <code>Dialog</code>.</li>
+      <li>Popovers aninhados.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Popover/index.css
+++ b/ux_references/ui_kits/components/Popover/index.css
@@ -1,0 +1,24 @@
+
+.grd-pop {
+  position: fixed; z-index: 800;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: 10px;
+  font-family: var(--font-sans); font-size: 13.5px; color: var(--fg);
+  max-width: 320px;
+  animation: grd-pop-in 140ms var(--ease-out);
+}
+@keyframes grd-pop-in { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+.grd-pop-top    { transform: translateY(-100%); }
+.grd-pop-left   { transform: translateX(-100%); }
+.grd-pop-al-center.grd-pop-bottom,
+.grd-pop-al-center.grd-pop-top   { transform: translateX(-50%); }
+.grd-pop-al-center.grd-pop-left,
+.grd-pop-al-center.grd-pop-right { transform: translateY(-50%); }
+.grd-pop-al-end.grd-pop-bottom,
+.grd-pop-al-end.grd-pop-top      { transform: translateX(-100%); }
+.grd-pop-al-end.grd-pop-left     { transform: translate(-100%, -100%); }
+.grd-pop-al-end.grd-pop-right    { transform: translateY(-100%); }
+.grd-pop-al-center.grd-pop-top   { transform: translate(-50%, -100%); }
+.grd-pop-al-center.grd-pop-left  { transform: translate(-100%, -50%); }

--- a/ux_references/ui_kits/components/Popover/index.tsx
+++ b/ux_references/ui_kits/components/Popover/index.tsx
@@ -1,0 +1,66 @@
+
+/**
+ * Popover — pop flutuante acionado por clique. Para conteúdo pequeno: filtros, forms, hints acionáveis.
+ * Props: trigger (elemento que abre), children (conteúdo), side, align, width.
+ */
+
+interface PopoverProps {
+  trigger: React.ReactElement;
+  children: React.ReactNode;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+  width?: number | string;
+  closeOnOutside?: boolean;
+}
+
+function Popover({ trigger, children, side = "bottom", align = "start", width, closeOnOutside = true }: PopoverProps) {
+  const [open, setOpen] = React.useState(false);
+  const [coords, setCoords] = React.useState<{ top: number; left: number } | null>(null);
+  const triggerRef = React.useRef<HTMLElement>(null);
+  const popRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    if (!triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    const gap = 6;
+    let top = 0, left = 0;
+    if (side === "bottom") { top = r.bottom + gap; left = align === "start" ? r.left : align === "end" ? r.right : r.left + r.width/2; }
+    if (side === "top")    { top = r.top - gap;    left = align === "start" ? r.left : align === "end" ? r.right : r.left + r.width/2; }
+    if (side === "right")  { left = r.right + gap; top  = align === "start" ? r.top  : align === "end" ? r.bottom : r.top + r.height/2; }
+    if (side === "left")   { left = r.left - gap;  top  = align === "start" ? r.top  : align === "end" ? r.bottom : r.top + r.height/2; }
+    setCoords({ top, left });
+  }, [open, side, align]);
+
+  React.useEffect(() => {
+    if (!open || !closeOnOutside) return;
+    function onDown(e: MouseEvent) {
+      const t = e.target as Node;
+      if (popRef.current?.contains(t) || triggerRef.current?.contains(t)) return;
+      setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open, closeOnOutside]);
+
+  const trig = React.cloneElement(trigger, {
+    ref: triggerRef,
+    onClick: (e: any) => { setOpen(o => !o); trigger.props.onClick?.(e); },
+  });
+  return (<>
+    {trig}
+    {open && coords && ReactDOM.createPortal(
+      <div
+        ref={popRef}
+        className={`grd-pop grd-pop-${side} grd-pop-al-${align}`}
+        style={{ top: coords.top, left: coords.left, width }}
+        role="dialog"
+      >
+        {children}
+      </div>,
+      document.body
+    )}
+  </>);
+}
+Popover.displayName = "Popover";
+(window as any).Popover = Popover;

--- a/ux_references/ui_kits/components/Progress/Progress.playground.html
+++ b/ux_references/ui_kits/components/Progress/Progress.playground.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Progress · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FEEDBACK · PROGRESSO</div>
+  <h1 class="pg-title">Progress</h1>
+  <span class="pg-codename">import Progress from "ui_kits/components/Progress"</span>
+  <p class="pg-desc">Barra de progresso linear ou circular. Suporta valor determinístico (0–100) ou modo <code>indeterminate</code> para tarefas sem previsão.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, w=440 }: any) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",maxWidth:w,gap:14}}>{children}</div></div>);
+}
+function App() {
+  const [v, setV] = React.useState(32);
+  React.useEffect(() => {
+    const id = setInterval(() => setV(p => (p >= 100 ? 0 : p + 2)), 180);
+    return () => clearInterval(id);
+  }, []);
+  return (<>
+    <Sec title="Linear · por tom">
+      <Progress value={85} tone="violet" showValue label="Processando lançamentos" />
+      <Progress value={62} tone="green"  showValue label="Conciliação" />
+      <Progress value={40} tone="amber"  showValue label="Revisão pendente" />
+      <Progress value={18} tone="red"    showValue label="Falhas no lote" />
+    </Sec>
+
+    <Sec title="Tamanhos">
+      <Progress size="sm" value={72} tone="violet" label="sm" showValue />
+      <Progress size="md" value={72} tone="violet" label="md" showValue />
+      <Progress size="lg" value={72} tone="violet" label="lg" showValue />
+    </Sec>
+
+    <Sec title="Animada (ao vivo)">
+      <Progress value={v} tone="violet" showValue label="Conciliando extrato · 248 itens" />
+    </Sec>
+
+    <Sec title="Indeterminate (sem previsão)">
+      <Progress indeterminate tone="violet" label="Chamando IA…" />
+      <Progress indeterminate tone="green" label="Exportando para Domínio…" />
+    </Sec>
+
+    <Sec title="Circular">
+      <div style={{display:"flex",gap:24,alignItems:"center"}}>
+        <Progress variant="circular" size="sm" value={72} tone="violet" showValue />
+        <Progress variant="circular" size="md" value={72} tone="violet" showValue />
+        <Progress variant="circular" size="lg" value={72} tone="violet" showValue />
+        <Progress variant="circular" size="lg" value={94} tone="green"  showValue />
+        <Progress variant="circular" size="lg" value={38} tone="amber"  showValue />
+      </div>
+    </Sec>
+
+    <Sec title="Circular · indeterminate">
+      <div style={{display:"flex",gap:20,alignItems:"center"}}>
+        <Progress variant="circular" size="md" tone="violet" indeterminate />
+        <Progress variant="circular" size="lg" tone="green"  indeterminate />
+      </div>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Progress"]) || "render(<div>Sem exemplo para Progress</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>value</code></td><td>number</td><td>—</td><td class="desc">Progresso atual</td></tr>
+  <tr><td><code>max</code></td><td>number</td><td>100</td><td class="desc">Valor máximo</td></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"linear"</td><td class="desc">linear · circular</td></tr>
+  <tr><td><code>tone</code></td><td>string</td><td>"violet"</td><td class="desc">violet · green · amber · red</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>label</code> · <code>showValue</code></td><td>node · boolean</td><td>—</td><td class="desc">Metadados acima (linear) / centro (circular)</td></tr>
+  <tr><td><code>indeterminate</code></td><td>boolean</td><td>false</td><td class="desc">Animação contínua sem valor</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Barra determinística para processos longos (importação de XMLs, conciliação em lote).</li>
+      <li>Indeterminada somente quando a duração é desconhecida.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Barra sem rótulo de etapa atual.</li>
+      <li>Progresso "falso" que fica preso em 90%.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Progress/index.css
+++ b/ux_references/ui_kits/components/Progress/index.css
@@ -1,0 +1,47 @@
+
+.grd-pg { font-family: var(--font-sans); }
+
+/* Linear */
+.grd-pg-linear { display: flex; flex-direction: column; gap: 6px; width: 100%; }
+.grd-pg-meta { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12.5px; }
+.grd-pg-label { color: var(--fg); font-weight: 500; }
+.grd-pg-val { color: var(--fg-muted); font-weight: 600; font-feature-settings: "tnum"; font-variant-numeric: tabular-nums; }
+.grd-pg-track { background: var(--gray-200); border-radius: var(--radius-pill); overflow: hidden; }
+.grd-pg-sm .grd-pg-track { height: 4px; }
+.grd-pg-md .grd-pg-track { height: 6px; }
+.grd-pg-lg .grd-pg-track { height: 10px; }
+.grd-pg-fill {
+  height: 100%; border-radius: var(--radius-pill);
+  transition: width 280ms var(--ease-standard);
+  background: var(--violet-500);
+}
+.grd-pg-violet .grd-pg-fill { background: var(--violet-500); }
+.grd-pg-green .grd-pg-fill  { background: var(--signal-green); }
+.grd-pg-amber .grd-pg-fill  { background: var(--signal-yellow); }
+.grd-pg-red .grd-pg-fill    { background: var(--signal-red); }
+
+.grd-pg-ind .grd-pg-fill {
+  width: 40% !important;
+  background: linear-gradient(90deg, transparent, var(--violet-500), transparent);
+  animation: grd-pg-slide 1.2s linear infinite;
+}
+@keyframes grd-pg-slide {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(250%); }
+}
+
+/* Circular */
+.grd-pg-circular { position: relative; display: inline-flex; align-items: center; justify-content: center; }
+.grd-pg-c-bg { color: var(--gray-200); }
+.grd-pg-c-fg { color: var(--violet-500); transition: stroke-dasharray 280ms var(--ease-standard); }
+.grd-pg-green.grd-pg-circular .grd-pg-c-fg { color: var(--signal-green); }
+.grd-pg-amber.grd-pg-circular .grd-pg-c-fg { color: var(--signal-yellow); }
+.grd-pg-red.grd-pg-circular .grd-pg-c-fg   { color: var(--signal-red); }
+.grd-pg-c-val {
+  position: absolute; inset: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700; color: var(--fg);
+  font-feature-settings: "tnum"; font-variant-numeric: tabular-nums;
+}
+.grd-pg-ind.grd-pg-circular svg { animation: grd-pg-spin 1s linear infinite; }
+@keyframes grd-pg-spin { to { transform: rotate(360deg); } }

--- a/ux_references/ui_kits/components/Progress/index.tsx
+++ b/ux_references/ui_kits/components/Progress/index.tsx
@@ -1,0 +1,66 @@
+
+/**
+ * Progress — barra de progresso linear ou circular.
+ * Variant: linear (default) | circular
+ * Props: value (0-100), max, label, showValue, tone (violet|green|amber|red)
+ */
+
+interface ProgressProps {
+  value: number;
+  max?: number;
+  variant?: "linear" | "circular";
+  label?: React.ReactNode;
+  showValue?: boolean;
+  tone?: "violet" | "green" | "amber" | "red";
+  size?: "sm" | "md" | "lg";
+  indeterminate?: boolean;
+  className?: string;
+}
+
+function Progress({
+  value, max = 100, variant = "linear", label, showValue = false,
+  tone = "violet", size = "md", indeterminate = false, className = "",
+}: ProgressProps) {
+  const pct = Math.max(0, Math.min(100, (value / max) * 100));
+  const cls = ["grd-pg", `grd-pg-${variant}`, `grd-pg-${tone}`, `grd-pg-${size}`, indeterminate && "grd-pg-ind", className].filter(Boolean).join(" ");
+
+  if (variant === "circular") {
+    const s = size === "sm" ? 36 : size === "lg" ? 64 : 48;
+    const stroke = size === "sm" ? 3 : size === "lg" ? 5 : 4;
+    const r = (s - stroke) / 2;
+    const c = 2 * Math.PI * r;
+    const dash = indeterminate ? c * 0.25 : (pct / 100) * c;
+    return (
+      <div className={cls} style={{ width: s, height: s }}>
+        <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`}>
+          <circle cx={s/2} cy={s/2} r={r} fill="none" stroke="currentColor" strokeWidth={stroke} className="grd-pg-c-bg" />
+          <circle
+            cx={s/2} cy={s/2} r={r} fill="none"
+            stroke="currentColor" strokeWidth={stroke}
+            strokeDasharray={`${dash} ${c}`}
+            strokeLinecap="round"
+            className="grd-pg-c-fg"
+            style={{ transform: "rotate(-90deg)", transformOrigin: "center" }}
+          />
+        </svg>
+        {showValue && !indeterminate && <div className="grd-pg-c-val">{Math.round(pct)}%</div>}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cls}>
+      {(label || showValue) && (
+        <div className="grd-pg-meta">
+          {label && <span className="grd-pg-label">{label}</span>}
+          {showValue && !indeterminate && <span className="grd-pg-val">{Math.round(pct)}%</span>}
+        </div>
+      )}
+      <div className="grd-pg-track" role="progressbar" aria-valuenow={indeterminate ? undefined : pct} aria-valuemin={0} aria-valuemax={100}>
+        <div className="grd-pg-fill" style={indeterminate ? undefined : { width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+Progress.displayName = "Progress";
+(window as any).Progress = Progress;

--- a/ux_references/ui_kits/components/README.md
+++ b/ux_references/ui_kits/components/README.md
@@ -1,0 +1,71 @@
+# Guardia · Components (React + TypeScript)
+
+Kit neutro de 45 componentes React tipados, reutilizáveis entre o Control Center, a plataforma contábil e as landing pages.
+
+> **Consumo em produção**: o target do repo é **Rsbuild** (não Babel). Os playgrounds deste kit usam `@babel/standalone` apenas porque rodam como HTML estático sem servidor. No repo real (`control-center-web`, `plataforma-contabil`), importe cada componente com `import { Button } from "@/components/Button"` e deixe o Rsbuild fazer o bundle; o CSS acompanha via `import "./index.css"` no topo do `index.tsx` ou via `@import` no CSS raiz.
+
+## Estrutura
+
+```
+ui_kits/components/
+├── _shared/
+│   ├── Icon.tsx          ← <Icon name size /> (~80 glifos Lucide-style)
+│   └── tokens.ts         ← re-exporta vars do colors_and_type.css como constantes TS
+├── Button/
+│   ├── Button.tsx
+│   ├── Button.css
+│   └── Button.playground.html
+├── Input/
+│   ├── Input.tsx
+│   ├── Input.css
+│   └── Input.playground.html
+└── … (44 total)
+```
+
+Cada componente é **independente**: um `.tsx`, um `.css` dedicado e um `playground.html` exibindo todas as variantes.
+
+## Stack técnica
+
+- **React 18.3.1**
+- **TypeScript** — no repo real, compilado pelo **Rsbuild**. Nos playgrounds deste kit, `@babel/standalone` (preset `typescript,react`) apenas como workaround de HTML estático.
+- **CSS por componente** — isolado por prefixo `grd-<slug>-` (ex.: `grd-btn-*`, `grd-input-*`). Todos os ~500 seletores usam esse prefixo para não colidir com estilos globais do app host.
+- **Ícones** — `<Icon />` compartilhado em `_shared/Icon.tsx`
+
+## Como usar num playground / app
+
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+
+<link rel="stylesheet" href="../../colors_and_type.css">
+<link rel="stylesheet" href="_shared/shared.css">
+<link rel="stylesheet" href="Button/Button.css">
+
+<script type="text/babel" data-presets="typescript,react" src="_shared/Icon.tsx"></script>
+<script type="text/babel" data-presets="typescript,react" src="Button/Button.tsx"></script>
+```
+
+Cada componente expõe seu default export no `window` *apenas dentro dos playgrounds Babel inline*, que não compartilham escopo. No repo com Rsbuild, você remove essa linha final e usa `export default Button` + `import` normalmente.
+
+## Convenções
+
+1. **Prefixo CSS** `grd-<slug>-` para evitar colisões com classes globais do host (ex.: `grd-btn`, `grd-dlg`, `grd-dt-row`).
+2. **Props tipadas**: `interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>`.
+3. **Compound components** quando fizer sentido: `<Tabs>`, `<Tabs.List>`, `<Tabs.Trigger>`, `<Tabs.Content>`.
+4. **`displayName`** sempre definido para inspeção no React DevTools.
+5. **Tokens via CSS vars** — nunca hex hard-coded; sempre `var(--violet-500)` etc.
+
+## Índice (44 componentes)
+
+**Primitivos (10)** · Button · IconButton · ButtonGroup · Badge · Chip · Avatar · Label · Separator · Spinner · Skeleton
+
+**Forms (10)** · Input · Textarea · Select · Combobox · Checkbox · Radio · Switch · Slider · DatePicker · FileUpload
+
+**Overlays & feedback (9)** · Dialog · Drawer · Popover · Menu · Tooltip · Toast · Alert · EmptyState · ConfidenceIndicator
+
+**Navegação (7)** · Tabs · Breadcrumbs · Pagination · SidebarNav · TopBar · Command · Accordion
+
+**Dados & conteúdo (8)** · Card · MetricCard · DataTable · Chart · Timeline · Progress · AgentCard · ChatMessage · Reconciliation
+
+Cada componente tem um playground em `ui_kits/components/<Nome>/<Nome>.playground.html`.

--- a/ux_references/ui_kits/components/Radio/Radio.playground.html
+++ b/ux_references/ui_kits/components/Radio/Radio.playground.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Radio · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORM · SELEÇÃO ÚNICA</div>
+  <h1 class="pg-title">Radio · RadioGroup</h1>
+  <span class="pg-codename">import { Radio, RadioGroup } from "ui_kits/components/Radio"</span>
+  <p class="pg-desc">Seleção exclusiva entre alternativas. Use <code>RadioGroup</code> para agrupar; ele cuida do <code>name</code>, do estado <code>checked</code> e dispara <code>onChange(value)</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch"}}>{children}</div></div>);
+}
+function App() {
+  const [regime, setRegime] = React.useState("simples");
+  return (<>
+    <Sec title="Tamanhos">
+      <Radio name="s1" size="sm" value="a" label="Tamanho sm" defaultChecked />
+      <Radio name="s2" size="md" value="a" label="Tamanho md (padrão)" defaultChecked />
+    </Sec>
+
+    <Sec title="Grupo com descrição">
+      <RadioGroup name="regime" value={regime} onChange={setRegime}>
+        <Radio value="mei" label="MEI" description="Receita bruta anual até R$ 81 mil." />
+        <Radio value="simples" label="Simples Nacional" description="Apuração unificada em DAS mensal." />
+        <Radio value="presumido" label="Lucro Presumido" description="Margem de lucro pré-definida por atividade." />
+        <Radio value="real" label="Lucro Real" description="Apuração sobre o lucro efetivo do período." />
+      </RadioGroup>
+      <div style={{marginTop:12,fontSize:13,color:"var(--gray-600)"}}>Selecionado: <b style={{color:"var(--orange-500)"}}>{regime}</b></div>
+    </Sec>
+
+    <Sec title="Em linha">
+      <RadioGroup name="periodo" defaultValue="mes" direction="row" gap={20}>
+        <Radio value="hoje" label="Hoje" />
+        <Radio value="semana" label="Semana" />
+        <Radio value="mes" label="Mês" />
+        <Radio value="tri" label="Trimestre" />
+      </RadioGroup>
+    </Sec>
+
+    <Sec title="Estados">
+      <Radio name="st" value="a" label="Marcado" defaultChecked />
+      <Radio name="st" value="b" label="Desmarcado" />
+      <Radio name="st2" value="a" label="Desabilitado marcado" defaultChecked disabled />
+      <Radio name="st2" value="b" label="Desabilitado" disabled />
+      <Radio name="st3" value="a" label="Com erro" invalid />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Radio"]) || "render(<div>Sem exemplo para Radio</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">Radio</th></tr>
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>value</code></td><td>string</td><td>—</td><td class="desc">Valor identificador (obrigatório)</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md</td></tr>
+  <tr><td><code>label</code></td><td>node</td><td>—</td><td class="desc">Rótulo principal</td></tr>
+  <tr><td><code>description</code></td><td>node</td><td>—</td><td class="desc">Texto de apoio abaixo do rótulo</td></tr>
+  <tr><td><code>invalid</code></td><td>boolean</td><td>false</td><td class="desc">Estado de erro</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">RadioGroup</th></tr>
+  <tr><td><code>name</code></td><td>string</td><td>—</td><td class="desc">Nome compartilhado entre os radios</td></tr>
+  <tr><td><code>value</code> · <code>defaultValue</code></td><td>string</td><td>—</td><td class="desc">Valor controlado/inicial</td></tr>
+  <tr><td><code>onChange</code></td><td>(v) ⇒ void</td><td>—</td><td class="desc">Dispara com o novo value selecionado</td></tr>
+  <tr><td><code>direction</code></td><td>string</td><td>"column"</td><td class="desc">column · row</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Escolha única entre 2-5 opções visíveis simultaneamente.</li>
+      <li>Label clicável; opção default pré-selecionada quando fizer sentido.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Mais de 5 opções — use <code>Select</code>.</li>
+      <li>Radios soltos sem <code>fieldset</code>/<code>legend</code>.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Radio/index.css
+++ b/ux_references/ui_kits/components/Radio/index.css
@@ -1,0 +1,41 @@
+
+.grd-rd {
+  display: inline-flex; align-items: flex-start; gap: 10px;
+  font-family: var(--font-sans); cursor: pointer;
+  -webkit-user-select: none; user-select: none;
+}
+.grd-rd-disabled { opacity: 0.55; cursor: not-allowed; }
+
+/* Radio — desenhado em um único box para evitar desalinhamento sub-pixel.
+   O ponto interno é um box-shadow inset que cresce do centro. */
+.grd-rd-box { position: relative; flex-shrink: 0; display: inline-block; line-height: 0; }
+.grd-rd input[type="radio"] { position: absolute; inset: 0; opacity: 0; cursor: inherit; margin: 0; }
+.grd-rd-mark {
+  display: block;
+  background: radial-gradient(circle, var(--violet-500) 0%, var(--violet-500) 0%, var(--surface) 0%, var(--surface) 100%);
+  border: 1.5px solid var(--border-strong);
+  border-radius: 50%;
+  transition: border-color 140ms, background 160ms var(--ease-out);
+}
+.grd-rd-sm .grd-rd-mark { width: 16px; height: 16px; }
+.grd-rd-md .grd-rd-mark { width: 18px; height: 18px; }
+/* .grd-rd-dot kept for JSX compatibility but invisible */
+.grd-rd-dot { display: none; }
+
+.grd-rd input:hover:not(:disabled) ~ .grd-rd-mark { border-color: var(--violet-500); }
+.grd-rd input:focus-visible ~ .grd-rd-mark { box-shadow: var(--focus-ring); outline: none; outline-offset: 1px; }
+.grd-rd input:checked ~ .grd-rd-mark { border-color: var(--violet-500); }
+.grd-rd-sm input:checked ~ .grd-rd-mark {
+  background: radial-gradient(circle, var(--violet-500) 0%, var(--violet-500) 28%, var(--surface) 30%, var(--surface) 100%);
+}
+.grd-rd-md input:checked ~ .grd-rd-mark {
+  background: radial-gradient(circle, var(--violet-500) 0%, var(--violet-500) 32%, var(--surface) 34%, var(--surface) 100%);
+}
+
+.grd-rd-invalid .grd-rd-mark { border-color: var(--signal-red); }
+
+.grd-rd-text { display: inline-flex; flex-direction: column; gap: 2px; }
+.grd-rd-label { font-size: 14px; font-weight: 500; color: var(--fg); line-height: 1.4; }
+.grd-rd-desc { font-size: 12.5px; color: var(--fg-muted); line-height: 1.45; }
+.grd-rd-sm .grd-rd-label { font-size: 13px; }
+.grd-rd-sm .grd-rd-desc { font-size: 12px; }

--- a/ux_references/ui_kits/components/Radio/index.tsx
+++ b/ux_references/ui_kits/components/Radio/index.tsx
@@ -1,0 +1,85 @@
+
+/**
+ * Radio — seleção única. Usado dentro de <RadioGroup name="...">.
+ * RadioGroup: gerencia o estado e repassa name para os radios.
+ */
+
+interface RadioProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size" | "type"> {
+  size?: "sm" | "md";
+  invalid?: boolean;
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  value: string;
+}
+
+function Radio({
+  size = "md",
+  invalid,
+  label,
+  description,
+  className = "",
+  id,
+  disabled,
+  ...rest
+}: RadioProps) {
+  const genId = React.useId();
+  const rId = id ?? genId;
+  const wrapCls = [
+    "grd-rd",
+    `grd-rd-${size}`,
+    invalid && "grd-rd-invalid",
+    disabled && "grd-rd-disabled",
+    className,
+  ].filter(Boolean).join(" ");
+  return (
+    <label className={wrapCls} htmlFor={rId}>
+      <span className="grd-rd-box">
+        <input id={rId} type="radio" disabled={disabled} {...rest} />
+        <span className="grd-rd-mark"><span className="grd-rd-dot" /></span>
+      </span>
+      {(label || description) && (
+        <span className="grd-rd-text">
+          {label && <span className="grd-rd-label">{label}</span>}
+          {description && <span className="grd-rd-desc">{description}</span>}
+        </span>
+      )}
+    </label>
+  );
+}
+Radio.displayName = "Radio";
+(window as any).Radio = Radio;
+
+interface RadioGroupProps {
+  name: string;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  direction?: "column" | "row";
+  gap?: number;
+  children: React.ReactNode;
+}
+
+function RadioGroup({ name, value, defaultValue, onChange, direction = "column", gap = 10, children }: RadioGroupProps) {
+  const [internal, setInternal] = React.useState(defaultValue ?? "");
+  const current = value !== undefined ? value : internal;
+  const wrapStyle: React.CSSProperties = { display: "flex", flexDirection: direction, gap };
+  return (
+    <div role="radiogroup" style={wrapStyle}>
+      {React.Children.map(children, (child) => {
+        if (!React.isValidElement(child)) return child;
+        const childVal = (child.props as any).value;
+        return React.cloneElement(child as any, {
+          name,
+          checked: current === childVal,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+            if (value === undefined) setInternal(childVal);
+            onChange?.(childVal);
+            (child.props as any).onChange?.(e);
+          },
+        });
+      })}
+    </div>
+  );
+}
+RadioGroup.displayName = "RadioGroup";
+(window as any).RadioGroup = RadioGroup;

--- a/ux_references/ui_kits/components/Reconciliation/Reconciliation.playground.html
+++ b/ux_references/ui_kits/components/Reconciliation/Reconciliation.playground.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Reconciliation · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=11">
+<link rel="stylesheet" href="../ConfidenceIndicator/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">DATA · CONCILIAÇÃO</div>
+  <h1 class="pg-title">Reconciliation</h1>
+  <span class="pg-codename">import Reconciliation from "ui_kits/components/Reconciliation"</span>
+  <p class="pg-desc">Linha de conciliação: sistema × banco, status do par, confidence e ações.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../ConfidenceIndicator/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=11"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:24,flexDirection:"column",alignItems:"stretch",gap:10,maxWidth:920}}>{children}</div></div>);
+}
+
+function App() {
+  return (<>
+    <Sec title="Em contexto · auto-conciliado (extrato Itaú ↔ NF fornecedor)">
+      <Reconciliation
+        status="match" confidence="high"
+        left={{  source: "Extrato Itaú",     label: "TED PAPELARIA BETA",    amount: 12480.00, date: "05/11/2025", meta: "Ag. 0478 · CC 91234-0" }}
+        right={{ source: "Lançamento contábil", label: "NF 8.421 · Papelaria Beta", amount: 12480.00, date: "05/11/2025", meta: "3.1.4.05 · Material de escritório" }}
+        onOpen={() => {}} onConfirm={() => {}} onReject={() => {}}
+      />
+      <div style={{padding:"12px 16px",background:"var(--success-soft)",borderRadius: "var(--radius-md)",display:"flex",justifyContent:"space-between",alignItems:"center",gap:12,fontSize:13,color:"color-mix(in oklab, var(--signal-green) 52%, black)"}}>
+        <span><b>Auto-conciliado pelo agente</b> · valor, data e fornecedor idênticos</span>
+      </div>
+    </Sec>
+
+    <Sec title="Em contexto · divergência que exige revisão humana">
+      <Reconciliation
+        status="diff" confidence="medium"
+        left={{  source: "Extrato Itaú",     label: "DEB AUTOMATICO ENERGIA", amount: 1230.00, date: "05/11/2025" }}
+        right={{ source: "Lançamento contábil", label: "Fatura CPFL · 10/2025", amount: 1280.00, date: "04/11/2025", meta: "Divergência em data e valor" }}
+        onOpen={() => {}} onConfirm={() => {}} onReject={() => {}}
+      />
+      <div style={{padding:"12px 16px",background:"var(--warning-soft)",borderRadius: "var(--radius-md)",display:"flex",justifyContent:"space-between",alignItems:"center",gap:12,fontSize:13,color:"var(--yellow-900)"}}>
+        <span>Diferença de <b>R$ 50,00</b> no valor · data com 1 dia a mais — agente pediu revisão</span>
+      </div>
+    </Sec>
+
+    <Sec title="Match · alta confiança">
+      <Reconciliation
+        status="match" confidence="high"
+        left={{  source: "Sistema", label: "NF 4891 — Alfa Comércio", amount: 12480.00, date: "12/10/2026", meta: "Receita de serviços" }}
+        right={{ source: "Itaú",    label: "TED recebida de Alfa Comércio", amount: 12480.00, date: "12/10/2026", meta: "Ag. 0478 · CC 91234-0" }}
+        onOpen={() => {}} onConfirm={() => {}} onReject={() => {}}
+      />
+    </Sec>
+
+    <Sec title="Divergência · confidence média">
+      <Reconciliation
+        status="diff" confidence="medium"
+        left={{  source: "Sistema", label: "Pagamento fornecedor Delta", amount: 8432.10, date: "15/10/2026", meta: "Duplicata #3320" }}
+        right={{ source: "Bradesco", label: "DOC Delta Indústria", amount: 8412.10, date: "15/10/2026", meta: "Tarifa R$ 20,00" }}
+        onOpen={() => {}} onConfirm={() => {}} onReject={() => {}}
+      />
+    </Sec>
+
+    <Sec title="Sem par">
+      <Reconciliation
+        status="unmatched" confidence="low"
+        left={{ source: "Sistema", label: "Transferência agendada — Horus", amount: 15200.00, date: "20/10/2026", meta: "Aguardando confirmação" }}
+        onOpen={() => {}} onReject={() => {}}
+      />
+    </Sec>
+
+    <Sec title="Em lote — empilhadas (sem ações)">
+      <Reconciliation
+        status="match" confidence="high"
+        left={{  source: "Sistema", label: "NF 4892 — Beta Serviços", amount: 4150.00, date: "13/10", meta: "Receita de serviços" }}
+        right={{ source: "Itaú",    label: "TED recebida de Beta",     amount: 4150.00, date: "13/10" }}
+      />
+      <Reconciliation
+        status="match" confidence="high"
+        left={{  source: "Sistema", label: "NF 4893 — Casa & Jardim",  amount: 890.50,  date: "13/10", meta: "Receita de serviços" }}
+        right={{ source: "Itaú",    label: "PIX recebido de Casa",     amount: 890.50,  date: "13/10" }}
+      />
+      <Reconciliation
+        status="diff" confidence="medium"
+        left={{  source: "Sistema", label: "NF 4894 — Epsilon",        amount: 2310.00, date: "14/10" }}
+        right={{ source: "Itaú",    label: "TED recebida de Epsilon",  amount: 2300.00, date: "14/10", meta: "Tarifa R$ 10,00" }}
+      />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Reconciliation"]) || "render(<div>Sem exemplo para Reconciliation</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>left</code></td><td>RecSide</td><td>—</td><td class="desc">Lado sistema (fonte interna)</td></tr>
+  <tr><td><code>right</code></td><td>RecSide?</td><td>—</td><td class="desc">Lado banco (ou omitir p/ unmatched)</td></tr>
+  <tr><td><code>status</code></td><td>string</td><td>"match"</td><td class="desc">match · diff · unmatched</td></tr>
+  <tr><td><code>confidence</code></td><td>string</td><td>—</td><td class="desc">high · medium · low — chip no centro</td></tr>
+  <tr><td><code>onOpen</code> · <code>onConfirm</code> · <code>onReject</code></td><td>fn</td><td>—</td><td class="desc">Ações à direita (renderizadas quando passadas)</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">RecSide</th></tr>
+  <tr><td><code>label</code></td><td>node</td><td>—</td><td class="desc">Descrição do lançamento</td></tr>
+  <tr><td><code>amount</code></td><td>number</td><td>—</td><td class="desc">Valor em BRL (formatado automaticamente)</td></tr>
+  <tr><td><code>date</code> · <code>meta</code> · <code>source</code></td><td>node</td><td>—</td><td class="desc">Metadados visuais</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Side-by-side sistema × banco com match score central.</li>
+      <li>Destacar campos divergentes em amarelo; ação explícita em divergências.</li>
+      <li>Auto-conciliar só quando confidence ≥ 95% e com trilha de auditoria.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Auto-conciliação silenciosa sem feedback.</li>
+      <li>Cores de status em campos individuais — destaque só a divergência.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Reconciliation/index.css
+++ b/ux_references/ui_kits/components/Reconciliation/index.css
@@ -1,0 +1,70 @@
+
+.grd-rc {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 12px 14px 12px 18px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  font-family: var(--font-sans);
+  overflow: hidden;
+}
+/* Barra de status à esquerda — bloco retangular, sem raio (remete ao símbolo G).
+   Não é "border-left accent"; é um indicador pleno que pertence à geometria
+   modular da marca. */
+.grd-rc::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 4px; background: var(--signal-green);
+}
+.grd-rc-diff::before      { background: var(--signal-yellow); }
+.grd-rc-unmatched::before { background: var(--signal-red); }
+
+.grd-rc-side { min-width: 0; }
+.grd-rc-src {
+  font-size: 10.5px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.04em; color: var(--fg-muted); margin-bottom: 3px;
+}
+.grd-rc-label { font-size: 13px; font-weight: 500; color: var(--fg); line-height: 1.35; }
+.grd-rc-amount {
+  font-size: 15px; font-weight: 600; color: var(--fg);
+  font-feature-settings: "tnum"; font-variant-numeric: tabular-nums;
+  margin-top: 2px;
+}
+.grd-rc-meta { font-size: 11.5px; color: var(--fg-muted); margin-top: 2px; }
+.grd-rc-right { text-align: right; }
+
+.grd-rc-center { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.grd-rc-status {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 11.5px; font-weight: 600;
+  padding: 3px 8px; border-radius: var(--radius-pill);
+}
+.grd-rc-status-match     { background: var(--success-soft); color: color-mix(in oklab, var(--signal-green) 52%, black); }
+.grd-rc-status-diff      { background: var(--yellow-100);   color: var(--yellow-900); }
+.grd-rc-status-unmatched { background: var(--danger-soft);  color: color-mix(in oklab, var(--signal-red) 45%, black); }
+.grd-rc-delta {
+  font-size: 11px; color: var(--fg-muted);
+  font-feature-settings: "tnum"; font-variant-numeric: tabular-nums;
+}
+
+.grd-rc-empty {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12.5px; color: var(--fg-muted); font-style: italic;
+}
+
+.grd-rc-actions { display: inline-flex; gap: 4px; align-items: center; }
+.grd-rc-btn {
+  display: inline-flex; align-items: center; gap: 4px;
+  border: 1px solid transparent; border-radius: var(--radius-md);
+  padding: 5px 10px; font-size: 12px; font-weight: 600;
+  cursor: pointer; font-family: inherit;
+  transition: background 140ms, border-color 140ms, color 140ms;
+}
+.grd-rc-btn-primary { background: var(--violet-500); color: #fff; }
+.grd-rc-btn-primary:hover { background: var(--violet-600); }
+.grd-rc-btn-ghost { background: transparent; color: var(--fg); }
+.grd-rc-btn-ghost:hover { background: var(--gray-100); }
+.grd-rc-btn-danger { background: transparent; color: var(--signal-red); padding: 5px 7px; }
+.grd-rc-btn-danger:hover { background: var(--danger-soft); }

--- a/ux_references/ui_kits/components/Reconciliation/index.tsx
+++ b/ux_references/ui_kits/components/Reconciliation/index.tsx
@@ -1,0 +1,119 @@
+
+/**
+ * Reconciliation — linha de conciliação (sistema / banco) com diff e status.
+ * Props:
+ *   left: { label, amount, date?, meta? }
+ *   right: { label, amount, date?, meta? }
+ *   status: "match" | "diff" | "unmatched"
+ *   confidence?: "high" | "medium" | "low"
+ *   delta?: number
+ *   onConfirm?, onReject?, onOpen?
+ */
+
+interface RecSide {
+  label: React.ReactNode;
+  amount: number;
+  date?: React.ReactNode;
+  meta?: React.ReactNode;
+  source?: React.ReactNode;
+}
+interface ReconciliationProps {
+  left: RecSide;
+  right?: RecSide;
+  status?: "match" | "diff" | "unmatched";
+  confidence?: "high" | "medium" | "low";
+  onConfirm?: () => void;
+  onReject?: () => void;
+  onOpen?: () => void;
+  className?: string;
+}
+
+function fmtBRL(n: number) {
+  return n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+}
+
+function Reconciliation({
+  left, right, status = "match", confidence,
+  onConfirm, onReject, onOpen, className = "",
+}: ReconciliationProps) {
+  const IconCmp = (window as any).Icon;
+  const ConfIndicator = (window as any).ConfidenceIndicator;
+  const delta = right ? (left.amount - right.amount) : null;
+  const cls = ["grd-rc", `grd-rc-${status}`, className].filter(Boolean).join(" ");
+
+  const STATUS_LBL: Record<string, string> = {
+    match: "Conciliado",
+    diff: "Divergente",
+    unmatched: "Sem par",
+  };
+
+  return (
+    <div className={cls}>
+      <div className="grd-rc-side grd-rc-left">
+        <div className="grd-rc-src">{left.source ?? "Sistema"}</div>
+        <div className="grd-rc-label">{left.label}</div>
+        <div className="grd-rc-amount">{fmtBRL(left.amount)}</div>
+        {(left.date || left.meta) && (
+          <div className="grd-rc-meta">
+            {left.date}{left.date && left.meta && " · "}{left.meta}
+          </div>
+        )}
+      </div>
+
+      <div className="grd-rc-center">
+        <span className={`grd-rc-status grd-rc-status-${status}`}>
+          {IconCmp && (
+            <IconCmp
+              name={status === "match" ? "check" : status === "diff" ? "equal-not" : "x"}
+              size={14}
+            />
+          )}
+          {STATUS_LBL[status]}
+        </span>
+        {confidence && ConfIndicator && (
+          <ConfIndicator level={confidence} variant="chip" size="sm" showValue={false} />
+        )}
+      </div>
+
+      {right ? (
+        <div className="grd-rc-side grd-rc-right">
+          <div className="grd-rc-src">{right.source ?? "Banco"}</div>
+          <div className="grd-rc-label">{right.label}</div>
+          <div className="grd-rc-amount">{fmtBRL(right.amount)}</div>
+          {(right.date || right.meta) && (
+            <div className="grd-rc-meta">
+              {right.date}{right.date && right.meta && " · "}{right.meta}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="grd-rc-side grd-rc-empty">
+          {IconCmp && <IconCmp name="search" size={18} />}
+          <span>Sem correspondência</span>
+        </div>
+      )}
+
+      {(onConfirm || onReject || onOpen) && (
+        <div className="grd-rc-actions">
+          {onOpen && (
+            <button type="button" className="grd-rc-btn grd-rc-btn-ghost" onClick={onOpen}>
+              {IconCmp && <IconCmp name="eye" size={13} />} Ver
+            </button>
+          )}
+          {onReject && (
+            <button type="button" className="grd-rc-btn grd-rc-btn-danger" onClick={onReject} aria-label="Rejeitar">
+              {IconCmp && <IconCmp name="x" size={14} />}
+            </button>
+          )}
+          {onConfirm && (
+            <button type="button" className="grd-rc-btn grd-rc-btn-primary" onClick={onConfirm}>
+              {IconCmp && <IconCmp name="check" size={14} />} Confirmar
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+Reconciliation.displayName = "Reconciliation";
+(window as any).Reconciliation = Reconciliation;

--- a/ux_references/ui_kits/components/Select/Select.playground.html
+++ b/ux_references/ui_kits/components/Select/Select.playground.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Select · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORM · SELEÇÃO</div>
+  <h1 class="pg-title">Select</h1>
+  <span class="pg-codename">import Select from "ui_kits/components/Select"</span>
+  <p class="pg-desc">Dropdown nativo. Ideal para listas curtas e conhecidas (até ~12 opções). Para listas longas, busca ou criação de novos valores, use <code>Combobox</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, w=360 }: { title: string; children: React.ReactNode; w?: number }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",maxWidth:w}}>{children}</div></div>);
+}
+
+const REGIMES = [
+  { value: "mei", label: "MEI" },
+  { value: "simples", label: "Simples Nacional" },
+  { value: "presumido", label: "Lucro Presumido" },
+  { value: "real", label: "Lucro Real" },
+];
+
+const PERIODOS = [
+  { value: "hoje", label: "Hoje" },
+  { value: "semana", label: "Esta semana" },
+  { value: "mes", label: "Este mês" },
+  { value: "tri", label: "Este trimestre" },
+  { value: "ano", label: "Este ano" },
+];
+
+function App() {
+  const [reg, setReg] = React.useState("simples");
+  return (<>
+    <Sec title="Tamanhos">
+      <Select size="sm" options={PERIODOS} defaultValue="mes" />
+      <Select size="md" options={PERIODOS} defaultValue="mes" />
+      <Select size="lg" options={PERIODOS} defaultValue="mes" />
+    </Sec>
+
+    <Sec title="Com placeholder + ícone esquerdo">
+      <Select leftIcon="building-2" options={REGIMES} placeholder="Selecione o regime tributário…" />
+    </Sec>
+
+    <Sec title="Estados">
+      <Select options={PERIODOS} defaultValue="mes" />
+      <Select options={PERIODOS} defaultValue="mes" state="error" />
+      <Select options={PERIODOS} defaultValue="mes" state="success" />
+      <Select options={PERIODOS} defaultValue="mes" disabled />
+    </Sec>
+
+    <Sec title="Controlado">
+      <Select
+        leftIcon="scale"
+        options={REGIMES}
+        value={reg}
+        onChange={e => setReg(e.target.value)}
+      />
+      <div style={{fontSize:13,color:"var(--gray-600)"}}>Regime selecionado: <b style={{color:"var(--orange-500)"}}>{REGIMES.find(r=>r.value===reg)?.label}</b></div>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Select"]) || "render(<div>Sem exemplo para Select</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>state</code></td><td>string</td><td>"default"</td><td class="desc">default · error · success</td></tr>
+  <tr><td><code>leftIcon</code></td><td>string</td><td>—</td><td class="desc">Nome do ícone Lucide à esquerda</td></tr>
+  <tr><td><code>placeholder</code></td><td>string</td><td>—</td><td class="desc">Opção inicial desabilitada/oculta</td></tr>
+  <tr><td><code>options</code></td><td>array</td><td>—</td><td class="desc">{`{ value, label, disabled? }[]`} · alternativa a children</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Lista curta (< 15 itens) sem necessidade de busca.</li>
+      <li>Placeholder indicando o que selecionar.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Listas longas — use <code>Combobox</code>.</li>
+      <li>Selects dependentes (cascata) sem feedback de carregamento.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Select/index.css
+++ b/ux_references/ui_kits/components/Select/index.css
@@ -1,0 +1,37 @@
+
+.grd-select {
+  display: inline-flex; align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  position: relative; width: 100%;
+  transition: border-color 140ms, box-shadow 140ms;
+  font-family: var(--font-sans);
+}
+.grd-select select {
+  appearance: none; -webkit-appearance: none;
+  font-family: inherit; border: 0; background: transparent; outline: none;
+  color: var(--fg); width: 100%; padding: 0; margin: 0; cursor: pointer;
+  padding-right: 28px;
+}
+
+.grd-select-sm { padding: 6px 10px; font-size: 13px; height: 32px; }
+.grd-select-sm select { font-size: 13px; }
+.grd-select-md { padding: 8px 12px; font-size: 14px; height: 38px; }
+.grd-select-md select { font-size: 14px; }
+.grd-select-lg { padding: 10px 14px; font-size: 15px; height: 46px; }
+.grd-select-lg select { font-size: 15px; }
+
+.grd-select-default:focus-within { border-color: var(--violet-500); box-shadow: var(--focus-ring); }
+.grd-select-error   { border-color: var(--signal-red); }
+.grd-select-error:focus-within { box-shadow: var(--focus-ring-error); }
+.grd-select-success { border-color: var(--signal-green); }
+.grd-select-success:focus-within { box-shadow: var(--focus-ring-success); }
+.grd-select-disabled { background: var(--gray-100); opacity: 0.7; }
+.grd-select-disabled select { cursor: not-allowed; }
+
+.grd-select-ic { color: var(--gray-500); display: inline-flex; flex-shrink: 0; margin-right: 8px; }
+.grd-select-chev {
+  position: absolute; right: 12px; top: 50%; transform: translateY(-50%);
+  color: var(--gray-500); pointer-events: none;
+}

--- a/ux_references/ui_kits/components/Select/index.tsx
+++ b/ux_references/ui_kits/components/Select/index.tsx
@@ -1,0 +1,67 @@
+
+/**
+ * Select — dropdown nativo <select>.
+ * Ideal para listas curtas e conhecidas. Para listas longas ou buscáveis, use <Combobox />.
+ */
+
+type SelectSize = "sm" | "md" | "lg";
+type SelectState = "default" | "error" | "success";
+
+interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "size"> {
+  size?: SelectSize;
+  state?: SelectState;
+  invalid?: boolean;
+  leftIcon?: string;
+  placeholder?: string;
+  options?: Array<{ value: string; label: string; disabled?: boolean }>;
+}
+
+function Select({
+  size = "md",
+  state = "default",
+  invalid,
+  leftIcon,
+  placeholder,
+  options,
+  className = "",
+  children,
+  disabled,
+  value,
+  defaultValue,
+  ...rest
+}: SelectProps) {
+  const IconCmp = (window as any).Icon;
+  const effective = invalid ? "error" : state;
+  const wrapCls = [
+    "grd-select",
+    `grd-select-${size}`,
+    `grd-select-${effective}`,
+    disabled && "grd-select-disabled",
+    leftIcon && "grd-select-has-left",
+    className,
+  ].filter(Boolean).join(" ");
+  const iconSize = size === "sm" ? 13 : size === "lg" ? 18 : 15;
+
+  // If no controlled value and there's a placeholder, show empty selected
+  const useDefault = value === undefined && defaultValue === undefined && placeholder !== undefined;
+
+  return (
+    <div className={wrapCls}>
+      {leftIcon && IconCmp && <span className="grd-select-ic grd-select-ic-l"><IconCmp name={leftIcon} size={iconSize} /></span>}
+      <select
+        disabled={disabled}
+        value={value}
+        defaultValue={useDefault ? "" : defaultValue}
+        {...rest}
+      >
+        {placeholder && <option value="" disabled hidden>{placeholder}</option>}
+        {options
+          ? options.map(o => <option key={o.value} value={o.value} disabled={o.disabled}>{o.label}</option>)
+          : children}
+      </select>
+      {IconCmp && <span className="grd-select-chev"><IconCmp name="chevron-down" size={iconSize} /></span>}
+    </div>
+  );
+}
+Select.displayName = "Select";
+(window as any).Select = Select;

--- a/ux_references/ui_kits/components/Separator/Separator.playground.html
+++ b/ux_references/ui_kits/components/Separator/Separator.playground.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Separator · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · ESTRUTURA</div>
+  <h1 class="pg-title">Separator</h1>
+  <span class="pg-codename">import Separator from "ui_kits/components/Separator"</span>
+  <p class="pg-desc">Divisor horizontal ou vertical para agrupar visualmente blocos de conteúdo. Três aparências e label opcional centralizado.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch"}}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Horizontal">
+      <Separator />
+      <Separator appearance="dashed" />
+      <Separator appearance="dotted" />
+    </Sec>
+    <Sec title="Com label">
+      <Separator label="ou" />
+      <Separator label="março de 2025" />
+      <Separator appearance="dashed" label="seção de arquivados" />
+    </Sec>
+    <Sec title="Vertical (inline)">
+      <div style={{display:"flex",alignItems:"center",gap:14,height:40,background:"#fff",padding:"0 16px",border:"1px solid var(--border)",borderRadius:"var(--radius-md)"}}>
+        <span style={{fontSize:13}}>Conciliado</span>
+        <Separator orientation="vertical" />
+        <span style={{fontSize:13}}>248 lançamentos</span>
+        <Separator orientation="vertical" />
+        <span style={{fontSize:13,color:"var(--gray-500)"}}>há 2 min</span>
+      </div>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Separator"]) || "render(<div>Sem exemplo para Separator</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>orientation</code></td><td>string</td><td>"horizontal"</td><td class="desc">horizontal · vertical</td></tr>
+  <tr><td><code>appearance</code></td><td>string</td><td>"solid"</td><td class="desc">solid · dashed · dotted</td></tr>
+  <tr><td><code>label</code></td><td>string</td><td>—</td><td class="desc">Texto centralizado entre dois traços</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Dividir grupos de conteúdo relacionados dentro de cards/drawers.</li>
+      <li>Horizontal 1px cinza-100; vertical no <code>ButtonGroup</code>.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Separadores como ornamentação.</li>
+      <li>Entre cada item de uma lista — use padding.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Separator/index.css
+++ b/ux_references/ui_kits/components/Separator/index.css
@@ -1,0 +1,77 @@
+/* Separator
+   Usa background (não border) para controle sub-pixel e dashes consistentes
+   entre Chrome/Safari/FF. Cor padrão = --border (neutro com viés violeta). */
+
+/* Horizontal solid */
+.grd-sep-horizontal:not(.grd-sep-labeled) {
+  width: 100%; height: 1px;
+  background: var(--border);
+  border: 0;
+}
+.grd-sep-horizontal.grd-sep-dashed:not(.grd-sep-labeled) {
+  height: 1px;
+  background: repeating-linear-gradient(
+    to right,
+    var(--border) 0 6px,
+    transparent 6px 12px
+  );
+}
+.grd-sep-horizontal.grd-sep-dotted:not(.grd-sep-labeled) {
+  height: 1px;
+  background: repeating-linear-gradient(
+    to right,
+    var(--border) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+/* Vertical */
+.grd-sep-vertical {
+  width: 1px; align-self: stretch;
+  background: var(--border);
+  border: 0;
+  min-height: 16px;
+}
+.grd-sep-vertical.grd-sep-dashed {
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--border) 0 4px,
+    transparent 4px 8px
+  );
+}
+.grd-sep-vertical.grd-sep-dotted {
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--border) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+/* Labeled: "linha — texto — linha" */
+.grd-sep-labeled {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--gray-500);
+  font-size: 11px; font-weight: 600; letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 0; background: transparent;
+}
+.grd-sep-labeled .grd-sep-line {
+  flex: 1; height: 1px;
+  background: var(--border);
+  border: 0;
+}
+.grd-sep-labeled.grd-sep-dashed .grd-sep-line {
+  background: repeating-linear-gradient(
+    to right,
+    var(--border) 0 6px,
+    transparent 6px 12px
+  );
+}
+.grd-sep-labeled.grd-sep-dotted .grd-sep-line {
+  background: repeating-linear-gradient(
+    to right,
+    var(--border) 0 2px,
+    transparent 2px 5px
+  );
+}
+.grd-sep-labeled .grd-sep-label { flex-shrink: 0; }

--- a/ux_references/ui_kits/components/Separator/index.tsx
+++ b/ux_references/ui_kits/components/Separator/index.tsx
@@ -1,0 +1,39 @@
+/**
+ * Separator — divisor horizontal ou vertical.
+ * Variantes: solid (default) · dashed · dotted
+ * Com label opcional centralizado.
+ */
+
+interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical";
+  appearance?: "solid" | "dashed" | "dotted";
+  label?: string;
+}
+
+function Separator({
+  orientation = "horizontal",
+  appearance = "solid",
+  label,
+  className = "",
+  ...rest
+}: SeparatorProps) {
+  const cls = [
+    "grd-sep",
+    `grd-sep-${orientation}`,
+    `grd-sep-${appearance}`,
+    label && "grd-sep-labeled",
+    className,
+  ].filter(Boolean).join(" ");
+  if (label) {
+    return (
+      <div className={cls} role="separator" {...rest}>
+        <span className="grd-sep-line" />
+        <span className="grd-sep-label">{label}</span>
+        <span className="grd-sep-line" />
+      </div>
+    );
+  }
+  return <div className={cls} role="separator" {...rest} />;
+}
+Separator.displayName = "Separator";
+(window as any).Separator = Separator;

--- a/ux_references/ui_kits/components/SidebarNav/SidebarNav.playground.html
+++ b/ux_references/ui_kits/components/SidebarNav/SidebarNav.playground.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>SidebarNav · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Badge/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">NAVEGAÇÃO · LATERAL</div>
+  <h1 class="pg-title">SidebarNav</h1>
+  <span class="pg-codename">import SidebarNav from "ui_kits/components/SidebarNav"</span>
+  <p class="pg-desc">Navegação lateral com seções, grupos aninhados e modo colapsado (só ícones).</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:24,gap:24,alignItems:"flex-start",background:"var(--gray-50)"}}>{children}</div></div>);
+}
+function ContentStub({ label }: { label: string }) {
+  return (
+    <div style={{flex:1,minHeight:420,padding:32,background:"var(--papel)",border:"1px solid var(--gray-200)",borderRadius:"var(--radius-lg)",color:"var(--gray-500)",fontSize:14}}>
+      Conteúdo: <b style={{color:"var(--fg)"}}>{label}</b>
+    </div>
+  );
+}
+
+function Demo({ collapsed }: { collapsed: boolean }) {
+  const [active, setActive] = React.useState("inicio");
+  const items = (k: string) => ({ active: active === k, onClick: () => setActive(k) });
+  return (
+    <SidebarNav collapsed={collapsed}>
+      <SidebarNav.Section label="Geral">
+        <SidebarNav.Item icon="layout-dashboard" {...items("inicio")}>Início</SidebarNav.Item>
+        <SidebarNav.Item icon="inbox" badge="12" {...items("inbox")}>Inbox</SidebarNav.Item>
+        <SidebarNav.Item icon="users" {...items("clientes")}>Clientes</SidebarNav.Item>
+      </SidebarNav.Section>
+      <SidebarNav.Section label="Operação">
+        <SidebarNav.Group icon="book-open-check" label="Contábil" defaultOpen>
+          <SidebarNav.Item {...items("lanc")}>Lançamentos</SidebarNav.Item>
+          <SidebarNav.Item {...items("razao")}>Razão</SidebarNav.Item>
+          <SidebarNav.Item {...items("plano")}>Plano de contas</SidebarNav.Item>
+        </SidebarNav.Group>
+        <SidebarNav.Group icon="arrow-left-right" label="Financeiro">
+          <SidebarNav.Item {...items("conc")}>Conciliação</SidebarNav.Item>
+          <SidebarNav.Item {...items("extratos")}>Extratos</SidebarNav.Item>
+        </SidebarNav.Group>
+        <SidebarNav.Item icon="receipt-text" badge="3" {...items("fiscal")}>Fiscal</SidebarNav.Item>
+      </SidebarNav.Section>
+      <SidebarNav.Section label="Sistema">
+        <SidebarNav.Item icon="settings" {...items("config")}>Configurações</SidebarNav.Item>
+        <SidebarNav.Item icon="life-buoy" {...items("ajuda")}>Ajuda</SidebarNav.Item>
+      </SidebarNav.Section>
+    </SidebarNav>
+  );
+}
+
+function App() {
+  return (<>
+    <Sec title="Padrão (expandida)">
+      <Demo collapsed={false} />
+      <ContentStub label="rotas / seções ativas" />
+    </Sec>
+    <Sec title="Colapsada (só ícones)">
+      <Demo collapsed={true} />
+      <ContentStub label="modo compacto" />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["SidebarNav"]) || "render(<div>Sem exemplo para SidebarNav</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">SidebarNav</th></tr>
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>collapsed</code></td><td>boolean</td><td>false</td><td class="desc">Oculta labels, mostra só ícones</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">SidebarNav.Section</th></tr>
+  <tr><td><code>label</code></td><td>node</td><td>—</td><td class="desc">Cabeçalho da seção (oculto em collapsed)</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">SidebarNav.Item</th></tr>
+  <tr><td><code>icon</code></td><td>string</td><td>—</td><td class="desc">Ícone Lucide</td></tr>
+  <tr><td><code>badge</code></td><td>node</td><td>—</td><td class="desc">Contador à direita</td></tr>
+  <tr><td><code>active</code></td><td>boolean</td><td>false</td><td class="desc">Estado selecionado</td></tr>
+  <tr><td><code>onClick</code> · <code>href</code></td><td>fn · string</td><td>—</td><td class="desc">Ação ou rota</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">SidebarNav.Group</th></tr>
+  <tr><td><code>icon</code> · <code>label</code></td><td>string · node</td><td>—</td><td class="desc">Cabeçalho</td></tr>
+  <tr><td><code>defaultOpen</code></td><td>boolean</td><td>true</td><td class="desc">Estado inicial expandido</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Navegação primária do app; ícone + label + indicador de rota ativa.</li>
+      <li>Colapsável em telas médias; agrupamento por seção.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Mais de 7 itens de primeiro nível.</li>
+      <li>Navegação sem indicação clara de item ativo.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/SidebarNav/index.css
+++ b/ux_references/ui_kits/components/SidebarNav/index.css
@@ -1,0 +1,49 @@
+
+.grd-sb {
+  font-family: var(--font-sans);
+  display: flex; flex-direction: column; gap: 14px;
+  width: 240px; padding: 14px 10px;
+  background: var(--gray-50);
+  border-right: 1px solid var(--border);
+  height: 100%;
+  transition: width 180ms var(--ease-standard);
+}
+.grd-sb-col { width: 60px; padding: 14px 6px; align-items: stretch; }
+.grd-sb-section { display: flex; flex-direction: column; gap: 2px; }
+.grd-sb-sect-label {
+  padding: 2px 10px 4px;
+  font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--fg-muted);
+}
+.grd-sb-sect-divider { height: 1px; background: var(--border); margin: 6px 4px; }
+.grd-sb-sect-items { display: flex; flex-direction: column; gap: 1px; }
+
+.grd-sb-item {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 0; background: transparent;
+  font-family: inherit; font-size: 13.5px; font-weight: 500;
+  color: var(--fg); cursor: pointer; border-radius: var(--radius-md);
+  text-align: left; text-decoration: none;
+  transition: background 120ms, color 120ms;
+}
+.grd-sb-col .grd-sb-item { justify-content: center; padding: 10px 0; }
+.grd-sb-item:hover { background: var(--violet-50); color: var(--violet-700); }
+.grd-sb-item-active { background: var(--violet-100); color: var(--violet-700); font-weight: 600; }
+.grd-sb-item-active:hover { background: var(--violet-100); }
+
+.grd-sb-item-ic { color: var(--fg-muted); display: inline-flex; flex-shrink: 0; }
+.grd-sb-item:hover .grd-sb-item-ic,
+.grd-sb-item-active .grd-sb-item-ic { color: var(--violet-600); }
+.grd-sb-item-lab { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.grd-sb-item-badge {
+  font-size: 10.5px; font-weight: 700;
+  background: var(--violet-200); color: var(--violet-700);
+  padding: 1px 7px; border-radius: var(--radius-pill); min-width: 18px; text-align: center;
+}
+
+.grd-sb-group-chev { color: var(--fg-muted); transition: transform 180ms var(--ease-standard); }
+.grd-sb-group-open .grd-sb-group-chev { transform: rotate(180deg); }
+.grd-sb-group-items { padding-left: 26px; display: flex; flex-direction: column; gap: 1px; margin-top: 1px; }
+.grd-sb-group-items .grd-sb-item { padding: 6px 10px; font-size: 13px; }

--- a/ux_references/ui_kits/components/SidebarNav/index.tsx
+++ b/ux_references/ui_kits/components/SidebarNav/index.tsx
@@ -1,0 +1,74 @@
+
+/**
+ * SidebarNav — navegação lateral vertical com seções e itens.
+ * Aninhamento via children (1 nível). Suporta ícone, badge, ativo.
+ * Pode ser collapsed (só ícones).
+ *
+ * Structure:
+ *   <SidebarNav collapsed={bool}>
+ *     <SidebarNav.Section label="Geral">
+ *       <SidebarNav.Item icon="home" active>Início</SidebarNav.Item>
+ *       <SidebarNav.Item icon="file-text" badge="4">Documentos</SidebarNav.Item>
+ *     </SidebarNav.Section>
+ *     <SidebarNav.Group icon="folder" label="Clientes">
+ *       <SidebarNav.Item>Todos</SidebarNav.Item>
+ *       <SidebarNav.Item>Favoritos</SidebarNav.Item>
+ *     </SidebarNav.Group>
+ *   </SidebarNav>
+ */
+
+interface SidebarNavCtx { collapsed: boolean; }
+const SidebarCtx = React.createContext<SidebarNavCtx>({ collapsed: false });
+
+function SidebarNav({ collapsed = false, children, className = "" }: { collapsed?: boolean; children: React.ReactNode; className?: string }) {
+  return (
+    <SidebarCtx.Provider value={{ collapsed }}>
+      <nav className={`grd-sb ${collapsed ? "grd-sb-col" : ""} ${className}`}>{children}</nav>
+    </SidebarCtx.Provider>
+  );
+}
+function SBSection({ label, children }: { label?: React.ReactNode; children: React.ReactNode }) {
+  const { collapsed } = React.useContext(SidebarCtx);
+  return (
+    <div className="grd-sb-section">
+      {label && !collapsed && <div className="grd-sb-sect-label">{label}</div>}
+      {collapsed && label && <div className="grd-sb-sect-divider" />}
+      <div className="grd-sb-sect-items">{children}</div>
+    </div>
+  );
+}
+function SBItem({
+  icon, badge, active, onClick, href, children,
+}: { icon?: string; badge?: React.ReactNode; active?: boolean; onClick?: () => void; href?: string; children: React.ReactNode }) {
+  const { collapsed } = React.useContext(SidebarCtx);
+  const IconCmp = (window as any).Icon;
+  const cls = ["grd-sb-item", active && "grd-sb-item-active"].filter(Boolean).join(" ");
+  const inner = (<>
+    {icon && IconCmp && <span className="grd-sb-item-ic"><IconCmp name={icon} size={16} /></span>}
+    {!collapsed && <span className="grd-sb-item-lab">{children}</span>}
+    {!collapsed && badge && <span className="grd-sb-item-badge">{badge}</span>}
+  </>);
+  if (href) return <a href={href} className={cls} onClick={onClick} title={collapsed && typeof children === "string" ? children : undefined}>{inner}</a>;
+  return <button type="button" className={cls} onClick={onClick} title={collapsed && typeof children === "string" ? children : undefined}>{inner}</button>;
+}
+function SBGroup({ icon, label, defaultOpen = true, children }: { icon?: string; label: React.ReactNode; defaultOpen?: boolean; children: React.ReactNode }) {
+  const { collapsed } = React.useContext(SidebarCtx);
+  const [open, setOpen] = React.useState(defaultOpen);
+  const IconCmp = (window as any).Icon;
+  if (collapsed) return <>{children}</>;
+  return (
+    <div className={`grd-sb-group ${open ? "grd-sb-group-open" : ""}`}>
+      <button type="button" className="grd-sb-item grd-sb-group-trigger" onClick={() => setOpen(o => !o)} aria-expanded={open}>
+        {icon && IconCmp && <span className="grd-sb-item-ic"><IconCmp name={icon} size={16} /></span>}
+        <span className="grd-sb-item-lab">{label}</span>
+        {IconCmp && <span className="grd-sb-group-chev"><IconCmp name="chevron-down" size={13} /></span>}
+      </button>
+      {open && <div className="grd-sb-group-items">{children}</div>}
+    </div>
+  );
+}
+(SidebarNav as any).Section = SBSection;
+(SidebarNav as any).Item = SBItem;
+(SidebarNav as any).Group = SBGroup;
+SidebarNav.displayName = "SidebarNav";
+(window as any).SidebarNav = SidebarNav;

--- a/ux_references/ui_kits/components/Skeleton/Skeleton.playground.html
+++ b/ux_references/ui_kits/components/Skeleton/Skeleton.playground.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Skeleton · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · CARREGAMENTO</div>
+  <h1 class="pg-title">Skeleton</h1>
+  <span class="pg-codename">import Skeleton from "ui_kits/components/Skeleton"</span>
+  <p class="pg-desc">Placeholder animado (shimmer) para conteúdo que ainda está carregando. Variantes: <code>text</code>, <code>title</code>, <code>rect</code>, <code>circle</code>. Para blocos de texto multi-linha, passe <code>lines</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch"}}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Variantes">
+      <div style={{display:"flex",alignItems:"center",gap:14}}>
+        <Skeleton variant="circle" width={40} height={40} />
+        <Skeleton variant="title" width={220} />
+      </div>
+      <Skeleton variant="text" width="60%" />
+      <Skeleton variant="rect" width="100%" height={120} />
+    </Sec>
+
+    <Sec title="Bloco de texto (multi-linha)">
+      <Skeleton lines={4} />
+    </Sec>
+
+    <Sec title="Card mock (composição real)">
+      <div style={{background:"#fff",border:"1px solid var(--border)",borderRadius:"var(--radius-md)",padding:16,maxWidth:420}}>
+        <div style={{display:"flex",alignItems:"center",gap:10,marginBottom:12}}>
+          <Skeleton variant="circle" width={36} height={36} />
+          <div style={{flex:1,display:"flex",flexDirection:"column",gap:4}}>
+            <Skeleton width="50%" />
+            <Skeleton width="30%" height={10} />
+          </div>
+        </div>
+        <Skeleton variant="rect" width="100%" height={100} style={{marginBottom:12}} />
+        <Skeleton lines={3} />
+      </div>
+    </Sec>
+
+    <Sec title="Linha de tabela mock">
+      <div style={{background:"#fff",border:"1px solid var(--border)",borderRadius:"var(--radius-md)",padding:"10px 14px"}}>
+        {Array.from({length:4}).map((_,i)=>(
+          <div key={i} style={{display:"grid",gridTemplateColumns:"2fr 1fr 1fr 80px",gap:16,alignItems:"center",padding:"12px 0",borderBottom:i<3?"1px solid var(--border)":"none"}}>
+            <div style={{display:"flex",alignItems:"center",gap:10}}>
+              <Skeleton variant="circle" width={28} height={28} />
+              <Skeleton width={140} />
+            </div>
+            <Skeleton width={80} />
+            <Skeleton width={70} />
+            <Skeleton width={60} />
+          </div>
+        ))}
+      </div>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Skeleton"]) || "render(<div>Sem exemplo para Skeleton</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"text"</td><td class="desc">text · title · rect · circle</td></tr>
+  <tr><td><code>width</code></td><td>number | string</td><td>auto</td><td class="desc">Largura (px ou %)</td></tr>
+  <tr><td><code>height</code></td><td>number | string</td><td>auto</td><td class="desc">Altura (px ou %)</td></tr>
+  <tr><td><code>lines</code></td><td>number</td><td>1</td><td class="desc">Número de linhas (só com variant=text); última linha a 70%</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Loading de listas e cards quando a forma do conteúdo é previsível.</li>
+      <li>Mesmo shape do conteúdo final; animação sutil.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Skeleton para requests instantâneos (< 300ms).</li>
+      <li>Loader genérico no meio da tela quando dá pra mostrar estrutura.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Skeleton/index.css
+++ b/ux_references/ui_kits/components/Skeleton/index.css
@@ -1,0 +1,19 @@
+/* Skeleton */
+.grd-skel {
+  display: inline-block;
+  background: linear-gradient(90deg, var(--gray-100), var(--gray-200), var(--gray-100));
+  background-size: 200% 100%;
+  animation: grd-skel-shimmer 1400ms ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+.grd-skel-text   { height: 14px; border-radius: var(--radius-sm); width: 100%; }
+.grd-skel-title  { height: 22px; border-radius: var(--radius-md); width: 60%; }
+.grd-skel-rect   { width: 100%; height: 80px; border-radius: var(--radius-md); }
+.grd-skel-circle { border-radius: var(--radius-pill); width: 40px; height: 40px; }
+
+.grd-skel-group { display: flex; flex-direction: column; gap: 8px; width: 100%; }
+
+@keyframes grd-skel-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/ux_references/ui_kits/components/Skeleton/index.tsx
+++ b/ux_references/ui_kits/components/Skeleton/index.tsx
@@ -1,0 +1,53 @@
+/**
+ * Skeleton — placeholder animado para conteúdo ainda carregando.
+ * Variants: text (linha) · title (linha maior) · rect (bloco) · circle.
+ * Props: width, height, lines (para text), className, style.
+ */
+
+type SkeletonVariant = "text" | "title" | "rect" | "circle";
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: SkeletonVariant;
+  width?: number | string;
+  height?: number | string;
+  lines?: number;
+}
+
+function Skeleton({
+  variant = "text",
+  width,
+  height,
+  lines = 1,
+  className = "",
+  style,
+  ...rest
+}: SkeletonProps) {
+  const baseCls = ["grd-skel", `grd-skel-${variant}`, className].filter(Boolean).join(" ");
+
+  if (variant === "text" && lines > 1) {
+    return (
+      <span className="grd-skel-group" {...rest}>
+        {Array.from({ length: lines }).map((_, i) => (
+          <span
+            key={i}
+            className={baseCls}
+            style={{
+              width: i === lines - 1 ? "70%" : width || "100%",
+              ...style,
+            }}
+          />
+        ))}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={baseCls}
+      style={{ width, height, ...style }}
+      {...rest}
+    />
+  );
+}
+Skeleton.displayName = "Skeleton";
+(window as any).Skeleton = Skeleton;

--- a/ux_references/ui_kits/components/Slider/Slider.playground.html
+++ b/ux_references/ui_kits/components/Slider/Slider.playground.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Slider · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORM · NUMÉRICO</div>
+  <h1 class="pg-title">Slider</h1>
+  <span class="pg-codename">import Slider from "ui_kits/components/Slider"</span>
+  <p class="pg-desc">Seletor numérico contínuo em um intervalo. Suporta <code>prefix</code>/<code>suffix</code>, formatador customizado e exibição do valor atual.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, w=440 }: { title: string; children: React.ReactNode; w?: number }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",maxWidth:w}}>{children}</div></div>);
+}
+const brl = (v:number) => v.toLocaleString("pt-BR",{style:"currency",currency:"BRL",maximumFractionDigits:0});
+
+function App() {
+  const [conf, setConf] = React.useState(85);
+  const [teto, setTeto] = React.useState(25000);
+  return (<>
+    <Sec title="Tamanhos">
+      <Slider size="sm" defaultValue={40} showValue suffix="%" />
+      <Slider size="md" defaultValue={60} showValue suffix="%" />
+    </Sec>
+
+    <Sec title="Limiar de confiança do agente">
+      <Slider
+        min={50} max={100} step={1}
+        value={conf}
+        onChange={e => setConf(+e.target.value)}
+        showValue suffix="%"
+      />
+      <div style={{fontSize:13,color:"var(--gray-600)"}}>
+        Agentes aplicam automaticamente acima de <b style={{color:"var(--orange-500)"}}>{conf}%</b>. Abaixo disso, a plataforma pede revisão humana.
+      </div>
+    </Sec>
+
+    <Sec title="Teto de valor para auto-aprovação (R$)">
+      <Slider
+        min={0} max={100000} step={500}
+        value={teto}
+        onChange={e => setTeto(+e.target.value)}
+        showValue
+        format={v => brl(v)}
+      />
+    </Sec>
+
+    <Sec title="Com passo maior (step=5)">
+      <Slider min={0} max={100} step={5} defaultValue={40} showValue suffix="%" />
+    </Sec>
+
+    <Sec title="Desabilitado">
+      <Slider defaultValue={30} showValue suffix="%" disabled />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Slider"]) || "render(<div>Sem exemplo para Slider</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>min</code> · <code>max</code></td><td>number</td><td>0 · 100</td><td class="desc">Faixa de valores</td></tr>
+  <tr><td><code>step</code></td><td>number</td><td>1</td><td class="desc">Incremento</td></tr>
+  <tr><td><code>value</code> · <code>defaultValue</code></td><td>number</td><td>50</td><td class="desc">Valor controlado/inicial</td></tr>
+  <tr><td><code>showValue</code></td><td>boolean</td><td>false</td><td class="desc">Exibe valor atual à direita</td></tr>
+  <tr><td><code>prefix</code> · <code>suffix</code></td><td>string</td><td>—</td><td class="desc">Ex.: "R$ ", " %"</td></tr>
+  <tr><td><code>format</code></td><td>(v) ⇒ string</td><td>—</td><td class="desc">Formatação customizada (sobrepõe prefix/suffix)</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Faixa contínua onde o valor exato importa menos que a posição (threshold de confidence, zoom).</li>
+      <li>Mostrar valor numérico ao lado.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Valores discretos não ordinais — use <code>Select</code>.</li>
+      <li>Slider sem marcadores quando a escala é não-linear.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Slider/index.css
+++ b/ux_references/ui_kits/components/Slider/index.css
@@ -1,0 +1,49 @@
+
+.grd-sl {
+  display: inline-flex; align-items: center; gap: 12px;
+  font-family: var(--font-sans);
+  width: 100%;
+}
+.grd-sl input[type="range"] {
+  flex: 1;
+  appearance: none; -webkit-appearance: none;
+  background: transparent; outline: none; padding: 0; margin: 0;
+  height: 20px; cursor: pointer;
+}
+/* Track */
+.grd-sl input[type="range"]::-webkit-slider-runnable-track {
+  height: 4px; border-radius: var(--radius-pill);
+  background: linear-gradient(to right, var(--violet-500) 0%, var(--violet-500) var(--pct), var(--gray-200) var(--pct), var(--gray-200) 100%);
+}
+.grd-sl input[type="range"]::-moz-range-track {
+  height: 4px; border-radius: var(--radius-pill); background: var(--gray-200);
+}
+.grd-sl input[type="range"]::-moz-range-progress {
+  height: 4px; border-radius: var(--radius-pill); background: var(--violet-500);
+}
+/* Thumb */
+.grd-sl input[type="range"]::-webkit-slider-thumb {
+  appearance: none; -webkit-appearance: none;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--surface); border: 2px solid var(--violet-500);
+  margin-top: -6px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+  transition: box-shadow 140ms, transform 140ms;
+}
+.grd-sl input[type="range"]::-moz-range-thumb {
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--surface); border: 2px solid var(--violet-500);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+}
+.grd-sl input[type="range"]:focus-visible::-webkit-slider-thumb {
+  box-shadow: var(--focus-ring);
+}
+.grd-sl-sm input[type="range"] { height: 16px; }
+.grd-sl-sm input[type="range"]::-webkit-slider-runnable-track { height: 3px; }
+.grd-sl-sm input[type="range"]::-webkit-slider-thumb { width: 14px; height: 14px; margin-top: -5.5px; }
+
+.grd-sl-val {
+  font-size: 13px; font-weight: 600; color: var(--violet-700);
+  font-feature-settings: "tnum"; font-variant-numeric: tabular-nums;
+  min-width: 38px; text-align: right;
+}

--- a/ux_references/ui_kits/components/Slider/index.tsx
+++ b/ux_references/ui_kits/components/Slider/index.tsx
@@ -1,0 +1,57 @@
+
+/**
+ * Slider — seletor numérico. Wrapper de <input type="range">.
+ * Props: min, max, step, value, showValue, prefix, suffix.
+ */
+
+interface SliderProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "size"> {
+  size?: "sm" | "md";
+  showValue?: boolean;
+  prefix?: string;
+  suffix?: string;
+  format?: (v: number) => string;
+}
+
+function Slider({
+  size = "md",
+  showValue = false,
+  prefix = "",
+  suffix = "",
+  format,
+  min = 0,
+  max = 100,
+  step = 1,
+  value,
+  defaultValue,
+  onChange,
+  className = "",
+  ...rest
+}: SliderProps) {
+  const [internal, setInternal] = React.useState<number>(
+    typeof defaultValue === "number" ? defaultValue : typeof defaultValue === "string" ? +defaultValue : 50
+  );
+  const current = value !== undefined ? +value : internal;
+  const pct = ((current - +min) / (+max - +min)) * 100;
+
+  const cls = ["grd-sl", `grd-sl-${size}`, className].filter(Boolean).join(" ");
+  const displayVal = format ? format(current) : `${prefix}${current}${suffix}`;
+
+  return (
+    <div className={cls}>
+      <input
+        type="range"
+        min={min} max={max} step={step}
+        value={current}
+        onChange={e => {
+          if (value === undefined) setInternal(+e.target.value);
+          onChange?.(e);
+        }}
+        style={{ ["--pct" as any]: `${pct}%` }}
+        {...rest}
+      />
+      {showValue && <span className="grd-sl-val">{displayVal}</span>}
+    </div>
+  );
+}
+Slider.displayName = "Slider";
+(window as any).Slider = Slider;

--- a/ux_references/ui_kits/components/Spinner/Spinner.playground.html
+++ b/ux_references/ui_kits/components/Spinner/Spinner.playground.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Spinner · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">PRIMITIVO · CARREGAMENTO</div>
+  <h1 class="pg-title">Spinner</h1>
+  <span class="pg-codename">import Spinner from "ui_kits/components/Spinner"</span>
+  <p class="pg-desc">Indicador circular de operação em andamento. Herda cor por padrão (<code>currentColor</code>) — basta definir o <code>color</code> do container.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, dark }: { title: string; children: React.ReactNode; dark?: boolean }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className={"pg-stage "+(dark?"dark":"")}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Tamanhos">
+      <Spinner size="xs" />
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+      <Spinner size="xl" />
+    </Sec>
+    <Sec title="Cores">
+      <Spinner color="brand" size="lg" />
+      <Spinner color="accent" size="lg" />
+      <span style={{color:"var(--verde-500)"}}><Spinner color="current" size="lg" /></span>
+      <span style={{color:"var(--gray-500)"}}><Spinner color="current" size="lg" /></span>
+    </Sec>
+    <Sec title="Em fundo escuro" dark>
+      <Spinner color="white" size="lg" />
+      <Spinner color="white" size="xl" />
+    </Sec>
+    <Sec title="Uso em contexto">
+      <div style={{display:"flex",alignItems:"center",gap:10,fontSize:14,color:"var(--gray-700)"}}>
+        <Spinner color="brand" size="sm" /> Conciliando 248 lançamentos…
+      </div>
+      <div style={{display:"flex",alignItems:"center",gap:10,fontSize:14,color:"var(--orange-500)"}}>
+        <Spinner color="current" size="sm" /> Gerando relatório fiscal…
+      </div>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Spinner"]) || "render(<div>Sem exemplo para Spinner</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">xs (12) · sm (16) · md (20) · lg (28) · xl (40)</td></tr>
+  <tr><td><code>color</code></td><td>string</td><td>"current"</td><td class="desc">current · brand · accent · white</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Ação pontual síncrona (salvando, exportando).</li>
+      <li>Inline ao lado do botão ou em IconButton.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Spinner de tela inteira — use <code>Skeleton</code>.</li>
+      <li>Spinner > 3s sem mensagem contextual.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Spinner/index.css
+++ b/ux_references/ui_kits/components/Spinner/index.css
@@ -1,0 +1,11 @@
+/* Spinner */
+.grd-spinner {
+  display: inline-flex; align-items: center; justify-content: center;
+  animation: grd-spinner-spin 900ms linear infinite;
+  color: currentColor;
+}
+.grd-spinner-brand   { color: var(--violet-500); }
+.grd-spinner-accent  { color: var(--orange-500); }
+.grd-spinner-white   { color: #fff; }
+.grd-spinner svg { display: block; }
+@keyframes grd-spinner-spin { to { transform: rotate(360deg); } }

--- a/ux_references/ui_kits/components/Spinner/index.tsx
+++ b/ux_references/ui_kits/components/Spinner/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * Spinner — indicador de carregamento circular.
+ * Props: size (xs|sm|md|lg|xl em px), color (currentColor | brand | accent | white).
+ */
+
+type SpinnerSize = "xs" | "sm" | "md" | "lg" | "xl";
+type SpinnerColor = "current" | "brand" | "accent" | "white";
+
+interface SpinnerProps extends React.HTMLAttributes<HTMLSpanElement> {
+  size?: SpinnerSize;
+  color?: SpinnerColor;
+}
+
+const SPINNER_PX: Record<SpinnerSize, number> = { xs: 12, sm: 16, md: 20, lg: 28, xl: 40 };
+
+function Spinner({ size = "md", color = "current", className = "", ...rest }: SpinnerProps) {
+  const cls = ["grd-spinner", `grd-spinner-${color}`, className].filter(Boolean).join(" ");
+  const px = SPINNER_PX[size];
+  return (
+    <span className={cls} style={{ width: px, height: px }} role="status" aria-label="Carregando" {...rest}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" width={px} height={px}>
+        <path d="M21 12a9 9 0 1 1-6.3-8.57" />
+      </svg>
+    </span>
+  );
+}
+Spinner.displayName = "Spinner";
+(window as any).Spinner = Spinner;

--- a/ux_references/ui_kits/components/Stepper/Stepper.playground.html
+++ b/ux_references/ui_kits/components/Stepper/Stepper.playground.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Stepper · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=3">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="../Badge/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">NAVEGAÇÃO · PROGRESSO</div>
+  <h1 class="pg-title">Stepper</h1>
+  <span class="pg-codename">import Stepper from "ui_kits/components/Stepper"</span>
+  <p class="pg-desc">Indicador de progresso em fluxos de múltiplas etapas. Horizontal ou vertical, numerado, com ícones ou compacto. Suporta estados (pendente · atual · completo · erro) e navegação por clique em passos anteriores.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Input/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=3"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,gap:40,alignItems:"flex-start",flexWrap:"wrap"}}>{children}</div></div>);
+}
+function Frame({ children, w=720, label }: { children: React.ReactNode; w?: number; label?: string }) {
+  return (
+    <div style={{ width: w }}>
+      {label && <div style={{ fontSize: 11.5, color: "var(--fg-muted)", marginBottom: 10, fontWeight: 600, letterSpacing: ".04em", textTransform: "uppercase" }}>{label}</div>}
+      <div style={{ background: "var(--papel)", border: "1px solid var(--gray-200)", borderRadius: "var(--radius-lg)", padding: "22px 26px" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/* ---------- 1. Onboarding horizontal ---------- */
+const ONBOARDING = [
+  { id: "1", title: "Criar conta",      description: "CNPJ validado" },
+  { id: "2", title: "Conectar banco",   description: "Open Finance" },
+  { id: "3", title: "Importar extrato", description: "OFX ou automático" },
+  { id: "4", title: "Configurar regras" },
+  { id: "5", title: "Revisar" },
+];
+
+/* ---------- 2. Com ícones ---------- */
+const ICONED = [
+  { id: "1", title: "Upload",        icon: "upload-cloud" },
+  { id: "2", title: "Parse",         icon: "file-text" },
+  { id: "3", title: "Match",         icon: "git-merge" },
+  { id: "4", title: "Reconciliação", icon: "check-circle" },
+];
+
+/* ---------- 3. Com erro ---------- */
+const WITH_ERROR = [
+  { id: "1", title: "Importar extrato", state: "complete" as const },
+  { id: "2", title: "Validar CNPJ",     state: "complete" as const },
+  { id: "3", title: "Enviar ao Domínio",state: "error" as const,   description: "Credencial expirada" },
+  { id: "4", title: "Confirmar" },
+];
+
+/* ---------- 3b. Com loading (estado assíncrono) ---------- */
+const WITH_LOADING = [
+  { id: "1", title: "Upload",   state: "complete" as const },
+  { id: "2", title: "Parse OFX", state: "complete" as const, description: "237 lançamentos" },
+  { id: "3", title: "Conciliando…", state: "loading" as const, description: "cruzando com ERP" },
+  { id: "4", title: "Revisar" },
+  { id: "5", title: "Fechar" },
+];
+
+/* ---------- 3c. Loading no fluxo do Copilot (compact) ---------- */
+const COPILOT_RUN = [
+  { id: "1", title: "Planejar",  state: "complete" as const },
+  { id: "2", title: "Buscar",    state: "complete" as const },
+  { id: "3", title: "Calcular",  state: "loading"  as const },
+  { id: "4", title: "Confirmar" },
+];
+
+/* ---------- 4. Vertical com meta (form step-by-step) ---------- */
+const FORM_STEPS = [
+  {
+    id: "1",
+    title: "Dados da empresa",
+    description: "Razão social, CNPJ e regime tributário",
+    meta: (
+      <div style={{ display: "grid", gap: 10, maxWidth: 320 }}>
+        <Input size="sm" placeholder="Razão social" defaultValue="Padaria da Esquina LTDA" />
+        <Input size="sm" placeholder="CNPJ" defaultValue="12.345.678/0001-90" />
+        <div style={{ display: "flex", gap: 8 }}>
+          <Button size="sm" variant="primary">Continuar</Button>
+          <Button size="sm" variant="ghost">Voltar</Button>
+        </div>
+      </div>
+    ),
+  },
+  { id: "2", title: "Conta bancária",  description: "Qual banco vamos conectar primeiro?" },
+  { id: "3", title: "Regras fiscais",  description: "Configure o plano de contas" },
+  { id: "4", title: "Primeiro fechamento", description: "A Guardia começa a trabalhar" },
+];
+
+/* ---------- 5. Processamento em background (compact) ---------- */
+const PROCESS = [
+  { id: "1", title: "Upload" },
+  { id: "2", title: "Parse" },
+  { id: "3", title: "Match" },
+  { id: "4", title: "Review" },
+  { id: "5", title: "Close" },
+];
+
+function App() {
+  const [step, setStep] = React.useState(2);
+  const [verticalStep, setVerticalStep] = React.useState(0);
+
+  return (<>
+    <Sec title="Horizontal numbered — onboarding (clickable)">
+      <Frame w={760} label={`Etapa ${step + 1} de ${ONBOARDING.length}`}>
+        <Stepper
+          steps={ONBOARDING}
+          activeIndex={step}
+          onStepClick={(i) => setStep(i)}
+        />
+        <div style={{ display: "flex", gap: 8, marginTop: 22, borderTop: "1px solid var(--gray-100)", paddingTop: 18, justifyContent: "flex-end" }}>
+          <Button variant="ghost" size="sm" disabled={step === 0} onClick={() => setStep(Math.max(0, step - 1))}>Voltar</Button>
+          <Button variant="primary" size="sm" disabled={step >= ONBOARDING.length - 1} onClick={() => setStep(Math.min(ONBOARDING.length - 1, step + 1))}>Avançar</Button>
+        </div>
+      </Frame>
+    </Sec>
+
+    <Sec title="Horizontal iconed — pipeline de processamento">
+      <Frame w={640}>
+        <Stepper steps={ICONED} activeIndex={2} variant="iconed" />
+      </Frame>
+    </Sec>
+
+    <Sec title="Estado de erro — fluxo interrompido">
+      <Frame w={720}>
+        <Stepper steps={WITH_ERROR} variant="numbered" />
+      </Frame>
+    </Sec>
+
+    <Sec title="Estado de loading — passo em processamento assíncrono">
+      <Frame w={720}>
+        <Stepper steps={WITH_LOADING} variant="numbered" />
+      </Frame>
+      <Frame w={360} label="Dentro do Copilot (compact)">
+        <Stepper steps={COPILOT_RUN} variant="compact" />
+      </Frame>
+    </Sec>
+
+    <Sec title="Vertical com conteúdo inline — onboarding longo">
+      <Frame w={520}>
+        <Stepper
+          steps={FORM_STEPS}
+          activeIndex={verticalStep}
+          orientation="vertical"
+          onStepClick={(i) => setVerticalStep(i)}
+        />
+      </Frame>
+    </Sec>
+
+    <Sec title="Compact — indicador minimalista">
+      <Frame w={320}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+          <span style={{ fontSize: 12, color: "var(--fg-muted)", fontWeight: 600, letterSpacing: ".04em", textTransform: "uppercase" }}>Processando extrato Itaú</span>
+          <span style={{ fontSize: 12, color: "var(--violet-600)", fontWeight: 600 }}>3 de 5</span>
+        </div>
+        <Stepper steps={PROCESS} activeIndex={2} variant="compact" />
+      </Frame>
+      <Frame w={220} label="sm">
+        <Stepper steps={PROCESS} activeIndex={3} variant="compact" size="sm" />
+      </Frame>
+    </Sec>
+
+    <Sec title="Todos os estados (vertical sm)">
+      <Frame w={320} label="Referência visual">
+        <Stepper
+          size="sm"
+          orientation="vertical"
+          steps={[
+            { id: "1", title: "Complete", description: "Concluído com sucesso", state: "complete" },
+            { id: "2", title: "Current",  description: "Em andamento", state: "current" },
+            { id: "3", title: "Loading",  description: "Processando…", state: "loading" },
+            { id: "4", title: "Error",    description: "Falhou — revisar", state: "error" },
+            { id: "5", title: "Pending",  description: "Ainda não iniciado", state: "pending" },
+          ]}
+        />
+      </Frame>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Stepper"]) || "render(<div>Sem exemplo para Stepper</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>steps</code></td><td>Step[]</td><td>—</td><td class="desc">Lista de passos em ordem</td></tr>
+  <tr><td><code>activeIndex</code></td><td>number</td><td>0</td><td class="desc">Passo atual — passos anteriores viram <code>complete</code> automaticamente</td></tr>
+  <tr><td><code>orientation</code></td><td>string</td><td>"horizontal"</td><td class="desc">horizontal · vertical</td></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"numbered"</td><td class="desc">numbered · iconed · compact</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md</td></tr>
+  <tr><td><code>onStepClick</code></td><td>(i, step) ⇒ void</td><td>—</td><td class="desc">Se informado, passos já concluídos viram clicáveis</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">Step</th></tr>
+  <tr><td><code>id</code></td><td>string</td><td>—</td><td class="desc">Chave única</td></tr>
+  <tr><td><code>title</code> · <code>description</code></td><td>node</td><td>—</td><td class="desc">Conteúdo do passo</td></tr>
+  <tr><td><code>icon</code></td><td>string</td><td>—</td><td class="desc">Usado em variant="iconed"</td></tr>
+  <tr><td><code>state</code></td><td>string</td><td>—</td><td class="desc">Força o estado (pending · current · loading · complete · error). Se omitido, é calculado a partir de <code>activeIndex</code>.</td></tr>
+  <tr><td><code>meta</code></td><td>node</td><td>—</td><td class="desc">Conteúdo inline (form, ações) — só aparece no passo <code>current</code> em orientação vertical</td></tr>
+</table>
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Fluxos com ≥ 3 etapas sequenciais e progresso relevante para o usuário.</li>
+      <li>Onboardings, wizards, pipelines de processamento e fluxos transacionais do Copilot.</li>
+      <li>Vertical quando cada etapa tem conteúdo próprio (form, escolhas); horizontal quando é só checkpoint.</li>
+      <li>Compact em headers e cards onde o foco é o status, não os rótulos.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Fluxos de 2 passos — use apenas um botão "Continuar".</li>
+      <li>Passos opcionais misturados com obrigatórios sem distinção visual clara.</li>
+      <li>Stepper como navegação lateral permanente — use <code>SidebarNav</code>.</li>
+    </ul>
+  </div>
+</div>
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Stepper/index.css
+++ b/ux_references/ui_kits/components/Stepper/index.css
@@ -1,0 +1,256 @@
+
+/* ===================================================================
+ * Stepper — tokens apenas; usa --violet-*, --signal-*, --gray-* etc.
+ * ================================================================= */
+
+.grd-st {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-sans);
+  color: var(--fg);
+}
+
+.grd-st-item { position: relative; }
+
+.grd-st-btn {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: default;
+  width: 100%;
+}
+
+.grd-st-clickable .grd-st-item:not(.grd-st-s-pending) > .grd-st-btn {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background 120ms, color 120ms;
+}
+.grd-st-clickable .grd-st-item:not(.grd-st-s-pending) > button.grd-st-btn:hover {
+  background: var(--violet-50);
+}
+.grd-st-clickable .grd-st-item:not(.grd-st-s-pending) > button.grd-st-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ---------- Marker ---------- */
+.grd-st-marker {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  font-feature-settings: "tnum";
+  transition: background 140ms, border-color 140ms, color 140ms;
+}
+.grd-st-sm .grd-st-marker { width: 20px; height: 20px; font-size: 11px; }
+
+.grd-st-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: currentColor;
+}
+.grd-st-sm .grd-st-dot { width: 6px; height: 6px; }
+
+.grd-st-num { line-height: 1; }
+.grd-st-tick { font-size: 13px; line-height: 1; }
+
+/* ---------- States ---------- */
+.grd-st-s-pending .grd-st-marker {
+  background: var(--surface);
+  border-color: var(--border);
+  color: var(--fg-muted);
+}
+.grd-st-s-current .grd-st-marker {
+  background: var(--violet-600);
+  border-color: var(--violet-600);
+  color: #fff;
+  box-shadow: 0 0 0 4px var(--violet-100);
+}
+.grd-st-s-loading .grd-st-marker {
+  background: var(--violet-50);
+  border-color: var(--violet-600);
+  color: var(--violet-600);
+  box-shadow: 0 0 0 4px var(--violet-100);
+}
+.grd-st-s-complete .grd-st-marker {
+  background: var(--violet-600);
+  border-color: var(--violet-600);
+  color: #fff;
+}
+.grd-st-s-error .grd-st-marker {
+  background: var(--danger-soft);
+  border-color: var(--signal-red);
+  color: var(--signal-red);
+}
+
+/* ---------- Spinner inline ---------- */
+.grd-st-spin {
+  width: 12px; height: 12px;
+  border: 1.5px solid var(--violet-200);
+  border-top-color: var(--violet-600);
+  border-radius: 50%;
+  animation: grd-st-spin 700ms linear infinite;
+}
+.grd-st-sm .grd-st-spin { width: 10px; height: 10px; border-width: 1.5px; }
+.grd-st-compact .grd-st-spin { width: 8px; height: 8px; border-width: 1.5px; }
+
+@keyframes grd-st-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ---------- Body ---------- */
+.grd-st-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  padding-top: 2px;
+}
+.grd-st-sm .grd-st-body { padding-top: 1px; }
+
+.grd-st-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--fg);
+  line-height: 1.3;
+}
+.grd-st-sm .grd-st-title { font-size: 12.5px; }
+
+.grd-st-s-pending .grd-st-title { color: var(--fg-muted); font-weight: 500; }
+.grd-st-s-current .grd-st-title { color: var(--violet-700); }
+.grd-st-s-loading .grd-st-title { color: var(--violet-700); }
+.grd-st-s-loading .grd-st-desc  { color: var(--violet-600); }
+.grd-st-s-error .grd-st-title   { color: var(--signal-red); }
+
+.grd-st-desc {
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  line-height: 1.4;
+}
+.grd-st-sm .grd-st-desc { font-size: 11.5px; }
+
+.grd-st-meta {
+  /* Vertical: alinhar com o body (depois do marker 24 + gap 10) */
+  margin-top: 10px;
+  padding-left: 34px;
+}
+.grd-st-sm .grd-st-meta { padding-left: 30px; }
+
+/* =========================================================
+ * Horizontal
+ * ========================================================= */
+.grd-st-horizontal {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+}
+.grd-st-horizontal .grd-st-item {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+}
+.grd-st-horizontal .grd-st-btn {
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+  padding: 4px 8px;
+}
+.grd-st-horizontal .grd-st-body {
+  align-items: center;
+  padding-top: 0;
+}
+.grd-st-horizontal .grd-st-title,
+.grd-st-horizontal .grd-st-desc {
+  text-align: center;
+}
+
+/* Connector horizontal */
+.grd-st-horizontal .grd-st-item:not(.grd-st-last)::after {
+  content: "";
+  position: absolute;
+  top: 12px;                     /* metade do marker md */
+  left: calc(50% + 16px);
+  right: calc(-50% + 16px);
+  height: 1.5px;
+  background: var(--border);
+  z-index: 0;
+}
+.grd-st-sm.grd-st-horizontal .grd-st-item:not(.grd-st-last)::after {
+  top: 10px;
+  left: calc(50% + 14px);
+  right: calc(-50% + 14px);
+}
+.grd-st-horizontal .grd-st-item.grd-st-s-complete:not(.grd-st-last)::after,
+.grd-st-horizontal .grd-st-item.grd-st-s-current:not(.grd-st-last)::after,
+.grd-st-horizontal .grd-st-item.grd-st-s-loading:not(.grd-st-last)::after {
+  background: var(--violet-500);
+}
+.grd-st-horizontal .grd-st-marker {
+  position: relative;
+  z-index: 1;
+}
+
+/* Compact horizontal: linha fina entre bolinhas, sem body */
+.grd-st-horizontal.grd-st-compact .grd-st-item:not(.grd-st-last)::after {
+  top: 50%;
+  left: calc(50% + 10px);
+  right: calc(-50% + 10px);
+  transform: translateY(-50%);
+}
+.grd-st-compact .grd-st-marker {
+  width: 14px; height: 14px; border-width: 1.5px;
+}
+.grd-st-compact.grd-st-sm .grd-st-marker { width: 10px; height: 10px; }
+.grd-st-compact .grd-st-s-current .grd-st-marker { box-shadow: 0 0 0 3px var(--violet-100); }
+.grd-st-compact .grd-st-s-loading .grd-st-marker { box-shadow: 0 0 0 3px var(--violet-100); }
+
+/* =========================================================
+ * Vertical
+ * ========================================================= */
+.grd-st-vertical { display: flex; flex-direction: column; }
+.grd-st-vertical .grd-st-item { padding-bottom: 18px; }
+.grd-st-vertical .grd-st-item.grd-st-last { padding-bottom: 0; }
+.grd-st-vertical.grd-st-sm .grd-st-item { padding-bottom: 12px; }
+
+.grd-st-vertical .grd-st-btn {
+  align-items: flex-start;
+}
+
+/* Connector vertical */
+.grd-st-vertical .grd-st-item:not(.grd-st-last)::after {
+  content: "";
+  position: absolute;
+  top: 28px;                    /* abaixo do marker md (24 + gap) */
+  bottom: -2px;
+  left: 11px;                   /* metade do marker md - metade linha */
+  width: 1.5px;
+  background: var(--border);
+  z-index: 0;
+}
+.grd-st-sm.grd-st-vertical .grd-st-item:not(.grd-st-last)::after {
+  top: 24px;
+  left: 9px;
+}
+.grd-st-vertical .grd-st-item.grd-st-s-complete:not(.grd-st-last)::after,
+.grd-st-vertical .grd-st-item.grd-st-s-current:not(.grd-st-last)::after,
+.grd-st-vertical .grd-st-item.grd-st-s-loading:not(.grd-st-last)::after {
+  background: var(--violet-500);
+}
+.grd-st-vertical .grd-st-marker { position: relative; z-index: 1; }

--- a/ux_references/ui_kits/components/Stepper/index.tsx
+++ b/ux_references/ui_kits/components/Stepper/index.tsx
@@ -1,0 +1,140 @@
+
+/**
+ * Stepper — indicador de progresso em fluxo de múltiplas etapas.
+ *
+ * Uso típico na Guardia:
+ *   - Onboarding (conectar banco → importar → configurar regras → revisar)
+ *   - Fluxo transacional dentro do Copilot (selecionar → validar → confirmar)
+ *   - Processamento longo (upload → parse → match → fechamento)
+ *
+ * Estados por step: pending · current · complete · error
+ * Orientação: horizontal | vertical
+ * Variantes: numbered (1,2,3) | iconed (ícone por step) | compact (apenas bolinhas)
+ */
+
+interface Step {
+  id: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  icon?: string;            // usado quando variant="iconed"
+  state?: "pending" | "current" | "loading" | "complete" | "error";
+  meta?: React.ReactNode;   // conteúdo extra abaixo (ex: um input, um botão) — apenas vertical
+}
+
+interface StepperProps {
+  steps: Step[];
+  activeIndex?: number;              // índice do passo atual (fonte de verdade se os steps não trouxerem state próprio)
+  orientation?: "horizontal" | "vertical";
+  variant?: "numbered" | "iconed" | "compact";
+  size?: "sm" | "md";
+  onStepClick?: (index: number, step: Step) => void;
+  className?: string;
+}
+
+function computeState(
+  step: Step,
+  index: number,
+  activeIndex: number
+): "pending" | "current" | "loading" | "complete" | "error" {
+  if (step.state) return step.state;
+  if (index < activeIndex) return "complete";
+  if (index === activeIndex) return "current";
+  return "pending";
+}
+
+function Stepper({
+  steps,
+  activeIndex = 0,
+  orientation = "horizontal",
+  variant = "numbered",
+  size = "md",
+  onStepClick,
+  className = "",
+}: StepperProps) {
+  const IconCmp = (window as any).Icon;
+  const cls = [
+    "grd-st",
+    `grd-st-${orientation}`,
+    `grd-st-${variant}`,
+    `grd-st-${size}`,
+    onStepClick ? "grd-st-clickable" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const iconSize = size === "sm" ? 12 : 14;
+
+  return (
+    <ol className={cls} aria-label="Progresso">
+      {steps.map((step, i) => {
+        const state = computeState(step, i, activeIndex);
+        const last = i === steps.length - 1;
+        const clickable = Boolean(onStepClick) && state !== "pending" && state !== "loading";
+
+        const marker = (
+          <span className="grd-st-marker" aria-hidden="true">
+            {state === "complete" ? (
+              IconCmp ? <IconCmp name="check" size={iconSize} /> : <span className="grd-st-tick">✓</span>
+            ) : state === "error" ? (
+              IconCmp ? <IconCmp name="x" size={iconSize} /> : <span className="grd-st-tick">✕</span>
+            ) : state === "loading" ? (
+              <span className="grd-st-spin" role="status" aria-label="carregando" />
+            ) : variant === "iconed" && step.icon && IconCmp ? (
+              <IconCmp name={step.icon} size={iconSize} />
+            ) : variant === "compact" ? (
+              <span className="grd-st-dot" />
+            ) : (
+              <span className="grd-st-num">{i + 1}</span>
+            )}
+          </span>
+        );
+
+        const bodyMain =
+          variant === "compact" ? null : (
+            <div className="grd-st-body">
+              <span className="grd-st-title">{step.title}</span>
+              {step.description && (
+                <span className="grd-st-desc">{step.description}</span>
+              )}
+            </div>
+          );
+
+        const header = (
+          <>
+            {marker}
+            {bodyMain}
+          </>
+        );
+
+        const showMeta =
+          orientation === "vertical" && step.meta && (state === "current" || state === "loading");
+
+        return (
+          <li
+            key={step.id}
+            className={`grd-st-item grd-st-s-${state} ${last ? "grd-st-last" : ""}`}
+            aria-current={state === "current" ? "step" : undefined}
+          >
+            {clickable ? (
+              <button
+                type="button"
+                className="grd-st-btn"
+                onClick={() => onStepClick?.(i, step)}
+              >
+                {header}
+              </button>
+            ) : (
+              <div className="grd-st-btn" role="presentation">
+                {header}
+              </div>
+            )}
+            {showMeta && <div className="grd-st-meta">{step.meta}</div>}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+Stepper.displayName = "Stepper";
+(window as any).Stepper = Stepper;

--- a/ux_references/ui_kits/components/Switch/Switch.playground.html
+++ b/ux_references/ui_kits/components/Switch/Switch.playground.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Switch · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORMS · TOGGLE</div>
+  <h1 class="pg-title">Switch</h1>
+  <span class="pg-codename">import Switch from "ui_kits/components/Switch"</span>
+  <p class="pg-desc">Alternador on/off para ações com efeito imediato — prefira sobre checkbox quando a mudança afeta estado do sistema (notificações, integrações, automações). Dois tamanhos, label e descrição opcionais.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, variant }: { title: string; children: React.ReactNode; variant?: string }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className={"pg-stage col "+(variant||"")}>{children}</div></div>);
+}
+function App() {
+  const [notifs, setNotifs] = React.useState(true);
+  const [daily, setDaily]   = React.useState(false);
+  return (<>
+    <Sec title="Tamanhos">
+      <Switch size="sm" label="Small — 30×18" defaultChecked />
+      <Switch size="md" label="Medium — 38×22 (default)" defaultChecked />
+    </Sec>
+    <Sec title="Com descrição">
+      <Switch label="Notificações por e-mail" description="Receba um resumo diário ao fim do expediente" defaultChecked />
+      <Switch label="Autopilot de conciliação" description="O agente concilia automaticamente matches com confiança &gt; 95%" />
+      <Switch label="Relatório semanal" description="Todo domingo 18h, PDF + link no Control Center" defaultChecked />
+    </Sec>
+    <Sec title="Estados">
+      <Switch label="Ativado" defaultChecked />
+      <Switch label="Desativado" />
+      <Switch label="Bloqueado (on)" defaultChecked disabled />
+      <Switch label="Bloqueado (off)" disabled />
+    </Sec>
+    <Sec title="Controlado">
+      <Switch label="Notificações" description={`estado: ${notifs ? "ligado" : "desligado"}`} checked={notifs} onChange={(e) => setNotifs(e.target.checked)} />
+      <Switch label="Resumo diário 18h" description={daily ? "ativo" : "inativo"} checked={daily} onChange={(e) => setDaily(e.target.checked)} />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+function ExampleApp() {
+  const code = `
+function Preferencias() {
+  const [auto, setAuto] = React.useState(true);
+
+  return (
+    <div style={{ width: 360 }}>
+      <Switch
+        label="Autopilot de conciliação"
+        description="Matches com confiança > 95% são aprovados sem revisão"
+        checked={auto}
+        onChange={(e) => setAuto(e.target.checked)}
+      />
+    </div>
+  );
+}
+
+render(<Preferencias />);
+`;
+  return <LiveCode code={code} />;
+}
+ReactDOM.createRoot(document.getElementById('example-root')!).render(<ExampleApp />);
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>size</code></td><td>string</td><td><code>"md"</code></td><td class="desc">sm · md</td></tr>
+  <tr><td><code>label</code></td><td>ReactNode</td><td>—</td><td class="desc">Texto principal ao lado do toggle</td></tr>
+  <tr><td><code>description</code></td><td>ReactNode</td><td>—</td><td class="desc">Texto de apoio abaixo do label</td></tr>
+  <tr><td><code>checked</code></td><td>boolean</td><td>—</td><td class="desc">Uso controlado</td></tr>
+  <tr><td><code>defaultChecked</code></td><td>boolean</td><td>—</td><td class="desc">Uso não-controlado</td></tr>
+  <tr><td><code>disabled</code></td><td>boolean</td><td><code>false</code></td><td class="desc">Bloqueia interação</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Liga/desliga aplicado imediatamente (auto-conciliação, notificações).</li>
+      <li>Label à esquerda; estado on = laranja.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Configurações que precisam "salvar" — use <code>Checkbox</code>.</li>
+      <li>Switch para ação temporária (filtros).</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Switch/index.css
+++ b/ux_references/ui_kits/components/Switch/index.css
@@ -1,0 +1,44 @@
+
+.grd-sw {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: var(--font-sans); cursor: pointer;
+  -webkit-user-select: none; user-select: none;
+}
+.grd-sw-disabled { opacity: 0.55; cursor: not-allowed; }
+
+.grd-sw-track {
+  position: relative;
+  background: var(--gray-300);
+  border-radius: var(--radius-pill);
+  transition: background 180ms var(--ease-standard);
+  flex-shrink: 0;
+}
+.grd-sw-sm .grd-sw-track { width: 30px; height: 18px; }
+.grd-sw-md .grd-sw-track { width: 38px; height: 22px; }
+
+.grd-sw input[type="checkbox"] { position: absolute; inset: 0; opacity: 0; cursor: inherit; margin: 0; }
+
+.grd-sw-thumb {
+  position: absolute; top: 2px; left: 2px;
+  background: var(--surface);
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15), 0 1px 3px rgba(0,0,0,0.1);
+  transition: transform 180ms var(--ease-standard);
+}
+.grd-sw-sm .grd-sw-thumb { width: 14px; height: 14px; }
+.grd-sw-md .grd-sw-thumb { width: 18px; height: 18px; }
+
+.grd-sw input:checked ~ .grd-sw-thumb { transform: translateX(calc(100% - 2px)); }
+.grd-sw-sm input:checked ~ .grd-sw-thumb { transform: translateX(12px); }
+.grd-sw-md input:checked ~ .grd-sw-thumb { transform: translateX(16px); }
+
+.grd-sw input:checked ~ .grd-sw-track,
+.grd-sw-track:has(input:checked) { background: var(--violet-500); }
+
+.grd-sw input:focus-visible ~ .grd-sw-thumb { box-shadow: var(--focus-ring), 0 1px 2px rgba(0,0,0,0.15); }
+
+.grd-sw-text { display: inline-flex; flex-direction: column; gap: 2px; }
+.grd-sw-label { font-size: 14px; font-weight: 500; color: var(--fg); line-height: 1.4; }
+.grd-sw-desc { font-size: 12.5px; color: var(--fg-muted); line-height: 1.45; }
+.grd-sw-sm .grd-sw-label { font-size: 13px; }
+.grd-sw-sm .grd-sw-desc { font-size: 12px; }

--- a/ux_references/ui_kits/components/Switch/index.tsx
+++ b/ux_references/ui_kits/components/Switch/index.tsx
@@ -1,0 +1,47 @@
+
+/**
+ * Switch — toggle on/off. Para mudanças imediatas (um checkbox seria passivo).
+ * Props: size, checked, disabled, label, description.
+ */
+
+interface SwitchProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size" | "type"> {
+  size?: "sm" | "md";
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+}
+
+function Switch({
+  size = "md",
+  label,
+  description,
+  className = "",
+  id,
+  disabled,
+  checked,
+  ...rest
+}: SwitchProps) {
+  const genId = React.useId();
+  const sId = id ?? genId;
+  const wrapCls = [
+    "grd-sw",
+    `grd-sw-${size}`,
+    disabled && "grd-sw-disabled",
+    className,
+  ].filter(Boolean).join(" ");
+  return (
+    <label className={wrapCls} htmlFor={sId}>
+      <span className="grd-sw-track">
+        <input id={sId} type="checkbox" role="switch" disabled={disabled} checked={checked} {...rest} />
+        <span className="grd-sw-thumb" />
+      </span>
+      {(label || description) && (
+        <span className="grd-sw-text">
+          {label && <span className="grd-sw-label">{label}</span>}
+          {description && <span className="grd-sw-desc">{description}</span>}
+        </span>
+      )}
+    </label>
+  );
+}
+Switch.displayName = "Switch";
+(window as any).Switch = Switch;

--- a/ux_references/ui_kits/components/Tabs/Tabs.playground.html
+++ b/ux_references/ui_kits/components/Tabs/Tabs.playground.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Tabs · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">NAVEGAÇÃO · TABS</div>
+  <h1 class="pg-title">Tabs</h1>
+  <span class="pg-codename">import Tabs from "ui_kits/components/Tabs"</span>
+  <p class="pg-desc">Alternância entre views dentro de uma mesma tela. Três variantes: <code>underline</code> (padrão, para tabs de página), <code>pills</code> (filtros leves) e <code>boxed</code> (seções compactas).</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",gap:14}}>{children}</div></div>);
+}
+
+const PAGINA = [
+  { value: "visao", label: "Visão geral", icon: "layout-dashboard" },
+  { value: "lanc", label: "Lançamentos", icon: "file-text", badge: 248 },
+  { value: "conc", label: "Conciliação", icon: "arrow-left-right", badge: 11 },
+  { value: "fisc", label: "Fiscal", icon: "receipt-text" },
+  { value: "rel", label: "Relatórios", icon: "line-chart" },
+];
+
+const PERIODO = [
+  { value: "hoje", label: "Hoje" },
+  { value: "7d", label: "7 dias" },
+  { value: "30d", label: "30 dias" },
+  { value: "ano", label: "Este ano" },
+];
+
+function App() {
+  const [page, setPage] = React.useState("lanc");
+  return (<>
+    <Sec title="Underline · tabs de página (com ícones e badges)">
+      <div style={{background:"#fff",border:"1px solid var(--border)",borderRadius:"var(--radius-md)",padding:"4px 16px 0"}}>
+        <Tabs items={PAGINA} value={page} onChange={setPage} />
+      </div>
+      <div style={{fontSize:13,color:"var(--gray-600)",paddingLeft:2}}>Tab ativa: <b style={{color:"var(--orange-500)"}}>{page}</b></div>
+    </Sec>
+
+    <Sec title="Pills · filtros leves">
+      <Tabs variant="pills" items={PERIODO} defaultValue="30d" />
+    </Sec>
+
+    <Sec title="Boxed · seções compactas">
+      <Tabs variant="boxed" items={[
+        { value: "json", label: "JSON" },
+        { value: "yaml", label: "YAML" },
+        { value: "curl", label: "cURL" },
+        { value: "node", label: "Node.js" },
+      ]} defaultValue="json" />
+    </Sec>
+
+    <Sec title="Tamanho sm">
+      <Tabs size="sm" items={PERIODO} defaultValue="hoje" />
+      <Tabs size="sm" variant="pills" items={PERIODO} defaultValue="hoje" />
+    </Sec>
+
+    <Sec title="Com item desabilitado">
+      <Tabs items={[
+        { value: "a", label: "Ativos" },
+        { value: "b", label: "Arquivados" },
+        { value: "c", label: "Em migração", disabled: true },
+      ]} defaultValue="a" />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Tabs"]) || "render(<div>Sem exemplo para Tabs</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>items</code></td><td>array</td><td>—</td><td class="desc">{`{ value, label, icon?, badge?, disabled? }[]`}</td></tr>
+  <tr><td><code>value</code> · <code>defaultValue</code></td><td>string</td><td>—</td><td class="desc">Tab ativa controlada/inicial</td></tr>
+  <tr><td><code>onChange</code></td><td>(v) ⇒ void</td><td>—</td><td class="desc">Callback da troca</td></tr>
+  <tr><td><code>variant</code></td><td>string</td><td>"underline"</td><td class="desc">underline · pills · boxed</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Visões paralelas do mesmo recurso (Resumo / Lançamentos / Auditoria de um cliente).</li>
+      <li>2-5 tabs; primeira como padrão.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Navegação principal — use <code>SidebarNav</code>.</li>
+      <li>Tabs com badge de contagem fora da paleta.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Tabs/index.css
+++ b/ux_references/ui_kits/components/Tabs/index.css
@@ -1,0 +1,60 @@
+
+.grd-tabs {
+  display: inline-flex; align-items: center;
+  font-family: var(--font-sans);
+}
+.grd-tabs-tab {
+  display: inline-flex; align-items: center; gap: 6px;
+  border: 0; background: transparent; cursor: pointer;
+  font-family: inherit; font-weight: 500; color: var(--fg-muted);
+  transition: color 140ms, background 140ms, border-color 140ms;
+  white-space: nowrap;
+}
+.grd-tabs-tab-dis { opacity: 0.5; cursor: not-allowed; }
+.grd-tabs-tab:focus-visible { outline: none; box-shadow: var(--focus-ring); border-radius: var(--radius-sm); }
+.grd-tabs-badge {
+  background: var(--gray-200); color: var(--fg-muted);
+  font-size: 10.5px; font-weight: 700;
+  padding: 1px 6px; border-radius: var(--radius-pill);
+  min-width: 18px; text-align: center;
+}
+.grd-tabs-tab-active .grd-tabs-badge { background: var(--violet-100); color: var(--violet-700); }
+
+/* Underline */
+.grd-tabs-underline { gap: 4px; border-bottom: 1px solid var(--border); }
+.grd-tabs-underline .grd-tabs-tab {
+  padding: 10px 14px;
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+  font-size: 14px;
+}
+.grd-tabs-underline.grd-tabs-sm .grd-tabs-tab { padding: 8px 12px; font-size: 13px; }
+.grd-tabs-underline .grd-tabs-tab:hover:not(.grd-tabs-tab-dis) { color: var(--fg); }
+.grd-tabs-underline .grd-tabs-tab-active {
+  color: var(--violet-700); border-bottom-color: var(--violet-500);
+}
+
+/* Pills */
+.grd-tabs-pills {
+  gap: 4px; background: var(--gray-100); padding: 4px; border-radius: var(--radius-pill);
+}
+.grd-tabs-pills .grd-tabs-tab {
+  padding: 6px 14px; border-radius: var(--radius-pill); font-size: 13.5px;
+}
+.grd-tabs-pills.grd-tabs-sm .grd-tabs-tab { padding: 5px 12px; font-size: 12.5px; }
+.grd-tabs-pills .grd-tabs-tab:hover:not(.grd-tabs-tab-dis) { color: var(--fg); }
+.grd-tabs-pills .grd-tabs-tab-active {
+  background: var(--surface); color: var(--violet-700);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Boxed */
+.grd-tabs-boxed { gap: 2px; }
+.grd-tabs-boxed .grd-tabs-tab {
+  padding: 8px 14px; font-size: 13.5px;
+  border: 1px solid var(--border); background: var(--surface);
+  border-radius: var(--radius-md);
+}
+.grd-tabs-boxed.grd-tabs-sm .grd-tabs-tab { padding: 6px 12px; font-size: 12.5px; }
+.grd-tabs-boxed .grd-tabs-tab:hover:not(.grd-tabs-tab-dis) { background: var(--violet-50); border-color: var(--violet-300); }
+.grd-tabs-boxed .grd-tabs-tab-active { background: var(--violet-500); color: #fff; border-color: var(--violet-500); }
+.grd-tabs-boxed .grd-tabs-tab-active .grd-tabs-badge { background: rgba(255,255,255,0.24); color: #fff; }

--- a/ux_references/ui_kits/components/Tabs/index.tsx
+++ b/ux_references/ui_kits/components/Tabs/index.tsx
@@ -1,0 +1,61 @@
+
+/**
+ * Tabs — navegação horizontal entre views. Composto: Tabs + Tabs.Item.
+ * Props: value, defaultValue, onChange, variant (underline|pills|boxed), size.
+ */
+
+interface TabItemProps {
+  value: string;
+  label: React.ReactNode;
+  icon?: string;
+  badge?: React.ReactNode;
+  disabled?: boolean;
+}
+interface TabsProps {
+  value?: string;
+  defaultValue?: string;
+  onChange?: (v: string) => void;
+  variant?: "underline" | "pills" | "boxed";
+  size?: "sm" | "md";
+  items: TabItemProps[];
+  className?: string;
+}
+
+function Tabs({ value, defaultValue, onChange, variant = "underline", size = "md", items, className = "" }: TabsProps) {
+  const [internal, setInternal] = React.useState(defaultValue ?? items[0]?.value);
+  const current = value !== undefined ? value : internal;
+  const IconCmp = (window as any).Icon;
+  const cls = ["grd-tabs", `grd-tabs-${variant}`, `grd-tabs-${size}`, className].filter(Boolean).join(" ");
+  return (
+    <div className={cls} role="tablist">
+      {items.map(it => {
+        const active = it.value === current;
+        const iCls = [
+          "grd-tabs-tab",
+          active && "grd-tabs-tab-active",
+          it.disabled && "grd-tabs-tab-dis",
+        ].filter(Boolean).join(" ");
+        return (
+          <button
+            key={it.value}
+            role="tab"
+            aria-selected={active}
+            disabled={it.disabled}
+            className={iCls}
+            onClick={() => {
+              if (it.disabled) return;
+              if (value === undefined) setInternal(it.value);
+              onChange?.(it.value);
+            }}
+          >
+            {it.icon && IconCmp && <IconCmp name={it.icon} size={size === "sm" ? 13 : 15} />}
+            <span>{it.label}</span>
+            {it.badge && <span className="grd-tabs-badge">{it.badge}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+Tabs.displayName = "Tabs";
+(window as any).Tabs = Tabs;

--- a/ux_references/ui_kits/components/Textarea/Textarea.playground.html
+++ b/ux_references/ui_kits/components/Textarea/Textarea.playground.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Textarea · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FORM · ENTRADA MULTI-LINHA</div>
+  <h1 class="pg-title">Textarea</h1>
+  <span class="pg-codename">import Textarea from "ui_kits/components/Textarea"</span>
+  <p class="pg-desc">Campo multi-linha. Suporta <code>size</code> (sm/md/lg), estados (default/error/success), controle de resize e contador de caracteres via <code>showCount</code> + <code>maxLength</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children, w=420 }: { title: string; children: React.ReactNode; w?: number }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage col" style={{alignItems:"stretch",maxWidth:w}}>{children}</div></div>);
+}
+function App() {
+  const [bio, setBio] = React.useState("Contador técnico com foco em conciliação bancária automatizada.");
+  const [obs, setObs] = React.useState("");
+  return (<>
+    <Sec title="Tamanhos">
+      <Textarea size="sm" defaultValue="Textarea pequena (sm)" rows={3} />
+      <Textarea size="md" defaultValue="Textarea média (md) — padrão" rows={3} />
+      <Textarea size="lg" defaultValue="Textarea grande (lg)" rows={3} />
+    </Sec>
+
+    <Sec title="Estados">
+      <Textarea placeholder="Digite uma observação…" rows={3} />
+      <Textarea state="error" defaultValue="CNPJ inválido informado no contexto" rows={3} />
+      <Textarea state="success" defaultValue="Revisado e aprovado pelo contador" rows={3} />
+      <Textarea disabled defaultValue="Campo travado durante exportação" rows={3} />
+    </Sec>
+
+    <Sec title="Controlada · com contador">
+      <Textarea
+        value={bio}
+        onChange={e => setBio(e.target.value)}
+        placeholder="Bio do profissional…"
+        showCount
+        maxLength={240}
+        rows={4}
+      />
+    </Sec>
+
+    <Sec title="Observação interna · sem resize" w={520}>
+      <Textarea
+        value={obs}
+        onChange={e => setObs(e.target.value)}
+        placeholder="Anote contexto para o time de apoio (visível só internamente)…"
+        resize="none"
+        rows={5}
+        showCount
+        maxLength={500}
+      />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Textarea"]) || "render(<div>Sem exemplo para Textarea</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md · lg</td></tr>
+  <tr><td><code>state</code></td><td>string</td><td>"default"</td><td class="desc">default · error · success</td></tr>
+  <tr><td><code>invalid</code></td><td>boolean</td><td>false</td><td class="desc">Força estado error</td></tr>
+  <tr><td><code>resize</code></td><td>string</td><td>"vertical"</td><td class="desc">none · vertical · both</td></tr>
+  <tr><td><code>showCount</code></td><td>boolean</td><td>false</td><td class="desc">Exibe contador (use com <code>maxLength</code>)</td></tr>
+  <tr><td><code>maxLength</code></td><td>number</td><td>—</td><td class="desc">Limite nativo</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Texto multilinha: observações em lançamento, notas de conciliação.</li>
+      <li>Indicador de caracteres se houver limite.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Textarea para campos curtos — use <code>Input</code>.</li>
+      <li>Sem indicação de altura mínima.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Textarea/index.css
+++ b/ux_references/ui_kits/components/Textarea/index.css
@@ -1,0 +1,27 @@
+
+.grd-textarea-wrap { position: relative; width: 100%; }
+.grd-textarea {
+  font-family: var(--font-sans);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  color: var(--fg);
+  width: 100%;
+  line-height: 1.55;
+  transition: border-color 140ms, box-shadow 140ms;
+  outline: none;
+}
+.grd-textarea::placeholder { color: var(--gray-400); }
+.grd-textarea-sm { padding: 8px 11px; font-size: 13px; min-height: 60px; }
+.grd-textarea-md { padding: 10px 13px; font-size: 14px; min-height: 84px; }
+.grd-textarea-lg { padding: 12px 15px; font-size: 15px; min-height: 112px; }
+.grd-textarea-default:focus { border-color: var(--violet-500); box-shadow: var(--focus-ring); }
+.grd-textarea-error { border-color: var(--signal-red); }
+.grd-textarea-error:focus { box-shadow: var(--focus-ring-error); }
+.grd-textarea-success { border-color: var(--signal-green); }
+.grd-textarea-count {
+  position: absolute; right: 10px; bottom: 8px;
+  font-size: 11px; color: var(--gray-500);
+  background: var(--surface); padding: 1px 4px; border-radius: var(--radius-sm);
+  pointer-events: none;
+}

--- a/ux_references/ui_kits/components/Textarea/index.tsx
+++ b/ux_references/ui_kits/components/Textarea/index.tsx
@@ -1,0 +1,52 @@
+
+/**
+ * Textarea — campo de texto multi-linha.
+ * Props: size, state, invalid, rows, resize, maxLength (com contador).
+ */
+
+interface TextareaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "size"> {
+  size?: "sm" | "md" | "lg";
+  state?: "default" | "error" | "success";
+  invalid?: boolean;
+  showCount?: boolean;
+  resize?: "none" | "vertical" | "both";
+}
+
+function Textarea({
+  size = "md",
+  state = "default",
+  invalid,
+  showCount = false,
+  resize = "vertical",
+  className = "",
+  value,
+  maxLength,
+  ...rest
+}: TextareaProps) {
+  const effectiveState = invalid ? "error" : state;
+  const cls = [
+    "grd-textarea",
+    `grd-textarea-${size}`,
+    `grd-textarea-${effectiveState}`,
+    className,
+  ].filter(Boolean).join(" ");
+  const currentLen = typeof value === "string" ? value.length : 0;
+  return (
+    <div className="grd-textarea-wrap">
+      <textarea
+        className={cls}
+        style={{ resize }}
+        value={value}
+        maxLength={maxLength}
+        {...rest}
+      />
+      {showCount && (
+        <span className="grd-textarea-count">
+          {currentLen}{maxLength ? ` / ${maxLength}` : ""}
+        </span>
+      )}
+    </div>
+  );
+}
+Textarea.displayName = "Textarea";
+(window as any).Textarea = Textarea;

--- a/ux_references/ui_kits/components/Timeline/Timeline.playground.html
+++ b/ux_references/ui_kits/components/Timeline/Timeline.playground.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Timeline · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Badge/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">DATA · HISTÓRICO</div>
+  <h1 class="pg-title">Timeline</h1>
+  <span class="pg-codename">import Timeline from "ui_kits/components/Timeline"</span>
+  <p class="pg-desc">Linha do tempo vertical. Marcador com ícone, título, descrição, timestamp, meta e tom por item.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,gap:40,alignItems:"flex-start",flexWrap:"wrap"}}>{children}</div></div>);
+}
+function Frame({ children, w=460 }: { children: React.ReactNode; w?: number }) {
+  return (<div style={{width:w,background:"var(--papel)",border:"1px solid var(--gray-200)",borderRadius:"var(--radius-lg)",padding:"18px 22px"}}>{children}</div>);
+}
+
+const AUDITORIA = [
+  { id: "1", tone: "violet" as const, icon: "upload-cloud", title: "Extrato Itaú importado", description: "237 lançamentos via OFX", timestamp: "hoje · 09:12" },
+  { id: "2", tone: "green"  as const, icon: "check",        title: "248 lançamentos aprovados automaticamente", description: "Confiança média 97,3% — regras fiscais aplicadas", timestamp: "09:14", meta: <Badge tone="green" variant="soft">Automático</Badge> },
+  { id: "3", tone: "amber"  as const, icon: "flag",         title: "11 lançamentos marcados para revisão", description: "Confiança abaixo do limiar de 95%", timestamp: "09:15", meta: <Badge tone="amber" variant="soft">Pendente</Badge> },
+  { id: "4", tone: "violet" as const, icon: "user",         title: "Luana aprovou 9 lançamentos", description: "2 reclassificados · NF 4891 corrigida", timestamp: "10:42", meta: <Badge tone="neutral" variant="soft">Humano</Badge> },
+  { id: "5", tone: "green"  as const, icon: "circle-check", title: "Conciliação Itaú concluída", description: "Balanço fechado · diferença R$ 0,00", timestamp: "10:44" },
+];
+
+const ERROS = [
+  { id: "1", tone: "neutral" as const, icon: "clock",         title: "Fechamento de setembro iniciado", timestamp: "01/10 · 08:00" },
+  { id: "2", tone: "red"     as const, icon: "triangle-alert", title: "Falha ao sincronizar com o Domínio", description: "Credencial expirada", timestamp: "01/10 · 08:03" },
+  { id: "3", tone: "amber"   as const, icon: "refresh-cw",    title: "Reprocessamento em fila", description: "3 tentativas restantes", timestamp: "01/10 · 08:12" },
+  { id: "4", tone: "green"   as const, icon: "check",         title: "Sincronização restabelecida", timestamp: "01/10 · 09:28" },
+];
+
+function App() {
+  return (<>
+    <Sec title="Auditoria de um fechamento (padrão)">
+      <Frame>
+        <Timeline items={AUDITORIA} />
+      </Frame>
+    </Sec>
+    <Sec title="Tons múltiplos + conector tracejado + sm">
+      <Frame w={420}>
+        <Timeline items={ERROS} size="sm" connector="dashed" />
+      </Frame>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Timeline"]) || "render(<div>Sem exemplo para Timeline</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>items</code></td><td>TimelineItem[]</td><td>—</td><td class="desc">Eventos em ordem cronológica</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md</td></tr>
+  <tr><td><code>connector</code></td><td>string</td><td>"solid"</td><td class="desc">solid · dashed</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">TimelineItem</th></tr>
+  <tr><td><code>id</code></td><td>string</td><td>—</td><td class="desc">Chave única</td></tr>
+  <tr><td><code>title</code> · <code>description</code></td><td>node</td><td>—</td><td class="desc">Conteúdo</td></tr>
+  <tr><td><code>timestamp</code></td><td>node</td><td>—</td><td class="desc">Horário à direita</td></tr>
+  <tr><td><code>icon</code></td><td>string</td><td>—</td><td class="desc">Ícone no marcador</td></tr>
+  <tr><td><code>tone</code></td><td>string</td><td>"violet"</td><td class="desc">violet · green · amber · red · neutral</td></tr>
+  <tr><td><code>meta</code></td><td>node</td><td>—</td><td class="desc">Badges/ações extras</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Histórico temporal com atores: quem fez o quê, quando (lançamento, agente, usuário).</li>
+      <li>Ícone por tipo de evento; timestamp relativo + absoluto no hover.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Timeline para listagem não-cronológica.</li>
+      <li>Itens sem ator identificado.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Timeline/index.css
+++ b/ux_references/ui_kits/components/Timeline/index.css
@@ -1,0 +1,40 @@
+
+.grd-tl { list-style: none; padding: 0; margin: 0; font-family: var(--font-sans); }
+.grd-tl-item { position: relative; display: grid; grid-template-columns: auto 1fr; gap: 12px; padding-bottom: 18px; }
+.grd-tl-sm .grd-tl-item { padding-bottom: 12px; gap: 10px; }
+
+.grd-tl-marker {
+  position: relative; z-index: 1;
+  width: 22px; height: 22px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  background: var(--surface); border: 2px solid var(--violet-500);
+  color: var(--violet-600);
+}
+.grd-tl-sm .grd-tl-marker { width: 16px; height: 16px; border-width: 1.5px; }
+.grd-tl-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+/* connectors */
+.grd-tl-item:not(.grd-tl-last)::before {
+  content: ""; position: absolute;
+  top: 22px; bottom: 0; left: 10px;
+  width: 2px; background: var(--border);
+}
+.grd-tl-sm .grd-tl-item:not(.grd-tl-last)::before { top: 16px; left: 7px; width: 1.5px; }
+.grd-tl-c-dashed .grd-tl-item:not(.grd-tl-last)::before { background: transparent; border-left: 1.5px dashed var(--border); width: 0; }
+
+/* tones */
+.grd-tl-t-violet .grd-tl-marker  { border-color: var(--violet-500); color: var(--violet-600); }
+.grd-tl-t-green .grd-tl-marker   { border-color: var(--signal-green); color: var(--signal-green); background: var(--success-soft); }
+.grd-tl-t-amber .grd-tl-marker   { border-color: var(--signal-yellow); color: var(--yellow-900); background: var(--yellow-100); }
+.grd-tl-t-red .grd-tl-marker     { border-color: var(--signal-red); color: var(--signal-red); background: var(--danger-soft); }
+.grd-tl-t-neutral .grd-tl-marker { border-color: var(--gray-400); color: var(--fg-muted); }
+
+.grd-tl-body { min-width: 0; }
+.grd-tl-row { display: flex; align-items: baseline; gap: 12px; justify-content: space-between; }
+.grd-tl-title { font-size: 14px; font-weight: 600; color: var(--fg); }
+.grd-tl-sm .grd-tl-title { font-size: 13px; }
+.grd-tl-ts { font-size: 11.5px; color: var(--fg-muted); flex-shrink: 0; font-feature-settings: "tnum"; font-variant-numeric: tabular-nums; }
+.grd-tl-desc { font-size: 13px; color: var(--fg-muted); margin-top: 2px; line-height: 1.5; }
+.grd-tl-sm .grd-tl-desc { font-size: 12.5px; }
+.grd-tl-meta { margin-top: 8px; }

--- a/ux_references/ui_kits/components/Timeline/index.tsx
+++ b/ux_references/ui_kits/components/Timeline/index.tsx
@@ -1,0 +1,52 @@
+
+/**
+ * Timeline — linha do tempo vertical com eventos.
+ * items: { id, title, description?, timestamp?, icon?, tone?, meta?: React.ReactNode, connector?: 'solid'|'dashed' }[]
+ * Tones: violet (default), green, amber, red, neutral.
+ */
+
+interface TimelineItem {
+  id: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  timestamp?: React.ReactNode;
+  icon?: string;
+  tone?: "violet" | "green" | "amber" | "red" | "neutral";
+  meta?: React.ReactNode;
+}
+interface TimelineProps {
+  items: TimelineItem[];
+  size?: "sm" | "md";
+  connector?: "solid" | "dashed";
+  className?: string;
+}
+
+function Timeline({ items, size = "md", connector = "solid", className = "" }: TimelineProps) {
+  const IconCmp = (window as any).Icon;
+  const cls = ["grd-tl", `grd-tl-${size}`, `grd-tl-c-${connector}`, className].filter(Boolean).join(" ");
+  return (
+    <ol className={cls}>
+      {items.map((it, i) => {
+        const tone = it.tone ?? "violet";
+        const last = i === items.length - 1;
+        return (
+          <li key={it.id} className={`grd-tl-item grd-tl-t-${tone} ${last ? "grd-tl-last" : ""}`}>
+            <span className="grd-tl-marker">
+              {it.icon && IconCmp ? <IconCmp name={it.icon} size={size === "sm" ? 11 : 13} /> : <span className="grd-tl-dot" />}
+            </span>
+            <div className="grd-tl-body">
+              <div className="grd-tl-row">
+                <span className="grd-tl-title">{it.title}</span>
+                {it.timestamp && <span className="grd-tl-ts">{it.timestamp}</span>}
+              </div>
+              {it.description && <div className="grd-tl-desc">{it.description}</div>}
+              {it.meta && <div className="grd-tl-meta">{it.meta}</div>}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+Timeline.displayName = "Timeline";
+(window as any).Timeline = Timeline;

--- a/ux_references/ui_kits/components/Toast/Toast.playground.html
+++ b/ux_references/ui_kits/components/Toast/Toast.playground.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Toast · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">FEEDBACK · NOTIFICAÇÃO</div>
+  <h1 class="pg-title">Toast</h1>
+  <span class="pg-codename">import { ToastProvider, useToast } from "ui_kits/components/Toast"</span>
+  <p class="pg-desc">Notificações transitórias, empilhadas no canto. Uso: envolva o app em <code>&lt;ToastProvider&gt;</code> e chame <code>toast.show()</code> via hook.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{gap:10,padding:28,flexWrap:"wrap"}}>{children}</div></div>);
+}
+function Demo() {
+  const toast = (useToast as any)();
+  const n = React.useRef(0);
+  return (<>
+    <Sec title="Tipos">
+      <button className="grd-btn grd-btn-secondary" onClick={() => toast.show({ type:"info",    title:"Processando 248 lançamentos…" })}>Info</button>
+      <button className="grd-btn grd-btn-secondary" onClick={() => toast.show({ type:"success", title:"Conciliação concluída", description:"237 aprovados · 11 pendentes" })}>Success</button>
+      <button className="grd-btn grd-btn-secondary" onClick={() => toast.show({ type:"warning", title:"Revisão humana necessária", description:"3 itens abaixo do limiar de confiança" })}>Warning</button>
+      <button className="grd-btn grd-btn-secondary" onClick={() => toast.show({ type:"danger",  title:"Falha ao sincronizar com o Itaú", description:"Reconecte sua conta para continuar" })}>Danger</button>
+    </Sec>
+    <Sec title="Com ação">
+      <button className="grd-btn grd-btn-secondary" onClick={() =>
+        toast.show({
+          type:"success", title:"Lançamento aprovado",
+          description:"NF 4891 movida para a contabilidade",
+          action: { label: "Desfazer", onClick: () => toast.show({ type:"info", title:"Ação desfeita" }) }
+        })
+      }>Success + undo</button>
+    </Sec>
+    <Sec title="Persistente (duration=0)">
+      <button className="grd-btn grd-btn-secondary" onClick={() =>
+        toast.show({ type:"warning", title:"Certificado vence em 7 dias", description:"Clique para renovar", duration: 0 })
+      }>Não dispensa automaticamente</button>
+    </Sec>
+    <Sec title="Disparar vários">
+      <button className="grd-btn grd-btn-primary" onClick={() => {
+        ["info","success","warning","danger"].forEach((t,i)=>
+          setTimeout(()=>toast.show({ type: t as any, title: `Toast #${++n.current}`, description: `Tipo ${t}` }), i*150)
+        );
+      }}>Disparar 4 em sequência</button>
+    </Sec>
+  </>);
+}
+function App() {
+  return <ToastProvider position="bottom-right"><Demo /></ToastProvider>;
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Toast"]) || "render(<div>Sem exemplo para Toast</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">toast.show(options)</th></tr>
+  <tr><th>Opção</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>type</code></td><td>string</td><td>"info"</td><td class="desc">info · success · warning · danger</td></tr>
+  <tr><td><code>title</code></td><td>node</td><td>—</td><td class="desc">Linha principal</td></tr>
+  <tr><td><code>description</code></td><td>node</td><td>—</td><td class="desc">Apoio</td></tr>
+  <tr><td><code>duration</code></td><td>number</td><td>4200</td><td class="desc">ms; <code>0</code> = persistente</td></tr>
+  <tr><td><code>action</code></td><td>{`{ label, onClick }`}</td><td>—</td><td class="desc">Botão à direita; fecha ao clicar</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">ToastProvider</th></tr>
+  <tr><td><code>position</code></td><td>string</td><td>"bottom-right"</td><td class="desc">top-right · bottom-right · top-left · bottom-left</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Confirmação transitória não-bloqueante ("lançamento salvo", "XML importado").</li>
+      <li>Auto-dismiss em 4-6s; ação "Desfazer" quando aplicável.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Erros que exigem atenção — use <code>Alert</code>.</li>
+      <li>Empilhar > 3 toasts simultâneos.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Toast/index.css
+++ b/ux_references/ui_kits/components/Toast/index.css
@@ -1,0 +1,51 @@
+
+.grd-tst-region {
+  position: fixed; z-index: 1100;
+  display: flex; flex-direction: column; gap: 10px;
+  pointer-events: none;
+  max-width: 420px; width: 100%;
+  padding: 20px;
+}
+.grd-tst-bottom-right { bottom: 0; right: 0; align-items: flex-end; }
+.grd-tst-bottom-left  { bottom: 0; left: 0;  align-items: flex-start; }
+.grd-tst-top-right    { top: 0;    right: 0; align-items: flex-end; }
+.grd-tst-top-left     { top: 0;    left: 0;  align-items: flex-start; }
+
+.grd-tst {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 14px; min-width: 300px; max-width: 400px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  font-family: var(--font-sans);
+  pointer-events: auto;
+  animation: grd-tst-in 200ms var(--ease-out);
+}
+@keyframes grd-tst-in { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+
+.grd-tst-type-info    .grd-tst-ic { color: var(--signal-blue); }
+.grd-tst-type-success .grd-tst-ic { color: var(--signal-green); }
+.grd-tst-type-warning .grd-tst-ic { color: var(--signal-yellow); }
+.grd-tst-type-danger  .grd-tst-ic { color: var(--signal-red); }
+
+.grd-tst-ic { flex-shrink: 0; padding-top: 1px; }
+.grd-tst-body { flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.grd-tst-title { font-size: 14px; font-weight: 600; color: var(--fg); line-height: 1.4; }
+.grd-tst-desc { font-size: 13px; color: var(--fg-muted); line-height: 1.5; }
+
+.grd-tst-action {
+  border: 0; background: transparent;
+  font-family: inherit; font-size: 12.5px; font-weight: 600;
+  color: var(--violet-600); cursor: pointer;
+  padding: 4px 8px; border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+.grd-tst-action:hover { background: var(--violet-50); }
+.grd-tst-close {
+  border: 0; background: transparent; cursor: pointer;
+  color: var(--fg-muted); opacity: 0.6;
+  width: 22px; height: 22px; border-radius: var(--radius-sm);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.grd-tst-close:hover { opacity: 1; background: var(--gray-100); }

--- a/ux_references/ui_kits/components/Toast/index.tsx
+++ b/ux_references/ui_kits/components/Toast/index.tsx
@@ -1,0 +1,83 @@
+
+/**
+ * Toast — notificações transitórias. Empilhadas em um canto.
+ * Uso:
+ *   <ToastProvider>...app...</ToastProvider>
+ *   const toast = useToast();
+ *   toast.show({ type: "success", title: "Salvo" });
+ * Tipos: info, success, warning, danger.
+ */
+
+interface ToastOptions {
+  id?: string;
+  type?: "info" | "success" | "warning" | "danger";
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  duration?: number; // ms; 0 = persistente
+  action?: { label: string; onClick: () => void };
+}
+
+interface ToastInternal extends ToastOptions {
+  id: string;
+  type: "info" | "success" | "warning" | "danger";
+}
+
+const ToastCtx = React.createContext<{ show: (o: ToastOptions) => string; dismiss: (id: string) => void } | null>(null);
+
+function ToastProvider({ children, position = "bottom-right" }: { children: React.ReactNode; position?: "top-right" | "bottom-right" | "top-left" | "bottom-left" }) {
+  const [items, setItems] = React.useState<ToastInternal[]>([]);
+
+  const dismiss = React.useCallback((id: string) => {
+    setItems(xs => xs.filter(x => x.id !== id));
+  }, []);
+
+  const show = React.useCallback((o: ToastOptions) => {
+    const id = o.id ?? Math.random().toString(36).slice(2);
+    const duration = o.duration === undefined ? 4200 : o.duration;
+    setItems(xs => [...xs, { ...o, id, type: o.type ?? "info" }]);
+    if (duration > 0) setTimeout(() => dismiss(id), duration);
+    return id;
+  }, [dismiss]);
+
+  const value = React.useMemo(() => ({ show, dismiss }), [show, dismiss]);
+
+  const IconCmp = (window as any).Icon;
+  const ALERT_IC: Record<string, string> = { info: "info", success: "circle-check", warning: "triangle-alert", danger: "circle-x" };
+
+  return (
+    <ToastCtx.Provider value={value}>
+      {children}
+      {ReactDOM.createPortal(
+        <div className={`grd-tst-region grd-tst-${position}`}>
+          {items.map(t => (
+            <div key={t.id} className={`grd-tst grd-tst-type-${t.type}`} role="status">
+              {IconCmp && <span className="grd-tst-ic"><IconCmp name={ALERT_IC[t.type]} size={18} /></span>}
+              <div className="grd-tst-body">
+                <div className="grd-tst-title">{t.title}</div>
+                {t.description && <div className="grd-tst-desc">{t.description}</div>}
+              </div>
+              {t.action && (
+                <button className="grd-tst-action" onClick={() => { t.action!.onClick(); dismiss(t.id); }}>
+                  {t.action.label}
+                </button>
+              )}
+              <button className="grd-tst-close" onClick={() => dismiss(t.id)} aria-label="Fechar">
+                {IconCmp && <IconCmp name="x" size={14} />}
+              </button>
+            </div>
+          ))}
+        </div>,
+        document.body
+      )}
+    </ToastCtx.Provider>
+  );
+}
+
+function useToast() {
+  const ctx = React.useContext(ToastCtx);
+  if (!ctx) throw new Error("useToast must be used within <ToastProvider>");
+  return ctx;
+}
+
+(window as any).ToastProvider = ToastProvider;
+(window as any).useToast = useToast;

--- a/ux_references/ui_kits/components/Tooltip/Tooltip.playground.html
+++ b/ux_references/ui_kits/components/Tooltip/Tooltip.playground.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Tooltip · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../IconButton/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">OVERLAY · DICA</div>
+  <h1 class="pg-title">Tooltip</h1>
+  <span class="pg-codename">import Tooltip from "ui_kits/components/Tooltip"</span>
+  <p class="pg-desc">Dica curta no hover/focus do elemento filho. Sempre texto conciso — para conteúdo rico, use <code>Popover</code>.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../IconButton/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{gap:18,padding:40,flexWrap:"wrap"}}>{children}</div></div>);
+}
+function App() {
+  return (<>
+    <Sec title="Lados">
+      <Tooltip content="Abrir acima" side="top"><button className="grd-btn grd-btn-secondary">Top</button></Tooltip>
+      <Tooltip content="À direita"    side="right"><button className="grd-btn grd-btn-secondary">Right</button></Tooltip>
+      <Tooltip content="Abaixo"       side="bottom"><button className="grd-btn grd-btn-secondary">Bottom</button></Tooltip>
+      <Tooltip content="À esquerda"   side="left"><button className="grd-btn grd-btn-secondary">Left</button></Tooltip>
+    </Sec>
+    <Sec title="Em icon-buttons (uso comum)">
+      <Tooltip content="Aprovar lançamento"><IconButton icon="check" variant="ghost" /></Tooltip>
+      <Tooltip content="Rejeitar"><IconButton icon="x" variant="ghost" /></Tooltip>
+      <Tooltip content="Abrir detalhes"><IconButton icon="external-link" variant="ghost" /></Tooltip>
+      <Tooltip content="Mais opções"><IconButton icon="more-horizontal" variant="ghost" /></Tooltip>
+    </Sec>
+    <Sec title="Tamanhos">
+      <Tooltip size="sm" content="sm — 11.5px"><button className="grd-btn grd-btn-secondary">sm</button></Tooltip>
+      <Tooltip size="md" content="md — 12.5px (padrão)"><button className="grd-btn grd-btn-secondary">md</button></Tooltip>
+    </Sec>
+    <Sec title="Conteúdo rico (mini)">
+      <Tooltip content={<><b>⌘K</b> · Buscar tudo</>}><button className="grd-btn grd-btn-ghost">Hover</button></Tooltip>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Tooltip"]) || "render(<div>Sem exemplo para Tooltip</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>content</code></td><td>node</td><td>—</td><td class="desc">Texto/conteúdo da dica</td></tr>
+  <tr><td><code>side</code></td><td>string</td><td>"top"</td><td class="desc">top · right · bottom · left</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md</td></tr>
+  <tr><td><code>delay</code></td><td>number</td><td>200</td><td class="desc">ms antes de abrir</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Explicação curta sob hover/focus em <code>IconButton</code>, campos abreviados, siglas fiscais.</li>
+      <li>Delay 300ms; posicionamento automático.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Conteúdo crítico em tooltip (não acessível em mobile).</li>
+      <li>Tooltips longos — use <code>Popover</code>.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Tooltip/index.css
+++ b/ux_references/ui_kits/components/Tooltip/index.css
@@ -1,0 +1,26 @@
+
+.grd-tt {
+  position: fixed; z-index: 9999;
+  background: var(--violet-900); color: #fff;
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  pointer-events: none;
+  box-shadow: var(--shadow-md);
+  animation: grd-tt-in 140ms var(--ease-out);
+  max-width: 220px;
+}
+.grd-tt-sm { padding: 4px 8px; font-size: 11.5px; line-height: 1.4; }
+.grd-tt-md { padding: 6px 10px; font-size: 12.5px; line-height: 1.45; }
+
+.grd-tt-top    { transform: translate(-50%, -100%); }
+.grd-tt-bottom { transform: translate(-50%, 0); }
+.grd-tt-left   { transform: translate(-100%, -50%); }
+.grd-tt-right  { transform: translate(0, -50%); }
+
+.grd-tt-arrow { position: absolute; width: 6px; height: 6px; background: inherit; transform: rotate(45deg); }
+.grd-tt-top .grd-tt-arrow    { bottom: -3px; left: 50%; margin-left: -3px; }
+.grd-tt-bottom .grd-tt-arrow { top: -3px;    left: 50%; margin-left: -3px; }
+.grd-tt-left .grd-tt-arrow   { right: -3px;  top: 50%;  margin-top: -3px; }
+.grd-tt-right .grd-tt-arrow  { left: -3px;   top: 50%;  margin-top: -3px; }
+
+@keyframes grd-tt-in { from { opacity: 0; } to { opacity: 1; } }

--- a/ux_references/ui_kits/components/Tooltip/index.tsx
+++ b/ux_references/ui_kits/components/Tooltip/index.tsx
@@ -1,0 +1,65 @@
+
+/**
+ * Tooltip — dica contextual curta em hover/focus.
+ * Props: content (string | node), side (top|right|bottom|left), size.
+ */
+
+interface TooltipProps {
+  content: React.ReactNode;
+  side?: "top" | "right" | "bottom" | "left";
+  size?: "sm" | "md";
+  children: React.ReactElement;
+  delay?: number;
+}
+
+function Tooltip({ content, side = "top", size = "md", children, delay = 200 }: TooltipProps) {
+  const [open, setOpen] = React.useState(false);
+  const [coords, setCoords] = React.useState<{top: number; left: number} | null>(null);
+  const triggerRef = React.useRef<HTMLElement>(null);
+  const timerRef = React.useRef<number | null>(null);
+
+  function show() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => {
+      if (!triggerRef.current) return;
+      const r = triggerRef.current.getBoundingClientRect();
+      let top = 0, left = 0;
+      const gap = 8;
+      if (side === "top")    { top = r.top - gap;  left = r.left + r.width/2; }
+      if (side === "bottom") { top = r.bottom + gap; left = r.left + r.width/2; }
+      if (side === "left")   { top = r.top + r.height/2; left = r.left - gap; }
+      if (side === "right")  { top = r.top + r.height/2; left = r.right + gap; }
+      setCoords({ top, left });
+      setOpen(true);
+    }, delay);
+  }
+  function hide() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setOpen(false);
+  }
+
+  const trigger = React.cloneElement(children, {
+    ref: triggerRef,
+    onMouseEnter: (e: any) => { show(); children.props.onMouseEnter?.(e); },
+    onMouseLeave: (e: any) => { hide(); children.props.onMouseLeave?.(e); },
+    onFocus: (e: any) => { show(); children.props.onFocus?.(e); },
+    onBlur: (e: any) => { hide(); children.props.onBlur?.(e); },
+  });
+
+  return (<>
+    {trigger}
+    {open && coords && (typeof document !== "undefined") && ReactDOM.createPortal(
+      <div
+        className={`grd-tt grd-tt-${side} grd-tt-${size}`}
+        style={{ top: coords.top, left: coords.left }}
+        role="tooltip"
+      >
+        {content}
+        <span className="grd-tt-arrow" />
+      </div>,
+      document.body
+    )}
+  </>);
+}
+Tooltip.displayName = "Tooltip";
+(window as any).Tooltip = Tooltip;

--- a/ux_references/ui_kits/components/TopBar/TopBar.playground.html
+++ b/ux_references/ui_kits/components/TopBar/TopBar.playground.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>TopBar · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=10">
+<link rel="stylesheet" href="../Button/index.css">
+<link rel="stylesheet" href="../IconButton/index.css">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="../Avatar/index.css">
+<link rel="stylesheet" href="../Badge/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">NAVEGAÇÃO · BARRA SUPERIOR</div>
+  <h1 class="pg-title">TopBar</h1>
+  <span class="pg-codename">import TopBar from "ui_kits/components/TopBar"</span>
+  <p class="pg-desc">Barra superior composável: left / center / right. O shell define o layout; os conteúdos vêm por prop.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../IconButton/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Input/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Avatar/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=10"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:0,flexDirection:"column",alignItems:"stretch",gap:0}}>{children}</div></div>);
+}
+function Stub() {
+  return <div style={{minHeight:160,background:"var(--gray-50)",display:"flex",alignItems:"center",justifyContent:"center",color:"var(--gray-400)",fontSize:13}}>— conteúdo da página —</div>;
+}
+
+function App() {
+  return (<>
+    <Sec title="Control Center — logo + busca global + ações">
+      <TopBar
+        sticky={false}
+        left={<><strong style={{fontSize:15,color:"var(--fg)"}}>Guardia</strong><span style={{color:"var(--gray-400)",fontSize:13,marginLeft:8}}>/ Control Center</span></>}
+        center={<Input leftIcon="search" placeholder="Buscar empresa, NF, extrato…  ⌘K" style={{width:"100%"}} />}
+        right={<>
+          <IconButton icon="bell" variant="ghost" />
+          <IconButton icon="help-circle" variant="ghost" />
+          <Avatar name="Luana Rocha" size="sm" />
+        </>}
+      />
+      <Stub />
+    </Sec>
+
+    <Sec title="Página de entidade — breadcrumb no left, ações no right">
+      <TopBar
+        sticky={false}
+        left={<span style={{color:"var(--gray-500)",fontSize:13}}>Empresas <span style={{color:"var(--gray-300)",margin:"0 6px"}}>/</span> <b style={{color:"var(--fg)",fontWeight:600}}>Alfa Comércio LTDA</b></span>}
+        right={<>
+          <button className="grd-btn grd-btn-ghost">Exportar</button>
+          <button className="grd-btn grd-btn-secondary">Ver histórico</button>
+          <button className="grd-btn grd-btn-primary">+ Novo lançamento</button>
+        </>}
+      />
+      <Stub />
+    </Sec>
+
+    <Sec title="Mínima — só marca + conta">
+      <TopBar
+        sticky={false}
+        left={<strong style={{fontSize:15,color:"var(--fg)"}}>Guardia</strong>}
+        right={<><Badge tone="violet" variant="soft">Plano Pro</Badge><Avatar name="Luana Rocha" size="sm" /></>}
+      />
+      <Stub />
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["TopBar"]) || "render(<div>Sem exemplo para TopBar</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>left</code> · <code>center</code> · <code>right</code></td><td>node</td><td>—</td><td class="desc">Slots composáveis. <code>center</code> cresce para preencher.</td></tr>
+  <tr><td><code>sticky</code></td><td>boolean</td><td>true</td><td class="desc">Fixa no topo ao rolar</td></tr>
+</table>
+
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Header global: logo + busca + atalhos + perfil.</li>
+      <li>Altura 56-64px; permanece visível em scroll.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>TopBar com > 5 ações à direita.</li>
+      <li>Esconder busca em breakpoints médios.</li>
+    </ul>
+  </div>
+</div>
+
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/TopBar/index.css
+++ b/ux_references/ui_kits/components/TopBar/index.css
@@ -1,0 +1,12 @@
+
+.grd-tb {
+  display: flex; align-items: center; gap: 16px;
+  height: 56px;
+  padding: 0 20px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-sans);
+}
+.grd-tb-sticky { position: sticky; top: 0; z-index: 50; }
+.grd-tb-left, .grd-tb-right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+.grd-tb-center { flex: 1; display: flex; justify-content: center; max-width: 560px; margin: 0 auto; }

--- a/ux_references/ui_kits/components/TopBar/index.tsx
+++ b/ux_references/ui_kits/components/TopBar/index.tsx
@@ -1,0 +1,26 @@
+
+/**
+ * TopBar — barra superior. Composição: Logo/título à esquerda, busca central, ações à direita.
+ * Conteúdo via props left, center, right (nós composáveis).
+ */
+
+interface TopBarProps {
+  left?: React.ReactNode;
+  center?: React.ReactNode;
+  right?: React.ReactNode;
+  sticky?: boolean;
+  className?: string;
+}
+
+function TopBar({ left, center, right, sticky = true, className = "" }: TopBarProps) {
+  const cls = ["grd-tb", sticky && "grd-tb-sticky", className].filter(Boolean).join(" ");
+  return (
+    <header className={cls}>
+      <div className="grd-tb-left">{left}</div>
+      {center && <div className="grd-tb-center">{center}</div>}
+      <div className="grd-tb-right">{right}</div>
+    </header>
+  );
+}
+TopBar.displayName = "TopBar";
+(window as any).TopBar = TopBar;

--- a/ux_references/ui_kits/components/Tree/Tree.playground.html
+++ b/ux_references/ui_kits/components/Tree/Tree.playground.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Tree · Playground</title>
+<link rel="stylesheet" href="../../../colors_and_type.css">
+<link rel="stylesheet" href="../_shared/shared.css?v=11">
+<link rel="stylesheet" href="./index.css?v=1">
+<link rel="stylesheet" href="../Input/index.css">
+<link rel="stylesheet" href="../Badge/index.css">
+<link rel="stylesheet" href="../Button/index.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../_shared/babel-tsx-preset.js"></script>
+</head>
+<body>
+
+<div class="pg-hdr">
+  <div class="pg-eyebrow">DATA · HIERARQUIA</div>
+  <h1 class="pg-title">Tree</h1>
+  <span class="pg-codename">import Tree from "ui_kits/components/Tree"</span>
+  <p class="pg-desc">Árvore hierárquica com expand/collapse, seleção única ou múltipla (com estado parcial em pais), ícones, meta à direita e busca. Usada principalmente para plano de contas, estrutura de empresas e categorias fiscais aninhadas.</p>
+</div>
+
+<div id="root"></div>
+
+<script type="text/babel" data-presets="tsx" src="../_shared/Icon.tsx?v=2"></script>
+<script type="text/babel" data-presets="tsx" src="../Input/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Badge/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../Button/index.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="./index.tsx?v=1"></script>
+
+<script type="text/babel" data-presets="tsx">
+function Sec({ title, children }: { title: string; children: React.ReactNode }) {
+  return (<div className="pg-sec"><p className="pg-sec-title">{title}</p><div className="pg-stage" style={{padding:28,gap:36,alignItems:"flex-start",flexWrap:"wrap"}}>{children}</div></div>);
+}
+function Frame({ children, w=380, label }: { children: React.ReactNode; w?: number; label?: string }) {
+  return (
+    <div style={{ width: w }}>
+      {label && <div style={{ fontSize: 11.5, color: "var(--fg-muted)", marginBottom: 10, fontWeight: 600, letterSpacing: ".04em", textTransform: "uppercase" }}>{label}</div>}
+      <div style={{ background: "var(--surface)", border: "1px solid var(--gray-200)", borderRadius: "var(--radius-lg)", padding: "12px 10px" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Plano de contas ---------- */
+const PLANO_CONTAS = [
+  {
+    id: "1", label: "1 · Ativo", description: "Bens e direitos", icon: "wallet",
+    defaultExpanded: true,
+    children: [
+      {
+        id: "1.1", label: "1.1 · Ativo Circulante", icon: "folder",
+        defaultExpanded: true,
+        children: [
+          { id: "1.1.01", label: "1.1.01 · Caixa Geral",      icon: "file-text", meta: "R$ 12.430,00" },
+          { id: "1.1.02", label: "1.1.02 · Bancos Conta Movimento", icon: "file-text", meta: "R$ 184.721,55" },
+          { id: "1.1.03", label: "1.1.03 · Aplicações Financeiras", icon: "file-text", meta: "R$ 50.000,00" },
+          { id: "1.1.04", label: "1.1.04 · Clientes a Receber",     icon: "file-text", meta: "R$ 41.892,10" },
+        ],
+      },
+      {
+        id: "1.2", label: "1.2 · Ativo Não Circulante", icon: "folder",
+        children: [
+          { id: "1.2.01", label: "1.2.01 · Imobilizado",  icon: "file-text", meta: "R$ 320.000,00" },
+          { id: "1.2.02", label: "1.2.02 · Intangível",   icon: "file-text", meta: "R$ 18.500,00" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "2", label: "2 · Passivo", description: "Obrigações", icon: "scale",
+    children: [
+      {
+        id: "2.1", label: "2.1 · Passivo Circulante", icon: "folder",
+        children: [
+          { id: "2.1.01", label: "2.1.01 · Fornecedores",          icon: "file-text", meta: "R$ 22.134,00" },
+          { id: "2.1.02", label: "2.1.02 · Impostos a Recolher",   icon: "file-text", meta: "R$ 8.900,00" },
+          { id: "2.1.03", label: "2.1.03 · Salários a Pagar",      icon: "file-text", meta: "R$ 31.200,00", disabled: true },
+        ],
+      },
+    ],
+  },
+  {
+    id: "3", label: "3 · Receita", icon: "trending-up",
+    children: [
+      { id: "3.1", label: "3.1 · Receita Operacional", icon: "file-text", meta: "R$ 890.500,00" },
+      { id: "3.2", label: "3.2 · Receita Financeira",  icon: "file-text", meta: "R$ 4.210,00" },
+    ],
+  },
+];
+
+/* ---------- Estrutura de empresas ---------- */
+const GRUPO = [
+  {
+    id: "holding", label: "Grupo Verona Participações", icon: "building-2",
+    description: "Holding · CNPJ 45.892.100/0001-33",
+    defaultExpanded: true,
+    meta: <Badge tone="violet" variant="soft">Holding</Badge>,
+    children: [
+      {
+        id: "verona-sp", label: "Verona Alimentos SP", icon: "building",
+        defaultExpanded: true,
+        meta: <Badge tone="green" variant="soft">Operacional</Badge>,
+        children: [
+          { id: "unidade-1", label: "Unidade Pinheiros",  icon: "map-pin" },
+          { id: "unidade-2", label: "Unidade Moema",      icon: "map-pin" },
+          { id: "unidade-3", label: "Unidade Tatuapé",    icon: "map-pin" },
+        ],
+      },
+      {
+        id: "verona-rj", label: "Verona Alimentos RJ", icon: "building",
+        meta: <Badge tone="green" variant="soft">Operacional</Badge>,
+        children: [
+          { id: "rj-1", label: "Unidade Ipanema",  icon: "map-pin" },
+          { id: "rj-2", label: "Unidade Botafogo", icon: "map-pin" },
+        ],
+      },
+      { id: "verona-log", label: "Verona Logística", icon: "building", meta: <Badge tone="amber" variant="soft">Em regularização</Badge> },
+    ],
+  },
+];
+
+/* ---------- Multi-seleção ---------- */
+function MultiSelectExample() {
+  const [selected, setSelected] = React.useState<string[]>(["1.1.02"]);
+  return (
+    <Frame w={440} label={`${selected.length} conta(s) selecionada(s)`}>
+      <Tree
+        nodes={PLANO_CONTAS}
+        mode="multi"
+        selected={selected}
+        onSelectedChange={setSelected}
+        defaultExpanded={["1","1.1","2","2.1"]}
+      />
+    </Frame>
+  );
+}
+
+/* ---------- Com busca ---------- */
+function SearchExample() {
+  const [q, setQ] = React.useState("");
+  const [selected, setSelected] = React.useState<string[]>([]);
+
+  /* filtra preservando caminhos; se o nó casa, mantém ele + ancestrais */
+  const filter = React.useCallback((nodes: any[], query: string): any[] => {
+    if (!query) return nodes;
+    const lc = query.toLowerCase();
+    const visit = (arr: any[]): any[] => {
+      return arr.flatMap((n) => {
+        const matches = String(n.label).toLowerCase().includes(lc);
+        const kids = n.children ? visit(n.children) : [];
+        if (matches || kids.length) return [{ ...n, children: kids.length ? kids : n.children }];
+        return [];
+      });
+    };
+    return visit(nodes);
+  }, []);
+
+  const filtered = React.useMemo(() => filter(PLANO_CONTAS, q), [q, filter]);
+  const autoExpanded = React.useMemo(() => q ? collectAllIds(filtered) : undefined, [q, filtered]);
+
+  return (
+    <Frame w={440}>
+      <div style={{ padding: "4px 4px 10px" }}>
+        <Input
+          size="sm"
+          placeholder="Buscar conta…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          leftIcon="search"
+        />
+      </div>
+      <Tree
+        nodes={filtered}
+        mode="single"
+        selected={selected}
+        onSelectedChange={setSelected}
+        expanded={autoExpanded}
+        emptyState={<div>Nenhuma conta encontrada</div>}
+      />
+    </Frame>
+  );
+}
+
+function collectAllIds(arr: any[]): string[] {
+  const out: string[] = [];
+  const walk = (xs: any[]) => xs.forEach((n) => { out.push(n.id); if (n.children) walk(n.children); });
+  walk(arr);
+  return out;
+}
+
+function App() {
+  return (<>
+    <Sec title="Plano de contas — seleção única">
+      <Frame w={440}>
+        <Tree nodes={PLANO_CONTAS} defaultExpanded={["1","1.1"]} defaultSelected={["1.1.02"]} />
+      </Frame>
+    </Sec>
+
+    <Sec title="Seleção múltipla com estado parcial (pais)">
+      <MultiSelectExample />
+    </Sec>
+
+    <Sec title="Com busca e expansão automática">
+      <SearchExample />
+    </Sec>
+
+    <Sec title="Estrutura de empresas — ícones + meta + badges">
+      <Frame w={460}>
+        <Tree nodes={GRUPO} mode="single" />
+      </Frame>
+    </Sec>
+
+    <Sec title="Size sm · sem linhas guia">
+      <Frame w={340}>
+        <Tree nodes={PLANO_CONTAS} size="sm" showLines={false} defaultExpanded={["1","1.1"]} />
+      </Frame>
+    </Sec>
+  </>);
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+</script>
+
+<div id="example-root"></div>
+
+<script src="../_shared/live-examples.js"></script>
+<script src="../_shared/highlight.js"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/LiveCode.tsx"></script>
+<script type="text/babel" data-presets="tsx" src="../_shared/SourceViewer.tsx"></script>
+<script type="text/babel" data-presets="tsx">
+(function mountExample(){
+  const code = (window.__LIVE_EXAMPLES && window.__LIVE_EXAMPLES["Tree"]) || "render(<div>Sem exemplo para Tree</div>);";
+  function ExampleApp(){ return <LiveCode code={code} />; }
+  ReactDOM.createRoot(document.getElementById('example-root')).render(<ExampleApp />);
+})();
+</script>
+
+<table class="pg-api">
+  <tr><th>Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+  <tr><td><code>nodes</code></td><td>TreeNode[]</td><td>—</td><td class="desc">Nós raiz</td></tr>
+  <tr><td><code>mode</code></td><td>string</td><td>"single"</td><td class="desc">none · single · multi (multi calcula estado parcial de pais automaticamente)</td></tr>
+  <tr><td><code>size</code></td><td>string</td><td>"md"</td><td class="desc">sm · md</td></tr>
+  <tr><td><code>expanded</code> · <code>onExpandedChange</code></td><td>string[] · fn</td><td>—</td><td class="desc">Controlled — ids dos nós expandidos</td></tr>
+  <tr><td><code>selected</code> · <code>onSelectedChange</code></td><td>string[] · fn</td><td>—</td><td class="desc">Controlled — ids selecionados</td></tr>
+  <tr><td><code>defaultExpanded</code> · <code>defaultSelected</code></td><td>string[]</td><td>—</td><td class="desc">Uncontrolled initial state</td></tr>
+  <tr><td><code>showLines</code></td><td>bool</td><td>true</td><td class="desc">Guias verticais entre pai e filhos</td></tr>
+  <tr><td><code>emptyState</code></td><td>node</td><td>—</td><td class="desc">Conteúdo quando <code>nodes=[]</code> (útil com busca vazia)</td></tr>
+  <tr><td><code>onNodeClick</code></td><td>fn</td><td>—</td><td class="desc">Callback por linha clicada</td></tr>
+  <tr><th colspan="4" style="background:var(--orange-50);color:var(--orange-700);font-weight:600;">TreeNode</th></tr>
+  <tr><td><code>id</code></td><td>string</td><td>—</td><td class="desc">Chave única</td></tr>
+  <tr><td><code>label</code> · <code>description</code></td><td>node</td><td>—</td><td class="desc">Conteúdo</td></tr>
+  <tr><td><code>icon</code></td><td>string</td><td>—</td><td class="desc">Ícone à esquerda</td></tr>
+  <tr><td><code>meta</code></td><td>node</td><td>—</td><td class="desc">Conteúdo à direita (valor, badge, etc.)</td></tr>
+  <tr><td><code>children</code></td><td>TreeNode[]</td><td>—</td><td class="desc">Subnós</td></tr>
+  <tr><td><code>disabled</code></td><td>bool</td><td>false</td><td class="desc">Bloqueia seleção/navegação do nó</td></tr>
+  <tr><td><code>defaultExpanded</code></td><td>bool</td><td>false</td><td class="desc">Expandir por padrão ao montar</td></tr>
+</table>
+
+<div class="pg-usage-grid">
+  <div class="pg-usage">
+    <strong>Usar</strong>
+    <ul>
+      <li>Plano de contas, estrutura de empresas, categorias fiscais aninhadas.</li>
+      <li>Seleção em lote com <code>multi</code> — pais mostram "partial" quando filhos estão parcialmente selecionados.</li>
+      <li>Busca + expansão automática quando a árvore tem mais de ~20 nós visíveis.</li>
+    </ul>
+  </div>
+  <div class="pg-antiuse">
+    <strong>Evitar</strong>
+    <ul>
+      <li>Árvores com 1 nível — prefira <code>SidebarNav</code> ou <code>Menu</code>.</li>
+      <li>Tree como navegação principal de app — use <code>SidebarNav</code>.</li>
+      <li>Árvores profundas (&gt; 5 níveis) sem busca.</li>
+    </ul>
+  </div>
+</div>
+
+<div id="sv-root"></div>
+<script type="text/babel" data-presets="tsx">
+ReactDOM.createRoot(document.getElementById('sv-root')!).render(<SourceViewer files={["index.tsx","index.css"]} />);
+</script>
+</body>
+</html>

--- a/ux_references/ui_kits/components/Tree/index.css
+++ b/ux_references/ui_kits/components/Tree/index.css
@@ -1,0 +1,141 @@
+
+/* ===================================================================
+ * Tree
+ * ================================================================= */
+
+.grd-tr {
+  list-style: none; margin: 0; padding: 0;
+  font-family: var(--font-sans);
+  color: var(--fg);
+  --tr-row-h: 30px;
+  --tr-gap: 6px;
+}
+.grd-tr-sm { --tr-row-h: 26px; --tr-gap: 4px; }
+
+.grd-tr-children { list-style: none; margin: 0; padding: 0; }
+
+/* ---------- Row ---------- */
+.grd-tr-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: var(--tr-row-h);
+  padding: 2px 8px 2px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  position: relative;
+  transition: background 120ms, color 120ms;
+  font-size: 13px;
+  line-height: 1.3;
+}
+.grd-tr-sm .grd-tr-row { font-size: 12.5px; gap: 5px; padding: 1px 6px 1px 6px; }
+
+.grd-tr-row:hover { background: var(--gray-50); }
+.grd-tr-row-sel  { background: var(--violet-50); color: var(--violet-700); }
+.grd-tr-row-sel:hover { background: var(--violet-100); }
+.grd-tr-row-disabled { opacity: .45; cursor: not-allowed; }
+.grd-tr-row-disabled:hover { background: transparent; }
+
+/* ---------- Caret ---------- */
+.grd-tr-caret {
+  width: 18px; height: 18px; flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 0; background: transparent; cursor: pointer;
+  border-radius: var(--radius-xs);
+  color: var(--fg-muted);
+  transition: transform 140ms, background 120ms;
+  padding: 0;
+}
+.grd-tr-sm .grd-tr-caret { width: 16px; height: 16px; }
+.grd-tr-caret:hover { background: var(--gray-100); color: var(--fg); }
+.grd-tr-caret-open { transform: rotate(90deg); }
+.grd-tr-caret-leaf { cursor: default; pointer-events: none; }
+
+/* ---------- Guia vertical (showLines) ---------- */
+.grd-tr-lines .grd-tr-children {
+  position: relative;
+}
+.grd-tr-lines .grd-tr-children::before {
+  content: "";
+  position: absolute;
+  top: 0; bottom: 6px;
+  left: calc(8px + 9px);            /* alinhado com centro do caret */
+  width: 1px;
+  background: var(--gray-200);
+  pointer-events: none;
+}
+.grd-tr-sm.grd-tr-lines .grd-tr-children::before {
+  left: calc(6px + 8px);
+}
+
+/* ---------- Checkbox (multi) ---------- */
+.grd-tr-cb {
+  width: 15px; height: 15px;
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--radius-xs);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  background: var(--surface);
+  color: #fff;
+  transition: background 120ms, border-color 120ms;
+}
+.grd-tr-sm .grd-tr-cb { width: 13px; height: 13px; }
+.grd-tr-cb-all {
+  background: var(--violet-600);
+  border-color: var(--violet-600);
+}
+.grd-tr-cb-partial {
+  background: var(--violet-600);
+  border-color: var(--violet-600);
+}
+.grd-tr-cb-bar {
+  width: 7px; height: 2px; background: #fff; border-radius: 1px;
+}
+
+/* ---------- Ícone + label ---------- */
+.grd-tr-ico {
+  width: 16px; height: 16px; flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--fg-muted);
+}
+.grd-tr-row-sel .grd-tr-ico { color: var(--violet-600); }
+
+.grd-tr-label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+.grd-tr-label-main {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.grd-tr-row-sel .grd-tr-label-main { font-weight: 600; }
+.grd-tr-label-desc {
+  font-size: 12px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.grd-tr-sm .grd-tr-label-desc { font-size: 11px; }
+
+.grd-tr-meta {
+  flex-shrink: 0;
+  margin-left: auto;
+  padding-left: 8px;
+  color: var(--fg-muted);
+  font-size: 12px;
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+}
+
+.grd-tr-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--fg-muted);
+}

--- a/ux_references/ui_kits/components/Tree/index.tsx
+++ b/ux_references/ui_kits/components/Tree/index.tsx
@@ -1,0 +1,288 @@
+
+/**
+ * Tree — árvore hierárquica com expand/collapse, seleção (single ou multi) e
+ * ícones opcionais.
+ *
+ * Casos na Guardia:
+ *   - Plano de contas (1 → 1.1 → 1.1.01)
+ *   - Estrutura de empresas (holding → filial → unidade)
+ *   - Categorias fiscais aninhadas
+ *   - Regras do Copilot
+ *
+ * Seleção:
+ *   - mode="single": um único nó selecionado
+ *   - mode="multi" : vários nós; pais auto-calculam estado (all | partial | none)
+ *   - mode="none"  : apenas navegação/expand
+ *
+ * API controlado E não-controlado: passe expanded/selected para controlar de
+ * fora; omita para usar estado interno.
+ */
+
+interface TreeNode {
+  id: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  icon?: string;                   // ícone à esquerda (opcional)
+  meta?: React.ReactNode;          // conteúdo à direita (badge, valor, ação)
+  disabled?: boolean;
+  children?: TreeNode[];
+  defaultExpanded?: boolean;
+}
+
+type SelectionState = "none" | "partial" | "all";
+
+interface TreeProps {
+  nodes: TreeNode[];
+  mode?: "none" | "single" | "multi";
+  size?: "sm" | "md";
+  /* Controlled */
+  expanded?: string[];
+  onExpandedChange?: (expanded: string[]) => void;
+  selected?: string[];
+  onSelectedChange?: (selected: string[]) => void;
+  /* Uncontrolled defaults */
+  defaultExpanded?: string[];
+  defaultSelected?: string[];
+  /* Features */
+  showLines?: boolean;             // linhas guia verticais
+  onNodeClick?: (node: TreeNode) => void;
+  emptyState?: React.ReactNode;
+  className?: string;
+}
+
+/* ------------------------------- utils ------------------------------- */
+
+function collectIds(nodes: TreeNode[], acc: string[] = []): string[] {
+  for (const n of nodes) {
+    acc.push(n.id);
+    if (n.children) collectIds(n.children, acc);
+  }
+  return acc;
+}
+
+function collectLeafIds(nodes: TreeNode[], acc: string[] = []): string[] {
+  for (const n of nodes) {
+    if (!n.children || n.children.length === 0) acc.push(n.id);
+    else collectLeafIds(n.children, acc);
+  }
+  return acc;
+}
+
+function computeNodeSelection(
+  node: TreeNode,
+  selectedSet: Set<string>
+): SelectionState {
+  if (!node.children || node.children.length === 0) {
+    return selectedSet.has(node.id) ? "all" : "none";
+  }
+  const states = node.children.map((c) => computeNodeSelection(c, selectedSet));
+  const all = states.every((s) => s === "all");
+  const none = states.every((s) => s === "none");
+  if (all) return "all";
+  if (none) return "none";
+  return "partial";
+}
+
+function toggleBranch(
+  node: TreeNode,
+  selectedSet: Set<string>,
+  target: boolean
+) {
+  // Aplica só a folhas (descendentes sem filhos) — pais são derivados
+  const leaves = collectLeafIds([node]);
+  leaves.forEach((id) => {
+    if (target) selectedSet.add(id);
+    else selectedSet.delete(id);
+  });
+}
+
+/* ---------------------------- componente ---------------------------- */
+
+function Tree({
+  nodes,
+  mode = "single",
+  size = "md",
+  expanded,
+  onExpandedChange,
+  selected,
+  onSelectedChange,
+  defaultExpanded,
+  defaultSelected,
+  showLines = true,
+  onNodeClick,
+  emptyState,
+  className = "",
+}: TreeProps) {
+  const IconCmp = (window as any).Icon;
+
+  /* Expansão: controlled ou uncontrolled */
+  const [internalExpanded, setInternalExpanded] = React.useState<string[]>(
+    () => {
+      if (defaultExpanded) return defaultExpanded;
+      // auto-expande nós marcados com defaultExpanded
+      const auto: string[] = [];
+      const walk = (arr: TreeNode[]) => {
+        for (const n of arr) {
+          if (n.defaultExpanded) auto.push(n.id);
+          if (n.children) walk(n.children);
+        }
+      };
+      walk(nodes);
+      return auto;
+    }
+  );
+  const expSet = React.useMemo(
+    () => new Set(expanded ?? internalExpanded),
+    [expanded, internalExpanded]
+  );
+  const toggleExpand = (id: string) => {
+    const next = new Set(expSet);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    const arr = Array.from(next);
+    if (expanded === undefined) setInternalExpanded(arr);
+    onExpandedChange?.(arr);
+  };
+
+  /* Seleção: controlled ou uncontrolled */
+  const [internalSelected, setInternalSelected] = React.useState<string[]>(
+    defaultSelected ?? []
+  );
+  const selSet = React.useMemo(
+    () => new Set(selected ?? internalSelected),
+    [selected, internalSelected]
+  );
+  const commitSelection = (set: Set<string>) => {
+    const arr = Array.from(set);
+    if (selected === undefined) setInternalSelected(arr);
+    onSelectedChange?.(arr);
+  };
+
+  const handleSelect = (node: TreeNode) => {
+    if (node.disabled) return;
+    if (mode === "none") return;
+    if (mode === "single") {
+      commitSelection(new Set([node.id]));
+      return;
+    }
+    // multi
+    const next = new Set(selSet);
+    if (node.children && node.children.length > 0) {
+      // toggle com base no estado atual do branch
+      const state = computeNodeSelection(node, selSet);
+      toggleBranch(node, next, state !== "all");
+    } else {
+      if (next.has(node.id)) next.delete(node.id);
+      else next.add(node.id);
+    }
+    commitSelection(next);
+  };
+
+  const isEmpty = nodes.length === 0;
+  if (isEmpty && emptyState) {
+    return <div className={`grd-tr grd-tr-${size} grd-tr-empty ${className}`}>{emptyState}</div>;
+  }
+
+  const cls = [
+    "grd-tr",
+    `grd-tr-${size}`,
+    `grd-tr-m-${mode}`,
+    showLines ? "grd-tr-lines" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const iconSize = size === "sm" ? 13 : 14;
+
+  const renderNode = (node: TreeNode, depth: number, isLast: boolean, ancestorsLast: boolean[]): React.ReactNode => {
+    const hasChildren = !!node.children && node.children.length > 0;
+    const isExpanded = expSet.has(node.id);
+    const selectionState: SelectionState = mode === "multi" ? computeNodeSelection(node, selSet) : selSet.has(node.id) ? "all" : "none";
+    const isSelected = mode === "single" ? selSet.has(node.id) : selectionState === "all";
+
+    const rowCls = [
+      "grd-tr-row",
+      isSelected ? "grd-tr-row-sel" : "",
+      node.disabled ? "grd-tr-row-disabled" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <li key={node.id} className="grd-tr-li" role="treeitem" aria-expanded={hasChildren ? isExpanded : undefined} aria-selected={isSelected || undefined}>
+        <div
+          className={rowCls}
+          style={{ paddingLeft: 8 + depth * (size === "sm" ? 16 : 18) }}
+          onClick={(e) => {
+            if (node.disabled) return;
+            onNodeClick?.(node);
+            if (mode !== "none") handleSelect(node);
+          }}
+        >
+          {/* caret */}
+          {hasChildren ? (
+            <button
+              type="button"
+              className={`grd-tr-caret ${isExpanded ? "grd-tr-caret-open" : ""}`}
+              onClick={(e) => { e.stopPropagation(); toggleExpand(node.id); }}
+              aria-label={isExpanded ? "Colapsar" : "Expandir"}
+            >
+              {IconCmp ? <IconCmp name="chevron-right" size={iconSize - 1} /> : <span>›</span>}
+            </button>
+          ) : (
+            <span className="grd-tr-caret grd-tr-caret-leaf" aria-hidden="true" />
+          )}
+
+          {/* checkbox (multi) */}
+          {mode === "multi" && (
+            <span
+              className={[
+                "grd-tr-cb",
+                selectionState === "all" ? "grd-tr-cb-all" : "",
+                selectionState === "partial" ? "grd-tr-cb-partial" : "",
+              ].filter(Boolean).join(" ")}
+              aria-hidden="true"
+            >
+              {selectionState === "all" && IconCmp && <IconCmp name="check" size={11} />}
+              {selectionState === "partial" && <span className="grd-tr-cb-bar" />}
+            </span>
+          )}
+
+          {/* ícone opcional */}
+          {node.icon && IconCmp && (
+            <span className="grd-tr-ico"><IconCmp name={node.icon} size={iconSize} /></span>
+          )}
+
+          <span className="grd-tr-label">
+            <span className="grd-tr-label-main">{node.label}</span>
+            {node.description && <span className="grd-tr-label-desc">{node.description}</span>}
+          </span>
+
+          {node.meta && <span className="grd-tr-meta">{node.meta}</span>}
+        </div>
+
+        {hasChildren && isExpanded && (
+          <ul className="grd-tr-children" role="group">
+            {node.children!.map((child, i) =>
+              renderNode(
+                child,
+                depth + 1,
+                i === node.children!.length - 1,
+                [...ancestorsLast, isLast]
+              )
+            )}
+          </ul>
+        )}
+      </li>
+    );
+  };
+
+  return (
+    <ul className={cls} role="tree">
+      {nodes.map((n, i) => renderNode(n, 0, i === nodes.length - 1, []))}
+    </ul>
+  );
+}
+Tree.displayName = "Tree";
+(window as any).Tree = Tree;

--- a/ux_references/ui_kits/components/_shared/Icon.tsx
+++ b/ux_references/ui_kits/components/_shared/Icon.tsx
@@ -1,0 +1,139 @@
+/**
+ * Icon — biblioteca de glifos em Lucide-style (stroke 2px, 24×24)
+ * ---------------------------------------------------------------
+ * Uso:
+ *   <Icon name="search" />
+ *   <Icon name="chevron-down" size={20} />
+ *   <Icon name="alert-triangle" color="var(--signal-red)" />
+ */
+
+type IconName =
+  | "activity" | "alert-circle" | "alert-triangle" | "archive" | "arrow-down" | "arrow-left" | "arrow-left-right" | "arrow-right" | "arrow-up"
+  | "bar-chart" | "bell" | "book-open" | "book-open-check" | "bot" | "calendar" | "check" | "check-circle" | "check-circle-2" | "chevron-down" | "chevron-left" | "chevron-right" | "chevron-up"
+  | "circle" | "circle-check" | "circle-x" | "clock" | "copy" | "credit-card" | "dashboard" | "device" | "dots" | "dots-vertical" | "download"
+  | "edit" | "external-link" | "eye" | "eye-off" | "file" | "file-text" | "filter" | "folder"
+  | "help-circle" | "home" | "image" | "inbox" | "info" | "key" | "layers" | "layout-dashboard" | "life-buoy" | "link" | "list" | "loader" | "loader-circle" | "lock" | "logout"
+  | "mail" | "menu" | "message" | "minus" | "more" | "paperclip" | "pen" | "phone" | "pie-chart" | "play" | "plus"
+  | "receipt-text" | "refresh" | "search" | "send" | "settings" | "shield" | "shield-check" | "sparkles" | "star" | "tag" | "trash"
+  | "trend" | "trend-down" | "triangle-alert" | "upload" | "cloud-upload" | "user" | "users" | "x" | "zap";
+
+interface IconProps extends React.SVGAttributes<SVGSVGElement> {
+  name: IconName;
+  size?: number;
+  color?: string;
+}
+
+const ICON_PATHS: Record<IconName, React.ReactNode> = {
+  "activity":       <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>,
+  "alert-circle":   <><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></>,
+  "alert-triangle": <><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></>,
+  "archive":        <><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5"/><line x1="10" y1="12" x2="14" y2="12"/></>,
+  "arrow-down":     <><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></>,
+  "arrow-left":     <><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></>,
+  "arrow-right":    <><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></>,
+  "arrow-up":       <><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></>,
+  "bar-chart":      <><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></>,
+  "bell":           <><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></>,
+  "book-open":      <><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></>,
+  "calendar":       <><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></>,
+  "check":          <polyline points="20 6 9 17 4 12"/>,
+  "check-circle":   <><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></>,
+  "chevron-down":   <polyline points="6 9 12 15 18 9"/>,
+  "chevron-left":   <polyline points="15 18 9 12 15 6"/>,
+  "chevron-right":  <polyline points="9 18 15 12 9 6"/>,
+  "chevron-up":     <polyline points="18 15 12 9 6 15"/>,
+  "circle":         <circle cx="12" cy="12" r="10"/>,
+  "clock":          <><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></>,
+  "copy":           <><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></>,
+  "credit-card":    <><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></>,
+  "dashboard":      <><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></>,
+  "device":         <><rect x="2" y="4" width="20" height="14" rx="2"/><line x1="8" y1="20" x2="16" y2="20"/><line x1="12" y1="18" x2="12" y2="20"/></>,
+  "dots":           <><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></>,
+  "dots-vertical":  <><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></>,
+  "download":       <><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></>,
+  "edit":           <><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></>,
+  "external-link":  <><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></>,
+  "eye":            <><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></>,
+  "eye-off":        <><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></>,
+  "file":           <><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></>,
+  "file-text":      <><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></>,
+  "filter":         <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/>,
+  "folder":         <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>,
+  "help-circle":    <><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></>,
+  "home":           <><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></>,
+  "image":          <><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></>,
+  "inbox":          <><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></>,
+  "info":           <><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></>,
+  "key":            <><circle cx="7.5" cy="15.5" r="4.5"/><path d="m10.5 12.5 10-10"/><path d="m16 6 3 3"/></>,
+  "layers":         <><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></>,
+  "link":           <><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></>,
+  "list":           <><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></>,
+  "loader":         <><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="4.93" y1="4.93" x2="7.76" y2="7.76"/><line x1="16.24" y1="16.24" x2="19.07" y2="19.07"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/><line x1="4.93" y1="19.07" x2="7.76" y2="16.24"/><line x1="16.24" y1="7.76" x2="19.07" y2="4.93"/></>,
+  "lock":           <><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></>,
+  "logout":         <><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></>,
+  "mail":           <><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></>,
+  "menu":           <><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></>,
+  "message":        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>,
+  "minus":          <line x1="5" y1="12" x2="19" y2="12"/>,
+  "more":           <><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></>,
+  "paperclip":      <path d="M21.44 11.05 12.25 20.24a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>,
+  "pen":            <path d="M12 19l7-7 3 3-7 7-3-3z M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z M2 2l7.586 7.586 M11 11 a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"/>,
+  "phone":          <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>,
+  "pie-chart":      <><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></>,
+  "play":           <polygon points="5 3 19 12 5 21 5 3"/>,
+  "plus":           <><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></>,
+  "refresh":        <><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></>,
+  "search":         <><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></>,
+  "send":           <><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></>,
+  "settings":       <><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></>,
+  "shield":         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>,
+  "shield-check":   <><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></>,
+  "sparkles":       <><path d="M12 3 13.5 8.5 19 10 13.5 11.5 12 17 10.5 11.5 5 10 10.5 8.5 12 3z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/></>,
+  "star":           <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>,
+  "tag":            <><path d="M20.59 13.41 13.42 20.58a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></>,
+  "trash":          <><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></>,
+  "trend":          <><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></>,
+  "trend-down":     <><polyline points="23 18 13.5 8.5 8.5 13.5 1 6"/><polyline points="17 18 23 18 23 12"/></>,
+  "upload":         <><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></>,
+  "cloud-upload":   <><path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M12 12v9"/><path d="m16 16-4-4-4 4"/></>,
+  "user":           <><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></>,
+  "users":          <><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></>,
+  "x":              <><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></>,
+  "zap":            <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>,
+  "layout-dashboard": <><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></>,
+  "book-open-check": <><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7"/><polyline points="17 10 19 12 23 8"/></>,
+  "bot":            <><path d="M12 2v4"/><rect x="4" y="6" width="16" height="14" rx="3"/><circle cx="9" cy="13" r="1.25"/><circle cx="15" cy="13" r="1.25"/><path d="M9 17h6"/><line x1="2" y1="13" x2="4" y2="13"/><line x1="20" y1="13" x2="22" y2="13"/></>,
+  "arrow-left-right": <><polyline points="17 11 21 7 17 3"/><line x1="21" y1="7" x2="9" y2="7"/><polyline points="7 21 3 17 7 13"/><line x1="15" y1="17" x2="3" y2="17"/></>,
+  "receipt-text":   <><path d="M4 2v20l2-1.5L8 22l2-1.5L12 22l2-1.5L16 22l2-1.5L20 22V2l-2 1.5L16 2l-2 1.5L12 2l-2 1.5L8 2 6 3.5 4 2z"/><line x1="8" y1="8" x2="16" y2="8"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="8" y1="16" x2="12" y2="16"/></>,
+  "life-buoy":      <><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="4"/><line x1="4.93" y1="4.93" x2="9.17" y2="9.17"/><line x1="14.83" y1="14.83" x2="19.07" y2="19.07"/><line x1="14.83" y1="9.17" x2="19.07" y2="4.93"/><line x1="14.83" y1="9.17" x2="18.36" y2="5.64"/><line x1="4.93" y1="19.07" x2="9.17" y2="14.83"/></>,
+  "check-circle-2": <><circle cx="12" cy="12" r="10"/><polyline points="9 12 11 14 15 10"/></>,
+  // — Aliases canônicos alinhados à iconografia oficial (Lucide v0.300+)
+  "circle-check":   <><circle cx="12" cy="12" r="10"/><polyline points="9 12 11 14 15 10"/></>,
+  "circle-x":       <><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></>,
+  "triangle-alert": <><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></>,
+  "loader-circle":  <path d="M21 12a9 9 0 1 1-6.219-8.56"/>,
+};
+
+function Icon({ name, size = 16, color = "currentColor", style, ...rest }: IconProps) {
+  const path = ICON_PATHS[name];
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ display: "inline-block", flexShrink: 0, ...style }}
+      {...rest}
+    >
+      {path}
+    </svg>
+  );
+}
+
+Icon.displayName = "Icon";
+(window as any).Icon = Icon;
+(window as any).ICON_NAMES = Object.keys(ICON_PATHS);

--- a/ux_references/ui_kits/components/_shared/LiveCode.tsx
+++ b/ux_references/ui_kits/components/_shared/LiveCode.tsx
@@ -1,0 +1,176 @@
+/**
+ * <LiveCode> — editor de TSX com preview ao vivo.
+ *
+ * O usuário edita o TSX à direita e o preview à esquerda re-renderiza.
+ * Props:
+ *   - code: string com código TSX inicial. Deve terminar em uma expressão JSX
+ *           OU conter `render(<Algo />)`. Qualquer componente referenciado precisa
+ *           estar disponível no window global (Button, Switch, Icon, etc.).
+ *   - scope: objeto extra injetado no escopo do código ({ myFoo: 42 })
+ *
+ * Uso:
+ *   <LiveCode
+ *     code={`
+ *       function Demo() {
+ *         const [n, setN] = React.useState(3);
+ *         return <Button onClick={() => setN(n+1)}>Clicou {n}</Button>;
+ *       }
+ *       render(<Demo />);
+ *     `}
+ *   />
+ */
+
+interface LiveCodeProps {
+  code: string;
+  title?: string;
+  file?: string;
+  /** extra globals disponíveis no código */
+  scope?: Record<string, unknown>;
+  /** padding extra no preview */
+  previewStyle?: React.CSSProperties;
+}
+
+function LiveCode({ code, title = "Exemplo editável", file = "index.tsx", scope = {}, previewStyle }: LiveCodeProps) {
+  const initial = React.useMemo(() => {
+    const lines = code.replace(/^\n+|\s+$/g, "").split("\n");
+    let min = Infinity;
+    for (const l of lines) {
+      if (!l.trim()) continue;
+      const m = l.match(/^[ \t]*/);
+      if (m && m[0].length < min) min = m[0].length;
+    }
+    if (!isFinite(min) || min === 0) return lines.join("\n");
+    return lines.map((l) => l.slice(min)).join("\n");
+  }, [code]);
+
+  const [source, setSource] = React.useState(initial);
+  const [error, setError] = React.useState<string | null>(null);
+  const previewRef = React.useRef<HTMLDivElement>(null);
+  const rootRef = React.useRef<any>(null);
+  const editorRef = React.useRef<HTMLPreElement>(null);
+  const highlightRef = React.useRef<HTMLPreElement>(null);
+
+  // Run the code
+  React.useEffect(() => {
+    if (!previewRef.current) return;
+    try {
+      // @ts-ignore
+      const Babel = (window as any).Babel;
+      if (!Babel) throw new Error("Babel não carregado");
+
+      // Transpile TSX → JS
+      const transformed = Babel.transform(source, {
+        presets: [["typescript", { isTSX: true, allExtensions: true }], "react"],
+        filename: "live.tsx",
+      }).code;
+
+      // Build scope: React, ReactDOM, all window globals the playgrounds export,
+      // plus any custom scope + a `render` function that hydrates previewRef.
+      const customRender = (el: React.ReactElement) => {
+        if (!rootRef.current) {
+          rootRef.current = ReactDOM.createRoot(previewRef.current!);
+        }
+        rootRef.current.render(el);
+      };
+
+      const globalKeys = Object.keys(window).filter(
+        (k) => /^([A-Z][A-Za-z]+|use[A-Z][A-Za-z]+)$/.test(k) && typeof (window as any)[k] === "function",
+      );
+      const keys = ["React", "ReactDOM", "render", ...globalKeys, ...Object.keys(scope)];
+      const vals = [
+        React,
+        ReactDOM,
+        customRender,
+        ...globalKeys.map((k) => (window as any)[k]),
+        ...Object.values(scope),
+      ];
+
+      // Wrap so the last statement auto-renders if it is a JSX expression and
+      // nobody called render() explicitly.
+      const wrapped = `
+        "use strict";
+        let __didRender = false;
+        const __origRender = render;
+        render = (el) => { __didRender = true; __origRender(el); };
+        try {
+          ${transformed}
+        } catch (e) { throw e; }
+        if (!__didRender) {
+          // Try to find a top-level function component named App or Demo or Example.
+          if (typeof App !== "undefined") __origRender(React.createElement(App));
+          else if (typeof Demo !== "undefined") __origRender(React.createElement(Demo));
+          else if (typeof Example !== "undefined") __origRender(React.createElement(Example));
+        }
+      `;
+
+      // eslint-disable-next-line no-new-func
+      const fn = new Function(...keys, wrapped);
+      fn(...vals);
+      setError(null);
+    } catch (e: any) {
+      setError(e?.message || String(e));
+    }
+  }, [source]);
+
+  // Sync syntax-highlighted <pre> with the editable <pre>
+  React.useEffect(() => {
+    if (!highlightRef.current) return;
+    highlightRef.current.textContent = source;
+    delete highlightRef.current.dataset.highlighted;
+    // @ts-ignore
+    if (typeof window.__pgHighlight === "function") window.__pgHighlight();
+  }, [source]);
+
+  const onInput = (e: React.FormEvent<HTMLPreElement>) => {
+    const text = e.currentTarget.textContent || "";
+    // Debounce
+    setSource(text);
+  };
+
+  // Tab key → 2 spaces
+  const onKeyDown = (e: React.KeyboardEvent<HTMLPreElement>) => {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      const sel = window.getSelection();
+      if (!sel || !sel.rangeCount) return;
+      const range = sel.getRangeAt(0);
+      range.deleteContents();
+      range.insertNode(document.createTextNode("  "));
+      range.collapse(false);
+      sel.removeAllRanges(); sel.addRange(range);
+      // force onInput
+      const el = editorRef.current!;
+      setSource(el.textContent || "");
+    }
+  };
+
+  return (
+    <div className={"pg-example" + (error ? " pg-example-err" : "")}>
+      <div className="pg-example-hdr">
+        <span className="t">{title}</span>
+        <span className="h">
+          {error ? <span style={{ color: "#FF7A7A" }}>● erro de sintaxe</span> : <>{file} · <em style={{ fontStyle: "normal", opacity: 0.7 }}>editável</em></>}
+        </span>
+      </div>
+      <div className="pg-example-body">
+        <div className="pg-example-preview" ref={previewRef} style={previewStyle} />
+        <div className="pg-live-editor">
+          <pre ref={highlightRef} className="pg-example-code pg-live-hl" data-lang="tsx" aria-hidden="true" />
+          <pre
+            ref={editorRef}
+            className="pg-example-code pg-live-ed"
+            contentEditable
+            spellCheck={false}
+            suppressContentEditableWarning
+            onInput={onInput}
+            onKeyDown={onKeyDown}
+          >{initial}</pre>
+        </div>
+      </div>
+      {error && <div className="pg-live-err">{error}</div>}
+    </div>
+  );
+}
+
+// @ts-ignore
+window.LiveCode = LiveCode;

--- a/ux_references/ui_kits/components/_shared/LiveExample.tsx
+++ b/ux_references/ui_kits/components/_shared/LiveExample.tsx
@@ -1,0 +1,81 @@
+/**
+ * <LiveExample> — preview + código fonte lado a lado.
+ * O código é uma função que recebe o estado atual e retorna uma string,
+ * então muda em tempo real conforme o preview é interagido.
+ *
+ * Uso típico:
+ *
+ *   function Example() {
+ *     const [open, setOpen] = React.useState(false);
+ *     return (
+ *       <LiveExample
+ *         title="Exemplo de uso"
+ *         file="index.tsx"
+ *         code={`
+ *           import Dialog from "ui_kits/components/Dialog";
+ *
+ *           function App() {
+ *             const [open, setOpen] = useState(${open});
+ *             return <Dialog open={open} onClose={() => setOpen(false)}>…</Dialog>;
+ *           }
+ *         `}
+ *       >
+ *         <button onClick={() => setOpen(true)}>Abrir</button>
+ *         <Dialog open={open} onClose={() => setOpen(false)}>…</Dialog>
+ *       </LiveExample>
+ *     );
+ *   }
+ *
+ * Depende do _shared/shared.css (classes .pg-example-*) e de window.__pgHighlight
+ * (_shared/highlight.js) — ambos já carregados pelos playgrounds.
+ */
+
+interface LiveExampleProps {
+  title?: string;
+  file?: string;
+  code: string;
+  children: React.ReactNode;
+  /** Flip no código para forçar re-highlight quando quiser. */
+  codeKey?: string | number;
+}
+
+function LiveExample({ title = "Exemplo de uso", file = "index.tsx", code, children, codeKey }: LiveExampleProps) {
+  const preRef = React.useRef<HTMLPreElement>(null);
+  const trimmed = React.useMemo(() => {
+    // Remove blank lines at top/bottom, outdent common leading whitespace.
+    const lines = code.replace(/^\n+|\s+$/g, "").split("\n");
+    let min = Infinity;
+    for (const l of lines) {
+      if (!l.trim()) continue;
+      const m = l.match(/^[ \t]*/);
+      if (m && m[0].length < min) min = m[0].length;
+    }
+    if (!isFinite(min) || min === 0) return lines.join("\n");
+    return lines.map((l) => l.slice(min)).join("\n");
+  }, [code]);
+
+  React.useEffect(() => {
+    const el = preRef.current;
+    if (!el) return;
+    el.textContent = trimmed;
+    delete el.dataset.highlighted;
+    // @ts-ignore — highlight helper registrado em window por highlight.js
+    if (typeof window.__pgHighlight === "function") window.__pgHighlight();
+  }, [trimmed, codeKey]);
+
+  return (
+    <div className="pg-example">
+      <div className="pg-example-hdr">
+        <span className="t">{title}</span>
+        <span className="h">{file}</span>
+      </div>
+      <div className="pg-example-body">
+        <div className="pg-example-preview">{children}</div>
+        <pre ref={preRef} className="pg-example-code" data-lang="tsx" />
+      </div>
+    </div>
+  );
+}
+
+// @ts-ignore
+window.LiveExample = LiveExample;

--- a/ux_references/ui_kits/components/_shared/SourceViewer.tsx
+++ b/ux_references/ui_kits/components/_shared/SourceViewer.tsx
@@ -1,0 +1,84 @@
+/**
+ * <SourceViewer> — mostra o código-fonte (index.tsx + index.css) do próprio
+ * componente. Busca os arquivos relativos à pasta do playground (./index.tsx e
+ * ./index.css) via fetch. Tabs simples entre os dois; bloco de código usa o
+ * mesmo highlighter dos exemplos (window.__pgHighlight).
+ *
+ * Uso:
+ *   <SourceViewer files={["index.tsx","index.css"]} />
+ *
+ * Depende de _shared/highlight.js já estar carregado.
+ */
+
+interface SourceViewerProps {
+  files?: string[];
+  /** Diretório base; default "./" (relativo ao playground HTML) */
+  base?: string;
+}
+
+function SourceViewer({ files = ["index.tsx", "index.css"], base = "./" }: SourceViewerProps) {
+  const [active, setActive] = React.useState(files[0]);
+  const [sources, setSources] = React.useState<Record<string, string>>({});
+  const [errors, setErrors] = React.useState<Record<string, string>>({});
+  const preRef = React.useRef<HTMLPreElement>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      for (const f of files) {
+        try {
+          const res = await fetch(base + f);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const text = await res.text();
+          if (!cancelled) setSources((s) => ({ ...s, [f]: text }));
+        } catch (e: any) {
+          if (!cancelled) setErrors((er) => ({ ...er, [f]: e?.message || "erro" }));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [files.join("|"), base]);
+
+  React.useEffect(() => {
+    const el = preRef.current;
+    if (!el) return;
+    el.textContent = sources[active] || (errors[active] ? `// ${errors[active]}` : "// carregando...");
+    el.dataset.lang = active.endsWith(".css") ? "css" : "tsx";
+    delete el.dataset.highlighted;
+    // @ts-ignore
+    if (typeof window.__pgHighlight === "function") window.__pgHighlight();
+  }, [active, sources, errors]);
+
+  const lines = (sources[active] || "").split("\n").length;
+
+  return (
+    <div className="pg-example">
+      <div className="pg-example-hdr">
+        <span className="t">Código fonte</span>
+        <span className="sv-tabs">
+          <span className="sv-tabs-seg">
+            {files.map((f) => (
+              <button
+                key={f}
+                type="button"
+                className={"sv-tab" + (f === active ? " is-active" : "")}
+                onClick={() => setActive(f)}
+              >
+                {f}
+              </button>
+            ))}
+          </span>
+          {lines > 0 && <span className="sv-meta">{lines} linhas</span>}
+        </span>
+      </div>
+      <div className="pg-example-body">
+        <pre ref={preRef} className="pg-example-code" data-lang="tsx" />
+      </div>
+    </div>
+  );
+}
+
+// @ts-ignore
+window.SourceViewer = SourceViewer;

--- a/ux_references/ui_kits/components/_shared/babel-tsx-preset.js
+++ b/ux_references/ui_kits/components/_shared/babel-tsx-preset.js
@@ -1,0 +1,30 @@
+/**
+ * Bootstrap do preset TypeScript para @babel/standalone no navegador.
+ * Deve ser carregado IMEDIATAMENTE após babel.min.js e ANTES de qualquer
+ * <script type="text/babel">.
+ *
+ * Por quê: o preset "typescript" nativo do Babel só é aplicado quando o
+ * filename termina em .ts/.tsx. Em scripts inline o filename é "Inline
+ * Babel script", fazendo o preset ser silenciosamente ignorado (bug
+ * conhecido: github.com/babel/babel/issues/17419). Aqui registramos um
+ * preset alternativo com { isTSX: true, allExtensions: true } que ignora
+ * a extensão e processa qualquer bloco como TSX.
+ *
+ * Uso no playground:
+ *   <script src="…/babel.min.js"></script>
+ *   <script src="…/_shared/babel-tsx-preset.js"></script>
+ *   <script type="text/babel" data-presets="tsx" src="./Foo.tsx"></script>
+ */
+(function () {
+  if (typeof Babel === "undefined") {
+    console.error("[babel-tsx-preset] Babel not loaded. Load @babel/standalone first.");
+    return;
+  }
+  if (Babel.availablePresets.tsx) return; // idempotent
+  Babel.registerPreset("tsx", {
+    presets: [
+      [Babel.availablePresets["typescript"], { isTSX: true, allExtensions: true }],
+      [Babel.availablePresets["react"], {}],
+    ],
+  });
+})();

--- a/ux_references/ui_kits/components/_shared/highlight.js
+++ b/ux_references/ui_kits/components/_shared/highlight.js
@@ -1,0 +1,90 @@
+/**
+ * Tiny JSX/TSX syntax highlighter for playgrounds.
+ * Não é um tokenizer completo — é o suficiente para destacar
+ * keywords, JSX tags/atributos, strings, comentários e números.
+ *
+ * Uso:
+ *   <pre class="pg-example-code" data-lang="tsx">...código aqui...</pre>
+ *   <script src="../_shared/highlight.js"></script>
+ *
+ * O script encontra todos os <pre data-lang> e substitui o conteúdo
+ * por HTML com spans .tok-*.
+ */
+(function () {
+  "use strict";
+
+  const KEYWORDS = new Set([
+    "const", "let", "var", "function", "return", "if", "else", "import", "from",
+    "export", "default", "new", "class", "extends", "type", "interface",
+    "as", "true", "false", "null", "undefined", "async", "await", "for", "while",
+  ]);
+
+  function escapeHtml(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function highlight(code) {
+    // Tokenize in a single pass with a regex that matches:
+    //  - line/block comments
+    //  - strings (single, double, template backticks)
+    //  - JSX open/close tag names and attribute names
+    //  - identifiers/keywords
+    //  - numbers
+    //  - everything else
+    const re = /(\/\/[^\n]*|\/\*[\s\S]*?\*\/)|("[^"]*"|'[^']*'|`[^`]*`)|(<\/?[A-Za-z][\w.]*)|(\b[A-Za-z_$][\w$]*)(?=\s*=)|(\b[A-Za-z_$][\w$]*\b)|(\b\d+(?:\.\d+)?\b)|([{}()\[\],;:=<>/.!?&|+\-*])/g;
+
+    let out = "";
+    let last = 0;
+    let m;
+    while ((m = re.exec(code)) !== null) {
+      out += escapeHtml(code.slice(last, m.index));
+      const [full, com, str, tag, attr, ident, num, punct] = m;
+      if (com) out += `<span class="tok-com">${escapeHtml(full)}</span>`;
+      else if (str) out += `<span class="tok-str">${escapeHtml(full)}</span>`;
+      else if (tag) out += `<span class="tok-tag">${escapeHtml(full)}</span>`;
+      else if (attr) out += `<span class="tok-attr">${escapeHtml(full)}</span>`;
+      else if (ident) {
+        if (KEYWORDS.has(full)) out += `<span class="tok-kw">${full}</span>`;
+        else out += escapeHtml(full);
+      }
+      else if (num) out += `<span class="tok-num">${full}</span>`;
+      else if (punct) out += `<span class="tok-punct">${escapeHtml(full)}</span>`;
+      else out += escapeHtml(full);
+      last = m.index + full.length;
+    }
+    out += escapeHtml(code.slice(last));
+    return out;
+  }
+
+  function trimIndent(raw) {
+    // Remove leading/trailing blank lines and outdent by the common
+    // minimum leading-whitespace across non-blank lines.
+    const lines = raw.replace(/^\n+|\s+$/g, "").split("\n");
+    let min = Infinity;
+    for (const l of lines) {
+      if (!l.trim()) continue;
+      const m = l.match(/^[ \t]*/);
+      if (m && m[0].length < min) min = m[0].length;
+    }
+    if (!isFinite(min) || min === 0) return lines.join("\n");
+    return lines.map((l) => l.slice(min)).join("\n");
+  }
+
+  function run() {
+    const blocks = document.querySelectorAll("pre.pg-example-code[data-lang]");
+    blocks.forEach((el) => {
+      if (el.dataset.highlighted === "1") return;
+      const src = trimIndent(el.textContent || "");
+      el.innerHTML = highlight(src);
+      el.dataset.highlighted = "1";
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", run);
+  } else {
+    run();
+  }
+  // Expose for manual re-runs
+  window.__pgHighlight = run;
+})();

--- a/ux_references/ui_kits/components/_shared/live-examples.js
+++ b/ux_references/ui_kits/components/_shared/live-examples.js
@@ -1,0 +1,959 @@
+/**
+ * Mapa de exemplos TSX executáveis para cada componente do DS.
+ * Cada chave é o nome do componente (= nome da pasta). Valor = código TSX
+ * que será passado como prop `code` pro <LiveCode>.
+ *
+ * Todo o código deve terminar em `render(<X />)` ou em uma expressão JSX final.
+ * Componentes usados precisam estar expostos em window (carregados pelos scripts
+ * do próprio playground).
+ */
+
+window.__LIVE_EXAMPLES = {
+
+  Accordion: `
+function FAQ() {
+  const items = [
+    { id: "1", title: "Como a Guardia reconcilia meus extratos?",
+      content: "Conectamos ao banco via Open Finance e cruzamos com os lançamentos do ERP usando modelos de confiança. Matches acima de 95% são auto-aprovados.",
+      defaultOpen: true },
+    { id: "2", title: "Posso revisar antes de aprovar?",
+      content: "Sim. Cada match vem com um indicador de confiança e você pode ajustar o limiar a qualquer momento." },
+    { id: "3", title: "Quais bancos são suportados?",
+      content: "Itaú, Bradesco, Santander, BB, Caixa, Inter, Nubank e todas as fintechs do Open Finance." },
+  ];
+  return (
+    <div style={{ width: 520 }}>
+      <Accordion items={items} type="single" />
+    </div>
+  );
+}
+render(<FAQ />);
+`,
+
+  AgentCard: `
+function Dashboard() {
+  return (
+    <div style={{ width: 380 }}>
+      <AgentCard
+        name="Conciliação Bancária"
+        role="Processa extratos e cruza com o ERP"
+        icon="git-merge"
+        status="active"
+        metrics={[
+          { label: "Aprovados hoje", value: "237" },
+          { label: "Precisão", value: "98.4%" },
+        ]}
+        lastRun="há 8 min"
+      />
+    </div>
+  );
+}
+render(<Dashboard />);
+`,
+
+  Badge: `
+function StatusList() {
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      <Badge tone="success">Aprovado</Badge>
+      <Badge tone="warning">Em revisão</Badge>
+      <Badge tone="danger">Rejeitado</Badge>
+      <Badge tone="info">Novo</Badge>
+      <Badge tone="neutral" dot>Rascunho</Badge>
+    </div>
+  );
+}
+render(<StatusList />);
+`,
+
+  Breadcrumbs: `
+function Header() {
+  const items = [
+    { label: "Clientes", href: "#" },
+    { label: "Silva & Cia", href: "#" },
+    { label: "Abril 2026" },
+  ];
+  return <Breadcrumbs items={items} />;
+}
+render(<Header />);
+`,
+
+  ButtonGroup: `
+function Toolbar() {
+  const [view, setView] = React.useState("list");
+  const mk = (k) => ({
+    variant: view === k ? "solid" : "ghost",
+    onClick: () => setView(k),
+  });
+  return (
+    <ButtonGroup>
+      <Button {...mk("list")}>Lista</Button>
+      <Button {...mk("grid")}>Grade</Button>
+      <Button {...mk("kanban")}>Kanban</Button>
+    </ButtonGroup>
+  );
+}
+render(<Toolbar />);
+`,
+
+  Calendar: `
+function AgendaFiscal() {
+  const [date, setDate] = React.useState(new Date(2025, 10, 1));
+  const [sel, setSel]   = React.useState(null);
+  const events = [
+    { id: "1", date: "2025-11-07", time: "23:59", title: "DCTFWeb",   tone: "red",    icon: "alert" },
+    { id: "2", date: "2025-11-14", time: "23:59", title: "SPED Contrib.", tone: "orange", icon: "file-text" },
+    { id: "3", date: "2025-11-10", time: "09:00", title: "Revisão Porto Brasil", tone: "violet", icon: "users" },
+    { id: "4", date: "2025-11-20", time: "23:59", title: "DARF IRRF",  tone: "red",    icon: "alert" },
+    { id: "5", date: "2025-11-21", allDay: true,   title: "Offsite SP",   tone: "violet" },
+    { id: "6", date: "2025-11-25", time: "15:00", title: "Fechamento Pietra Moda", tone: "green" },
+  ];
+  return (
+    <div style={{ height: 560 }}>
+      <Calendar
+        view="month"
+        date={date}
+        onDateChange={setDate}
+        events={events}
+        selectedDate={sel}
+        onDayClick={setSel}
+        legend={[
+          { label: "Prazo crítico",    tone: "red" },
+          { label: "Obrigação fiscal", tone: "orange" },
+          { label: "Reunião cliente",  tone: "violet" },
+          { label: "Marco",             tone: "green" },
+        ]}
+      />
+    </div>
+  );
+}
+render(<AgendaFiscal />);
+`,
+
+  Card: `
+function Resumo() {
+  return (
+    <Card variant="elevated" padding="lg" style={{ width: 360 }}>
+      <div style={{ fontSize: 11, color: 'var(--gray-500)', letterSpacing: '0.1em', textTransform: 'uppercase' }}>
+        Faturamento de abril
+      </div>
+      <div style={{ fontSize: 32, fontWeight: 700, color: 'var(--violet-500)', marginTop: 8 }}>
+        R$ 142.380
+      </div>
+      <div style={{ fontSize: 13, color: 'var(--signal-green)', marginTop: 4 }}>
+        +12,4% em relação a março
+      </div>
+    </Card>
+  );
+}
+render(<Resumo />);
+`,
+
+  Chart: `
+function Metrica() {
+  const data = [
+    { label: "Jan", value: 84 },
+    { label: "Fev", value: 92 },
+    { label: "Mar", value: 118 },
+    { label: "Abr", value: 142 },
+  ];
+  return (
+    <div style={{ width: 420 }}>
+      <Chart type="bar" data={data} height={200} title="Lançamentos / mês" />
+    </div>
+  );
+}
+render(<Metrica />);
+`,
+
+  ChatMessage: `
+function Conversa() {
+  return (
+    <div style={{ width: 460, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <ChatMessage role="user" name="Você" timestamp="14:02">
+        Quais lançamentos estão pendentes de revisão?
+      </ChatMessage>
+      <ChatMessage role="assistant" name="Conciliação" avatarIcon="bot" timestamp="14:02">
+        Encontrei 3 lançamentos com confiança abaixo de 85%. Quer revisar agora?
+      </ChatMessage>
+    </div>
+  );
+}
+render(<Conversa />);
+`,
+
+  Chip: `
+function Filtros() {
+  const [tags, setTags] = React.useState(["Aprovado", "Abril", "Silva & Cia"]);
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      {tags.map((t) => (
+        <Chip key={t} onRemove={() => setTags(tags.filter(x => x !== t))}>{t}</Chip>
+      ))}
+      {tags.length === 0 && (
+        <button onClick={() => setTags(["Aprovado", "Abril", "Silva & Cia"])}
+                style={{ fontSize: 12, color: 'var(--orange-500)', background: 'none', border: 0, cursor: 'pointer' }}>
+          Restaurar
+        </button>
+      )}
+    </div>
+  );
+}
+render(<Filtros />);
+`,
+
+  Combobox: `
+function SeletorCliente() {
+  const [value, setValue] = React.useState("");
+  const options = [
+    { value: "1", label: "Silva & Cia",        meta: "CNPJ 12.345.678/0001-90" },
+    { value: "2", label: "Nova Era Contábil",  meta: "CNPJ 98.765.432/0001-11" },
+    { value: "3", label: "Prime Consultoria",  meta: "CNPJ 54.321.987/0001-55" },
+    { value: "4", label: "Horizonte ME",       meta: "CNPJ 11.222.333/0001-44" },
+  ];
+  return (
+    <div style={{ width: 320 }}>
+      <Combobox
+        placeholder="Selecione um cliente..."
+        value={value}
+        options={options}
+        onChange={setValue}
+        leftIcon="search"
+        clearable
+      />
+    </div>
+  );
+}
+render(<SeletorCliente />);
+`,
+
+  Command: `
+function Paleta() {
+  const [open, setOpen] = React.useState(true);
+  const items = [
+    { group: "Ações rápidas", entries: [
+      { id: "a1", label: "Novo cliente",       icon: "plus",   shortcut: "⌘N" },
+      { id: "a2", label: "Importar extrato",   icon: "upload" },
+      { id: "a3", label: "Rodar conciliação",  icon: "play" },
+    ]},
+    { group: "Navegar", entries: [
+      { id: "n1", label: "Ir para Clientes",    icon: "users" },
+      { id: "n2", label: "Ir para Relatórios",  icon: "bar-chart" },
+    ]},
+  ];
+  return (
+    <>
+      {!open && <Button onClick={() => setOpen(true)}>Abrir paleta (⌘K)</Button>}
+      <Command open={open} onClose={() => setOpen(false)} items={items} />
+    </>
+  );
+}
+render(<Paleta />);
+`,
+
+  ConfidenceIndicator: `
+function ResultadoMatch() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, width: 320 }}>
+      <ConfidenceIndicator value={98} label="Match automático"   variant="bar" showValue />
+      <ConfidenceIndicator value={82} label="Revisão sugerida"   variant="bar" showValue />
+      <ConfidenceIndicator value={54} label="Ambíguo"            variant="bar" showValue />
+    </div>
+  );
+}
+render(<ResultadoMatch />);
+`,
+
+  DataTable: `
+function TabelaLancamentos() {
+  const columns = [
+    { id: "data",       header: "Data",        accessor: "data",       width: 80 },
+    { id: "descricao",  header: "Descrição",   accessor: "descricao" },
+    { id: "valor",      header: "Valor",       accessor: "valor",      align: "right" },
+    { id: "status",     header: "Status",      accessor: "status",     render: (v) => v },
+  ];
+  const rows = [
+    { id: 1, data: "14/04", descricao: "Boleto — Fornecedor X", valor: "R$ 1.280,00",  status: <Badge tone="success">Aprovado</Badge> },
+    { id: 2, data: "15/04", descricao: "PIX — Silva & Cia",     valor: "R$ 3.400,00",  status: <Badge tone="warning">Em revisão</Badge> },
+    { id: 3, data: "16/04", descricao: "TED — Salários",        valor: "R$ 28.900,00", status: <Badge tone="success">Aprovado</Badge> },
+  ];
+  return (
+    <div style={{ width: 600 }}>
+      <DataTable columns={columns} rows={rows} />
+    </div>
+  );
+}
+render(<TabelaLancamentos />);
+`,
+
+  DatePicker: `
+function SeletorPeriodo() {
+  const [date, setDate] = React.useState(new Date(2026, 3, 15));
+  return (
+    <div style={{ width: 280 }}>
+      <DatePicker value={date} onChange={setDate} />
+    </div>
+  );
+}
+render(<SeletorPeriodo />);
+`,
+
+  Dialog: `
+function ConfirmarExclusao() {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <>
+      <Button variant="danger" onClick={() => setOpen(true)}>Excluir cliente</Button>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Excluir Silva & Cia?"
+        description="Todos os lançamentos e extratos vinculados serão removidos. Essa ação não pode ser desfeita."
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setOpen(false)}>Cancelar</Button>
+            <Button variant="danger" onClick={() => setOpen(false)}>Excluir</Button>
+          </>
+        }
+      />
+    </>
+  );
+}
+render(<ConfirmarExclusao />);
+`,
+
+  Drawer: `
+function PainelDetalhes() {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Ver detalhes do lançamento</Button>
+      <Drawer
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Lançamento #48291"
+        description="PIX recebido · 15/04/2026"
+        side="right"
+      >
+        <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div><strong>De:</strong> Silva & Cia</div>
+          <div><strong>Valor:</strong> R$ 3.400,00</div>
+          <div><strong>Match:</strong> NF 2841 — 98% de confiança</div>
+        </div>
+      </Drawer>
+    </>
+  );
+}
+render(<PainelDetalhes />);
+`,
+
+  EmptyState: `
+function ListaVazia() {
+  return (
+    <div style={{ width: 480 }}>
+      <EmptyState
+        icon="inbox"
+        title="Nenhum lançamento ainda"
+        description="Conecte seu banco para começarmos a importar automaticamente."
+        action={<Button variant="accent">Conectar banco</Button>}
+      />
+    </div>
+  );
+}
+render(<ListaVazia />);
+`,
+
+  FileUpload: `
+function ImportarExtrato() {
+  const [files, setFiles] = React.useState([]);
+  return (
+    <div style={{ width: 420 }}>
+      <FileUpload
+        accept=".csv,.ofx,.pdf"
+        multiple
+        hint="CSV, OFX ou PDF até 10MB"
+        onFiles={(list) => setFiles([...files, ...list])}
+      />
+      {files.length > 0 && (
+        <p style={{ fontSize: 12, color: 'var(--gray-500)', marginTop: 8 }}>
+          {files.length} arquivo(s) selecionado(s)
+        </p>
+      )}
+    </div>
+  );
+}
+render(<ImportarExtrato />);
+`,
+
+  IconButton: `
+function BarraAcoes() {
+  return (
+    <div style={{ display: 'flex', gap: 6 }}>
+      <IconButton icon="edit"    aria-label="Editar" />
+      <IconButton icon="copy"    aria-label="Duplicar" />
+      <IconButton icon="archive" aria-label="Arquivar" />
+      <IconButton icon="trash"   variant="danger" aria-label="Excluir" />
+    </div>
+  );
+}
+render(<BarraAcoes />);
+`,
+
+  FormLayout: `
+function FormularioCliente() {
+  const [cnpj, setCnpj] = React.useState("");
+  const [regime, setRegime] = React.useState("presumido");
+  const [notas, setNotas] = React.useState("");
+
+  return (
+    <FormLayout variant="stacked" density="comfy">
+      <FormLayout.Header
+        title="Novo cliente"
+        description="Dados para abrir a operação contábil."
+      />
+      <FormLayout.Section title="Identificação">
+        <FormLayout.Row>
+          <FormLayout.Field label="CNPJ" required span={5}
+            hint="Validaremos na Receita ao salvar.">
+            <Input placeholder="00.000.000/0000-00"
+                   leftIcon="building"
+                   value={cnpj}
+                   onChange={(e) => setCnpj(e.target.value)} />
+          </FormLayout.Field>
+          <FormLayout.Field label="Razão social" required span={7}>
+            <Input placeholder="Nome empresarial" />
+          </FormLayout.Field>
+        </FormLayout.Row>
+        <FormLayout.Field label="Regime tributário" required>
+          <Select value={regime} onChange={(e) => setRegime(e.target.value)}
+            options={[
+              { value: "simples",   label: "Simples Nacional" },
+              { value: "presumido", label: "Lucro Presumido" },
+              { value: "real",      label: "Lucro Real" },
+            ]} />
+        </FormLayout.Field>
+        <FormLayout.Field label="Notas internas" optional
+          labelAside={notas.length + " / 280"}
+          hint="Visível só para a equipe da Guardia.">
+          <Textarea rows={3} maxLength={280}
+            value={notas}
+            onChange={(e) => setNotas(e.target.value)}
+            placeholder="Contexto do relacionamento..." />
+        </FormLayout.Field>
+      </FormLayout.Section>
+      <FormLayout.Actions align="between">
+        <Button variant="ghost">Cancelar</Button>
+        <Button variant="primary" rightIcon="arrow-right">Criar cliente</Button>
+      </FormLayout.Actions>
+    </FormLayout>
+  );
+}
+render(<FormularioCliente />);
+`,
+
+  Kanban: `
+function Tarefas() {
+  const [cards, setCards] = React.useState([
+    { id: "1", columnId: "todo",   title: "Conciliar Itaú — abril", displayId: "TSK-2420", priority: "med",  assignee: { name: "Bianca" }, dueDate: "02 mai", dueStatus: "ok" },
+    { id: "2", columnId: "todo",   title: "Resposta à Receita",       displayId: "TSK-2421", priority: "high", assignee: { name: "Luana" },  dueDate: "28 abr", dueStatus: "danger" },
+    { id: "3", columnId: "doing",  title: "Plano de contas — Verona", displayId: "TSK-2410", priority: "med",  assignee: { name: "Thiago" }, progress: 0.68 },
+    { id: "4", columnId: "review", title: "DRE abril — Mercearia",    displayId: "TSK-2401", priority: "low",  assignee: { name: "Bianca" }, confidence: 0.98 },
+    { id: "5", columnId: "done",   title: "SPED Contribuições mar",   displayId: "TSK-2390", assignee: { name: "Carolina" }, progress: 1 },
+  ]);
+  const cols = [
+    { id: "todo",   title: "A fazer",      color: "var(--blue-500)" },
+    { id: "doing",  title: "Em andamento", color: "var(--signal-yellow)" },
+    { id: "review", title: "Revisão",      color: "var(--violet-500)" },
+    { id: "done",   title: "Concluído",    color: "var(--signal-green)" },
+  ];
+  const handleMove = (id, toCol, _lane, idx) => {
+    setCards(prev => {
+      const m = prev.find(c => c.id === id); if (!m) return prev;
+      const rest = prev.filter(c => c.id !== id);
+      const out = []; let placed = false; let b = 0;
+      for (const c of rest) {
+        if (c.columnId === toCol && b === idx && !placed) { out.push({ ...m, columnId: toCol }); placed = true; }
+        out.push(c); if (c.columnId === toCol) b++;
+      }
+      if (!placed) out.push({ ...m, columnId: toCol });
+      return out;
+    });
+  };
+  return <Kanban columns={cols} cards={cards} onCardMove={handleMove} />;
+}
+render(<Tarefas />);
+`,
+
+  Label: `
+function CampoFormulario() {
+  return (
+    <div style={{ width: 320, display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <Label htmlFor="cnpj" required>CNPJ da empresa</Label>
+        <Input id="cnpj" placeholder="00.000.000/0000-00" />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <Label htmlFor="obs" optional>Observações</Label>
+        <Input id="obs" placeholder="Notas internas..." />
+      </div>
+    </div>
+  );
+}
+render(<CampoFormulario />);
+`,
+
+  Menu: `
+function MenuContexto() {
+  const items = [
+    { label: "Ver detalhes", icon: "eye" },
+    { label: "Editar",       icon: "edit", shortcut: "⌘E" },
+    { label: "Duplicar",     icon: "copy" },
+    { type: "separator" },
+    { label: "Excluir",      icon: "trash", destructive: true },
+  ];
+  return (
+    <Menu trigger={<Button variant="ghost" rightIcon="chevron-down">Ações</Button>} items={items} />
+  );
+}
+render(<MenuContexto />);
+`,
+
+  MetricCard: `
+function KPIs() {
+  return (
+    <div style={{ display: 'flex', gap: 12 }}>
+      <MetricCard
+        label="Aprovados hoje"
+        value="237"
+        delta="+12%"
+        deltaType="up"
+      />
+      <MetricCard
+        label="Precisão"
+        value="98,4"
+        suffix="%"
+        delta="+0,3 pp"
+        deltaType="up"
+      />
+    </div>
+  );
+}
+render(<KPIs />);
+`,
+
+  Pagination: `
+function NavPag() {
+  const [page, setPage] = React.useState(3);
+  return (
+    <Pagination
+      page={page}
+      pageCount={24}
+      onChange={setPage}
+    />
+  );
+}
+render(<NavPag />);
+`,
+
+  Popover: `
+function InfoCliente() {
+  return (
+    <Popover
+      trigger={<Button variant="ghost">Sobre este cliente</Button>}
+      side="bottom"
+      align="start"
+      width={260}
+    >
+      <div style={{ padding: 14 }}>
+        <strong>Silva & Cia</strong>
+        <p style={{ fontSize: 12, color: 'var(--gray-500)', margin: '6px 0 0' }}>
+          CNPJ 12.345.678/0001-90<br/>Ativo desde fev/2024
+        </p>
+      </div>
+    </Popover>
+  );
+}
+render(<InfoCliente />);
+`,
+
+  Progress: `
+function ProgressoImportacao() {
+  const [v, setV] = React.useState(68);
+  return (
+    <div style={{ width: 360, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <Progress value={v} label="Importando extratos" showValue />
+      <div style={{ display: 'flex', gap: 6 }}>
+        <Button size="sm" onClick={() => setV(Math.max(0, v - 10))}>-10</Button>
+        <Button size="sm" onClick={() => setV(Math.min(100, v + 10))}>+10</Button>
+      </div>
+    </div>
+  );
+}
+render(<ProgressoImportacao />);
+`,
+
+  Radio: `
+function PlanoComercial() {
+  const [plano, setPlano] = React.useState("essencial");
+  return (
+    <RadioGroup name="plano" value={plano} onChange={setPlano}>
+      <Radio value="basico"    label="Básico"    description="Até 1 empresa, 500 lançamentos/mês" />
+      <Radio value="essencial" label="Essencial" description="Até 5 empresas, 5k lançamentos/mês" />
+      <Radio value="pro"       label="Pro"       description="Empresas ilimitadas, suporte prioritário" />
+    </RadioGroup>
+  );
+}
+render(<PlanoComercial />);
+`,
+
+  Reconciliation: `
+function Match() {
+  return (
+    <div style={{ width: 600 }}>
+      <Reconciliation
+        status="match"
+        confidence="high"
+        left={{
+          title: "PIX SILVA CIA LTDA",
+          subtitle: "Extrato bancário · 15/04",
+          amount: "R$ 3.400,00",
+        }}
+        right={{
+          title: "Silva & Cia — NF 2841",
+          subtitle: "ERP · 15/04",
+          amount: "R$ 3.400,00",
+        }}
+      />
+    </div>
+  );
+}
+render(<Match />);
+`,
+
+  Select: `
+function SeletorConta() {
+  const [conta, setConta] = React.useState("itau");
+  return (
+    <div style={{ width: 280 }}>
+      <Select value={conta} onChange={(e) => setConta(e.target.value)}>
+        <option value="itau">Itaú · Corrente 12345-6</option>
+        <option value="bb">Banco do Brasil · Poupança 98765-4</option>
+        <option value="nu">Nubank · Corrente 00123-8</option>
+      </Select>
+    </div>
+  );
+}
+render(<SeletorConta />);
+`,
+
+  Separator: `
+function Secoes() {
+  return (
+    <div style={{ width: 360 }}>
+      <p style={{ margin: 0 }}>Configurações da empresa</p>
+      <Separator />
+      <p style={{ margin: '12px 0 0' }}>Integrações bancárias</p>
+      <Separator label="OU" />
+      <p style={{ margin: '12px 0 0' }}>Importar manualmente</p>
+    </div>
+  );
+}
+render(<Secoes />);
+`,
+
+  SidebarNav: `
+function Nav() {
+  const [active, setActive] = React.useState("conciliar");
+  const mk = (k) => ({ active: active === k, onClick: () => setActive(k) });
+  return (
+    <div style={{ display: 'inline-block', border: '1px solid var(--border)', borderRadius: "var(--radius-xl)", overflow: 'hidden', background: '#fff' }}>
+      <SidebarNav>
+        <SidebarNav.Item icon="home"              {...mk("visao")}>Visão geral</SidebarNav.Item>
+        <SidebarNav.Item icon="arrow-left-right"  {...mk("conciliar")}>Conciliar</SidebarNav.Item>
+        <SidebarNav.Item icon="users"             {...mk("clientes")} badge="12">Clientes</SidebarNav.Item>
+        <SidebarNav.Item icon="bar-chart"         {...mk("relatorios")}>Relatórios</SidebarNav.Item>
+      </SidebarNav>
+    </div>
+  );
+}
+render(<Nav />);
+`,
+
+  Skeleton: `
+function Carregando() {
+  return (
+    <div style={{ width: 360, display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <Skeleton variant="text" width="70%" />
+      <Skeleton variant="text" width="90%" />
+      <Skeleton variant="rect" height={120} />
+      <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+        <Skeleton variant="circle" width={32} height={32} />
+        <Skeleton variant="text" width="50%" />
+      </div>
+    </div>
+  );
+}
+render(<Carregando />);
+`,
+
+  Slider: `
+function LimiarConfianca() {
+  const [v, setV] = React.useState(85);
+  return (
+    <div style={{ width: 360 }}>
+      <label style={{ fontSize: 12, color: 'var(--gray-500)', marginBottom: 6, display: 'block' }}>
+        Limiar de auto-aprovação
+      </label>
+      <Slider
+        value={v}
+        min={50}
+        max={99}
+        suffix="%"
+        showValue
+        onChange={(e) => setV(+e.target.value)}
+      />
+    </div>
+  );
+}
+render(<LimiarConfianca />);
+`,
+
+  Spinner: `
+function Carga() {
+  return (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+      <span style={{ fontSize: 13, color: 'var(--gray-500)' }}>Processando extrato…</span>
+    </div>
+  );
+}
+render(<Carga />);
+`,
+
+  Stepper: `
+function Onboarding() {
+  const [step, setStep] = React.useState(1);
+  const steps = [
+    { id: "1", title: "Criar conta",      description: "CNPJ validado" },
+    { id: "2", title: "Conectar banco",   description: "Open Finance" },
+    { id: "3", title: "Importar extrato", description: "OFX ou automático" },
+    { id: "4", title: "Configurar regras" },
+    { id: "5", title: "Revisar" },
+  ];
+  return (
+    <div style={{ width: 640 }}>
+      <Stepper steps={steps} activeIndex={step} onStepClick={setStep} />
+      <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 22, borderTop: "1px solid var(--gray-100)", paddingTop: 16 }}>
+        <Button variant="ghost" size="sm" disabled={step === 0} onClick={() => setStep(Math.max(0, step - 1))}>Voltar</Button>
+        <Button variant="primary" size="sm" disabled={step >= steps.length - 1} onClick={() => setStep(Math.min(steps.length - 1, step + 1))}>Avançar</Button>
+      </div>
+    </div>
+  );
+}
+render(<Onboarding />);
+`,
+
+  Tabs: `
+function DetalhesCliente() {
+  const [tab, setTab] = React.useState("lancamentos");
+  const items = [
+    { value: "lancamentos", label: "Lançamentos", badge: "248" },
+    { value: "extratos",    label: "Extratos" },
+    { value: "config",      label: "Configurações", icon: "settings" },
+  ];
+  return (
+    <div style={{ width: 520 }}>
+      <Tabs value={tab} onChange={setTab} items={items} variant="underline" />
+      <div style={{ padding: '14px 2px', fontSize: 13, color: 'var(--gray-500)' }}>
+        {tab === "lancamentos" && "248 lançamentos em abril"}
+        {tab === "extratos"    && "3 contas conectadas"}
+        {tab === "config"      && "Limiar atual: 85%"}
+      </div>
+    </div>
+  );
+}
+render(<DetalhesCliente />);
+`,
+
+  Textarea: `
+function NotaRevisao() {
+  const [nota, setNota] = React.useState("");
+  return (
+    <div style={{ width: 360 }}>
+      <Textarea
+        placeholder="Motivo da rejeição..."
+        value={nota}
+        onChange={(e) => setNota(e.target.value)}
+        rows={4}
+        maxLength={280}
+        showCount
+      />
+    </div>
+  );
+}
+render(<NotaRevisao />);
+`,
+
+  Timeline: `
+function HistoricoLancamento() {
+  const items = [
+    { id: "1", title: "Lançamento criado",             timestamp: "14/04 · 09:12", icon: "plus",     tone: "neutral" },
+    { id: "2", title: "Match sugerido pelo agente",    timestamp: "14/04 · 09:13", icon: "sparkles", tone: "violet",
+      description: "Silva & Cia — NF 2841 · confiança 98%" },
+    { id: "3", title: "Aprovado automaticamente",      timestamp: "14/04 · 09:13", icon: "check",    tone: "green" },
+    { id: "4", title: "Exportado para ERP",            timestamp: "14/04 · 09:15", icon: "upload",   tone: "neutral" },
+  ];
+  return (
+    <div style={{ width: 440 }}>
+      <Timeline items={items} />
+    </div>
+  );
+}
+render(<HistoricoLancamento />);
+`,
+
+  Toast: `
+function Demo() {
+  const toast = useToast();
+  return (
+    <div style={{ display: 'flex', gap: 8 }}>
+      <Button onClick={() => toast.show({ type: "success", title: "248 lançamentos aprovados" })}>Sucesso</Button>
+      <Button onClick={() => toast.show({ type: "danger",  title: "Falha ao conectar ao Itaú" })}>Erro</Button>
+      <Button onClick={() => toast.show({ type: "info",    title: "Nova versão disponível",
+                                          description: "Atualize para ver as novidades." })}>Info</Button>
+    </div>
+  );
+}
+function App() {
+  return (
+    <ToastProvider>
+      <Demo />
+    </ToastProvider>
+  );
+}
+render(<App />);
+`,
+
+  Tree: `
+function PlanoDeContas() {
+  const [selected, setSelected] = React.useState(["1.1.02"]);
+  const nodes = [
+    { id: "1", label: "1 · Ativo", icon: "wallet", defaultExpanded: true, children: [
+      { id: "1.1", label: "1.1 · Circulante", icon: "folder", defaultExpanded: true, children: [
+        { id: "1.1.01", label: "1.1.01 · Caixa",   icon: "file-text", meta: "R$ 12.430,00" },
+        { id: "1.1.02", label: "1.1.02 · Bancos",  icon: "file-text", meta: "R$ 184.721,55" },
+        { id: "1.1.03", label: "1.1.03 · Clientes",icon: "file-text", meta: "R$ 41.892,10" },
+      ]},
+      { id: "1.2", label: "1.2 · Não Circulante", icon: "folder", children: [
+        { id: "1.2.01", label: "1.2.01 · Imobilizado", icon: "file-text", meta: "R$ 320.000,00" },
+      ]},
+    ]},
+    { id: "3", label: "3 · Receita", icon: "trending-up", children: [
+      { id: "3.1", label: "3.1 · Operacional", icon: "file-text", meta: "R$ 890.500,00" },
+    ]},
+  ];
+  return (
+    <div style={{ width: 420, background: "var(--surface)", border: "1px solid var(--gray-200)", borderRadius: 10, padding: "12px 10px" }}>
+      <Tree nodes={nodes} mode="single" selected={selected} onSelectedChange={setSelected} />
+    </div>
+  );
+}
+render(<PlanoDeContas />);
+`,
+
+  Tooltip: `
+function CabecalhoComDica() {
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <strong>Confiança</strong>
+      <Tooltip content="Probabilidade de o match estar correto, calculada pelo modelo.">
+        <span style={{
+          width: 18, height: 18, borderRadius: "var(--radius-pill)",
+          background: 'var(--violet-100)', color: 'var(--violet-500)',
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 11, fontWeight: 700, cursor: 'help',
+        }}>?</span>
+      </Tooltip>
+    </div>
+  );
+}
+render(<CabecalhoComDica />);
+`,
+
+  TopBar: `
+function Topo() {
+  return (
+    <div style={{ width: 720, border: '1px solid var(--border)', borderRadius: "var(--radius-xl)", overflow: 'hidden' }}>
+      <TopBar
+        left={<strong style={{ color: 'var(--violet-500)' }}>Guardia</strong>}
+        center={
+          <Input
+            placeholder="Buscar cliente, lançamento, agente..."
+            leftIcon="search"
+            size="sm"
+            style={{ minWidth: 320 }}
+          />
+        }
+        right={
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <IconButton icon="bell"        aria-label="Notificações" />
+            <IconButton icon="help-circle" aria-label="Ajuda" />
+            <Avatar name="Ana Lima" color="violeta" size="sm" />
+          </div>
+        }
+      />
+    </div>
+  );
+}
+render(<Topo />);
+`,
+
+  Alert: `
+function AvisoRevisao() {
+  const [shown, setShown] = React.useState(true);
+  if (!shown) return <Button onClick={() => setShown(true)}>Reexibir alerta</Button>;
+  return (
+    <div style={{ width: 520 }}>
+      <Alert
+        type="warning"
+        title="Revisão humana necessária"
+        closable
+        onClose={() => setShown(false)}
+      >
+        3 lançamentos estão abaixo do limiar de confiança configurado (85%).
+      </Alert>
+    </div>
+  );
+}
+render(<AvisoRevisao />);
+`,
+
+  Logo: `
+function AppIcons() {
+  return (
+    <div style={{ display: "flex", gap: 18, alignItems: "center" }}>
+      <Logo size={48} />
+      <Logo variant="rounded-purple" size={48} />
+      <Logo variant="rounded-orange" size={48} />
+      <Logo variant="mono-black" size={48} />
+    </div>
+  );
+}
+render(<AppIcons />);
+`,
+
+  Logotipo: `
+function Header() {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 16, padding: "14px 20px", background: "#fff", border: "1px solid var(--border)", borderRadius: 8 }}>
+      <Logotipo height={28} />
+      <span style={{ fontSize: 13, color: "var(--gray-500)" }}>· Painel financeiro</span>
+    </div>
+  );
+}
+render(<Header />);
+`,
+
+};

--- a/ux_references/ui_kits/components/_shared/shared.css
+++ b/ux_references/ui_kits/components/_shared/shared.css
@@ -1,0 +1,228 @@
+/* Shared helpers used by every component playground */
+/* Imported AFTER colors_and_type.css                */
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  color: var(--fg);
+  background: var(--bg);
+  padding: 28px 32px;
+  min-height: 100vh;
+}
+
+/* Playground scaffolding */
+.pg-hdr { margin-bottom: 18px; }
+.pg-eyebrow {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--gray-500);
+}
+.pg-title {
+  margin: 4px 0 2px; font-size: 22px; font-weight: 700;
+  letter-spacing: -0.015em; color: var(--violet-500);
+}
+.pg-codename {
+  display: inline-block; font-family: var(--font-mono); font-size: 11px;
+  color: var(--violet-700); background: var(--violet-100);
+  padding: 2px 8px; border-radius: var(--radius-pill); margin-top: 6px;
+}
+.pg-desc {
+  font-size: 13px; color: var(--gray-500); line-height: 1.5;
+  max-width: 720px; margin: 10px 0 0;
+}
+
+/* Section (preview stage) */
+.pg-sec { margin-top: 22px; }
+.pg-sec-title {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--gray-500); margin: 0 0 10px;
+}
+.pg-stage {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  display: flex; flex-wrap: wrap; gap: 14px; align-items: center;
+}
+.pg-stage.col { flex-direction: column; align-items: stretch; gap: 12px; }
+.pg-stage.center { justify-content: center; }
+.pg-stage.dark { background: #1F092B; color: #fff; }
+
+/* Example of use — pairs a preview with its source code side by side.
+   On narrow screens, code stacks below the preview. */
+.pg-example {
+  margin-top: 22px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: #fff;
+}
+.pg-example-hdr {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 16px; border-bottom: 1px solid var(--border);
+  background: #FAF8FC;
+}
+.pg-example-hdr .t {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--gray-500);
+}
+.pg-example-hdr .h {
+  font-size: 11px; color: var(--violet-500); font-family: var(--font-mono);
+}
+
+/* SourceViewer tabs — pill segmented control */
+.sv-tabs {
+  display: inline-flex; align-items: center; gap: 10px;
+}
+.sv-tabs-seg {
+  display: inline-flex; align-items: center; gap: 2px;
+  padding: 3px;
+  background: #F1ECF5;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+.sv-tab {
+  appearance: none; border: 0; cursor: pointer;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--gray-500);
+  padding: 4px 10px;
+  border-radius: 4px;
+  letter-spacing: 0.01em;
+  transition: background .14s var(--ease-standard), color .14s var(--ease-standard);
+}
+.sv-tab:hover { color: var(--violet-700); }
+.sv-tab.is-active {
+  background: #FFFFFF;
+  color: var(--violet-700);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(47, 14, 64, .08);
+}
+.sv-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--gray-300);
+  font-variant-numeric: tabular-nums;
+}
+.pg-example-body {
+  display: flex;
+  flex-direction: column;
+}
+.pg-example-preview {
+  padding: 28px;
+  display: flex; flex-wrap: wrap; gap: 14px; align-items: center; justify-content: center;
+  border-bottom: 1px solid var(--border);
+  min-height: 120px;
+}
+.pg-example-code {
+  margin: 0; padding: 18px 22px;
+  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.65;
+  color: #DBD0E1; background: #1F092B;
+  overflow: auto;
+  max-height: 540px;
+  white-space: pre;
+  tab-size: 2;
+}
+.pg-example-preview { overflow: auto; }
+.pg-example-code .tok-kw  { color: #F59E67; }           /* keyword */
+.pg-example-code .tok-tag { color: #C4B5FD; }           /* JSX tag  */
+.pg-example-code .tok-attr{ color: #F0B7E4; }           /* attr     */
+.pg-example-code .tok-str { color: #FFD7A8; }           /* string   */
+.pg-example-code .tok-com { color: #9E8AA9; font-style: italic; }
+.pg-example-code .tok-punct { color: #9E8AA9; }
+.pg-example-code .tok-num { color: #FCA5A5; }
+
+/* Live editor: highlighted <pre> underneath, transparent editable <pre> on top */
+.pg-live-editor {
+  position: relative;
+  background: #1F092B;
+  min-height: 200px;
+  max-height: 540px;
+  overflow: auto;
+}
+.pg-live-editor .pg-live-hl,
+.pg-live-editor .pg-live-ed {
+  margin: 0;
+  padding: 18px 22px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.65;
+  tab-size: 2;
+  white-space: pre;
+  word-wrap: normal;
+  overflow-wrap: normal;
+}
+.pg-live-editor .pg-live-hl {
+  position: absolute; top: 0; left: 0; right: 0;
+  color: #DBD0E1;
+  pointer-events: none;
+  user-select: none;
+  /* cresce com o conteúdo; não limita a altura do editor */
+  min-height: 100%;
+}
+.pg-live-editor .pg-live-ed {
+  position: relative;
+  color: transparent;
+  caret-color: #FFD7A8;
+  background: transparent;
+  outline: none;
+  min-height: 100%;
+  /* garante que o editor define a altura do container */
+  box-sizing: border-box;
+}
+.pg-live-editor .pg-live-ed::selection { background: rgba(219, 98, 134, 0.35); color: transparent; }
+.pg-live-editor .pg-live-ed:focus { box-shadow: inset 0 0 0 1px rgba(255, 215, 168, 0.45); }
+
+.pg-example.pg-example-err .pg-live-editor { box-shadow: inset 0 -2px 0 #FF7A7A; }
+.pg-live-err {
+  font-family: var(--font-mono); font-size: 11px;
+  color: #fff; background: #7A1F1F;
+  padding: 8px 16px; border-top: 1px solid #FF7A7A;
+  white-space: pre-wrap; word-break: break-word;
+}
+
+/* API table */
+.pg-api {
+  margin-top: 18px; width: 100%; border-collapse: collapse;
+  font-size: 13px; background: #fff;
+  border: 1px solid var(--border); border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.pg-api th, .pg-api td { text-align: left; padding: 9px 14px; border-bottom: 1px solid var(--border); }
+.pg-api tr:last-child td { border-bottom: none; }
+.pg-api th {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--gray-500); background: #FAF8FC;
+}
+.pg-api td code {
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--violet-700); background: var(--violet-100);
+  padding: 1px 6px; border-radius: var(--radius-sm);
+}
+.pg-api td.desc { color: var(--gray-500); }
+
+/* Usar / Evitar — guidelines de uso */
+.pg-usage-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-top: 18px;
+}
+@media (max-width: 780px) { .pg-usage-grid { grid-template-columns: 1fr; } }
+.pg-usage, .pg-antiuse {
+  padding: 14px 16px; border-radius: var(--radius-md);
+  font-size: 12.5px; line-height: 1.55;
+  border: 1px solid;
+}
+.pg-usage    { background: var(--success-soft); border-color: #A9E6C8; color: #0A5A30; }
+.pg-antiuse  { background: var(--danger-soft);  border-color: #F2B0B0; color: #7A1616; }
+.pg-usage strong, .pg-antiuse strong {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase;
+  margin-bottom: 8px; font-weight: 700;
+}
+.pg-usage strong::before   { content: "✓"; font-size: 13px; }
+.pg-antiuse strong::before { content: "✕"; font-size: 13px; }
+.pg-usage ul, .pg-antiuse ul { margin: 0; padding-left: 18px; }
+.pg-usage li, .pg-antiuse li { margin-bottom: 4px; }
+.pg-usage li:last-child, .pg-antiuse li:last-child { margin-bottom: 0; }


### PR DESCRIPTION
Closes #229

## Summary

Adds `ux_references/` to `main` as a versioned read-only snapshot of the legacy `wip/` bundle — the canonical visual source of truth for the 31 remaining v0.1.0 DoD component migrations.

**Trigger**: review do PR #225 (Tabs) revelou drift visual significativo. A migração adotou defaults do shadcn e perdeu DNA da marca:
- 3 variantes visuais (`underline` / `pills` / `boxed`) → reduzidas a 1 (shadcn pill)
- Props `icon` + `badge` por item → removidas
- Cor de marca `violet-700` no estado ativo → substituída por neutro `bg-background`

Sem fonte da verdade versionada (bundle `wip/` era gitignored), próximas migrações estavam no mesmo risco. Esse snapshot fecha o gap.

## Scope

- **165 arquivos**, ~1.1MB, zero binários pesados
- **51 componentes** em `ux_references/ui_kits/components/{Component}/` com `{Component}.playground.html` + `index.tsx` + `index.css`
- **`_shared/`** com Icon.tsx, shared.css, babel-tsx-preset.js, highlight.js, live-examples.js, LiveCode.tsx, SourceViewer.tsx
- **README.md** documentando a stack original (React 18.3.1 + Babel standalone + CSS prefixado `grd-*`)

**Out of scope:** modificação de qualquer componente atual em `ui_kit/`; alteração do `.gitignore` para `wip/` (mantém-se); toques em código de produção.

## Companion change (já aplicado fora deste PR)

As 62 issues abertas de migração v0.1.0 DoD (31 parent + 31 Plan) já foram atualizadas em batch para apontar este path no DoD do Playground e em nova seção `## Referência visual`. Ver issues #54 a #117 (parent) e correspondentes Plans.

## Test plan

- [ ] Inspeção visual do diff: 100% additions, nenhuma modificação de código existente
- [ ] CI green (build + typecheck + lint + test)
- [ ] Verificar pelo menos 1 playground HTML abre standalone no browser (não há dependência de build)
- [ ] Confirmar que `.gitignore` do `wip/` segue intacto

## Notas

- Snapshot é **read-only**: futuras alterações em componentes devem acontecer em `ui_kit/components/`, não aqui. `ux_references/` permanece como referência histórica fixa.
- Migrações que detectarem divergência intencional vs referência DEVEM registrar justificativa na Architecture (Fase 3) per template das issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)