### PR TITLE
docs(adr): propose ADR-008 — adopt AG-UI / CopilotKit as Generative UI protocol on Bedrock

### DIFF
--- a/docs/adr/ADR-008-ag-ui-generative-ui-protocol-on-bedrock.md
+++ b/docs/adr/ADR-008-ag-ui-generative-ui-protocol-on-bedrock.md
@@ -33,6 +33,48 @@ A escolha de AG-UI repousa em três propriedades que nenhuma alternativa entrega
 - **Não escolhe o framework backend do agente.** Bedrock AgentCore Runtime hospeda agentes de várias origens (Mastra-on-AgentCore, LangGraph-on-AgentCore, ou um agente "naked" sobre o Converse API). Esta ADR só exige que o backend exponha um endpoint AG-UI conforme; a escolha do framework agêntico é uma decisão separada.
 - **Não congela CopilotKit como única lib cliente.** CopilotKit é a referência hoje; se um cliente AG-UI alternativo surgir e for mais alinhado com o stack, a substituição é permitida desde que respeite o mesmo protocolo (o catálogo do DS continua funcionando).
 
+### Cenário concreto — braço analítico do financial-context com consulta ad-hoc
+
+A escolha do protocolo fica concreta no caso típico de Isac sendo usado pelo cliente final. Considere a pergunta `"me mostre receita por categoria nos últimos 3 meses"`: a sessão Claude no thread roteia pro **braço analítico do bounded context `financial-context`** (agente especialista hospedado em Bedrock AgentCore), que precisa (a) decidir qual consulta ad-hoc rodar, (b) executar contra a fonte de dados do contexto, e (c) compor a resposta visual que aparece no thread.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Cliente
+    participant IsacUI as Isac UI<br/>(CopilotKit + AG-UI client)
+    participant AgentCore as Bedrock<br/>AgentCore Runtime
+    participant FinAgent as financial-context<br/>braço analítico
+    participant Claude
+    participant FinData as financial-context<br/>data source
+    participant Dispatcher as @guardia/design-system/agent<br/>(dispatcher Zod)
+
+    Cliente->>IsacUI: "Mostre receita por categoria<br/>nos últimos 3 meses"
+    IsacUI->>AgentCore: AG-UI message (turno do usuário)
+    AgentCore->>FinAgent: roteia pro agente do contexto
+
+    Note over FinAgent,FinData: Loop ad-hoc — Claude propõe query, agente executa
+    FinAgent->>Claude: prompt + tools<br/>(query_revenue, list_categories, ...)
+    Claude-->>FinAgent: tool_call(query_revenue,<br/>period=3m, group_by=category)
+    FinAgent->>FinData: SQL ad-hoc gerado
+    FinData-->>FinAgent: dataset (rows)
+    FinAgent->>Claude: tool_result(dataset)<br/>+ pedido de composição visual
+    Claude-->>FinAgent: AG-UI tool_calls:<br/>Card > Chart(bars) + Table(rows)
+
+    Note right of FinAgent: brand-voice filter<br/>server-side (salvaguarda)
+    FinAgent->>AgentCore: stream AG-UI events (filtrados)
+    AgentCore-->>IsacUI: SSE: TOOL_CALL_*<br/>(incremental)
+
+    Note over IsacUI,Dispatcher: Salvaguardas client-side
+    IsacUI->>Dispatcher: dispatch(toolCall)
+    Dispatcher->>Dispatcher: Zod.parse(props) OK
+    Dispatcher->>Dispatcher: axe-core runtime OK
+    Dispatcher-->>IsacUI: React tree<br/>Card / Chart / Table
+
+    IsacUI->>Cliente: renderiza no thread<br/>(progressivo, conforme chega)
+```
+
+O loop ad-hoc (passos 4–8) é o que justifica a escolha de Bedrock AgentCore + AG-UI: cada turno Claude pode propor uma nova ferramenta de consulta, o agente executa, e o resultado realimenta o próximo turno até a composição visual estar pronta. O AG-UI carrega o resultado como uma sequência de `TOOL_CALL_*` que o dispatcher do DS valida com Zod antes de virar React tree — a árvore final (`Card > Chart + Table`) é decidida pelo Claude no último turno, não pré-registrada como template.
+
 ## Decision 2 — A decisão é cross-repo: DS + Isac + demais widget exporters
 
 **Adotado:** a adoção de AG-UI/CopilotKit é uma decisão de **arquitetura horizontal**, não de uma biblioteca local. Tem três superfícies de execução simultâneas, com responsabilidades distintas:
@@ -48,6 +90,46 @@ O inventário definitivo de "demais projetos que exportam widgets" é **out of s
 ### Por que a decisão precisa ser declarada cross-repo aqui
 
 Se essa ADR fosse só "o DS expõe descritores", os consumidores ficariam livres pra inventar outro protocolo cliente. Resultado previsível: dois caminhos divergentes em produção, dobro de manutenção, e violação prática de `lex-design-system-library` (porque cada consumer reinventaria a integração). Declarar o escopo aqui — neste ADR neste repo — fixa a expectativa pra todos os consumidores **antes** da divergência acontecer.
+
+### Topologia cross-repo
+
+```mermaid
+flowchart LR
+    subgraph DS["@guardia/design-system (este repo) — Catálogo agêntico"]
+        Catalog["entry-point<br/>@guardia/design-system/agent"]
+        Descriptors["descritores<br/>name + propsSchema (Zod) + render"]
+        Primitives["primitivas DS<br/>Alert · Card · Button<br/>Badge · Chart · Table · ..."]
+        Catalog --- Descriptors
+        Descriptors --- Primitives
+    end
+
+    subgraph Isac["Isac — consumer primário"]
+        IsacClient["@copilotkit/react-core<br/>+ dispatcher do DS"]
+    end
+
+    subgraph Other["Demais widget exporters"]
+        OtherClient["dashboards · embeds<br/>fluxos auditados · ..."]
+    end
+
+    subgraph Bedrock["AWS Bedrock AgentCore Runtime"]
+        Endpoint["AG-UI endpoint nativo<br/>(FAST template)"]
+        subgraph Agents["Agentes especialistas por bounded context"]
+          FinAgent["financial-context<br/>braço analítico"]
+          FiscAgent["fiscal-context"]
+          MoreAgents["outros contextos..."]
+        end
+        Claude["Claude (Opus / Sonnet)"]
+        Endpoint --> Agents
+        Agents --> Claude
+    end
+
+    Catalog -.->|"npm import"| IsacClient
+    Catalog -.->|"npm import"| OtherClient
+    IsacClient <==>|"AG-UI / SSE"| Endpoint
+    OtherClient <==>|"AG-UI / SSE"| Endpoint
+```
+
+Cada flecha sólida (`<==>`) representa comunicação em runtime (AG-UI/SSE entre cliente e Bedrock AgentCore Runtime); cada flecha tracejada (`-.->`) representa dependência de build/distribuição (import npm do entry-point `@guardia/design-system/agent`). O catálogo do DS é o ponto único de declaração das primitivas agênticas: trocar uma prop, adicionar um descritor ou apertar uma validação Zod acontece **neste repo**, e os consumidores recebem via bump de versão coordenado.
 
 ### Coordenação de versionamento (esboço, decisão pós-PoC)
 
@@ -65,6 +147,38 @@ A primeira versão do entry-point `@guardia/design-system/agent` será publicada
 | **Confirmação explícita pra ações irreversíveis** | `lex-ai-first-experience` é categórica: ações irreversíveis exigem confirmação. Um widget `<Button intent="primary">Aprovar</Button>` gerado pelo agente **não pode** auto-executar a aprovação no `onClick`. O catálogo agêntico só permite registrar o **descritor visual** da ação; a execução é wrap'd numa primitiva de confirmação (`<ConfirmAction>`) que o consumer plumbiza. | `@guardia/design-system/agent` (forma do descritor) + Isac (plumbing) |
 
 Essas salvaguardas são parte do PoC, não trabalho pós-PoC. Sem elas a stack não é Lex-compliant.
+
+### Ciclo de vida de um widget gerado e os 4 portões
+
+```mermaid
+flowchart TB
+    Start([Agente compõe widget<br/>e emite AG-UI tool_call])
+
+    Start --> G1{1. brand-voice filter<br/>server-side}
+    G1 -->|"buzzword detectado"| G1Fail[bloqueia o field<br/>log pra ajustar prompt]
+    G1 -->|OK| Stream[stream AG-UI<br/>chega ao cliente]
+
+    Stream --> G2{2. Zod.parse<br/>no dispatcher do DS}
+    G2 -->|"prop inválida<br/>intent=awesome"| G2Fail["fallback Alert tone=warning<br/>(degradação graciosa)"]
+    G2 -->|OK| G3{3. axe-core<br/>runtime check}
+
+    G3 -->|"violação crítica<br/>(role conflict, missing label)"| G3Fail[bloqueia render<br/>log a11y]
+    G3 -->|OK| G4{4. ação irreversível?<br/>Approve · Delete · Send}
+
+    G4 -->|sim| Wrap["wrap em ConfirmAction<br/>(per lex-ai-first-experience)"]
+    G4 -->|não| Render
+    Wrap --> Render([widget no DOM])
+
+    style G1 fill:#e8f0ff,stroke:#4f86c6
+    style G2 fill:#e8f0ff,stroke:#4f86c6
+    style G3 fill:#e8f0ff,stroke:#4f86c6
+    style G4 fill:#e8f0ff,stroke:#4f86c6
+    style G1Fail fill:#ffe8e8,stroke:#c64f4f
+    style G3Fail fill:#ffe8e8,stroke:#c64f4f
+    style G2Fail fill:#fff5e8,stroke:#c69d4f
+```
+
+Os 4 portões são sequenciais e não-opcionais. Portões **1** e **4** dependem de plumbing fora do DS (filtro server-side no backend agêntico; wrapper de confirmação no consumer); portões **2** e **3** são entregues pelo dispatcher exportado de `@guardia/design-system/agent` — habilitados por construção pra todo widget que passar por ele. Sem o dispatcher central, cada consumer ficaria livre pra pular portões em silêncio; esse risco é o motivo principal de o catálogo ser exposto via dispatcher único, não como componentes "soltos" que o consumer instancia direto.
 
 ## Consequences
 

--- a/docs/adr/ADR-008-ag-ui-generative-ui-protocol-on-bedrock.md
+++ b/docs/adr/ADR-008-ag-ui-generative-ui-protocol-on-bedrock.md
@@ -1,0 +1,128 @@
+# ADR-008 — Adopt AG-UI / CopilotKit as the Generative UI protocol on Bedrock
+
+- **Status:** proposed
+- **Date:** 2026-05-28
+- **Deciders:** Fernando Seguim (review pendente da squad-theros)
+- **Issue:** [#246](https://github.com/guardiatechnology/design-system/issues/246)
+- **Supersedes:** none. **Complements:** [ADR-005](ADR-005-popover-api-shape-and-token-alignment.md) (token contract that any generated widget MUST inherit).
+
+## Context
+
+A experiência ponta-a-ponta da Guardia é AI-First por construção: per [`lex-ai-first-experience`](../../.claude/rules/design/system/lex-ai-first-experience.md), a conversa com Isac é a superfície primária e o workspace renderiza, em tempo real, artefatos (tabelas, gráficos, formulários, ações) compostos a partir do diálogo. Essa superfície depende de uma camada de **generative UI**: o agente, rodando Claude (Opus/Sonnet) hospedado em **AWS Bedrock**, escolhe primitivas de `@guardia/design-system` em tempo de resposta e as compõe em widgets que aparecem dentro do thread.
+
+Hoje não existe uma decisão formal de como essa camada é construída. Cada surface que precisa renderizar saída agêntica está fazendo escolhas pontuais. O risco prático:
+
+1. **Fragmentação do catálogo agêntico.** Sem um contrato comum, cada consumidor (Isac, dashboards, futuros widget exporters) registra primitivas do DS de um jeito diferente, e o agente passa a depender da forma do consumidor — não da forma do componente. Isso quebra `lex-design-system-library` na prática (cada consumidor reinventa a interface).
+2. **Lock-in de provedor implícito.** Bedrock continua sendo a única superfície de modelo permitida pra Guardia; qualquer escolha de framework precisa ter caminho nativo pra Bedrock, não adapter de terceiro.
+3. **Falta de padronização do modo "ad-hoc estrutural".** Existe diferença material entre o agente *selecionar* uma primitiva pré-registrada (1 widget = 1 tool call) e o agente *compor uma árvore* de primitivas (`<Card>` aninhando `<Card>`). Esse segundo modo é o que entrega a sensação real de "workspace reativo ao diálogo" da `lex-ai-first-experience` — e não existe padrão de facto pra ele fora do AG-UI/A2UI.
+
+Em maio/2026 avaliamos 7 candidatos (compatíveis com Bedrock). O resumo está na seção "Alternativas consideradas" abaixo. Esta ADR formaliza a escolha e — crítico — **declara o escopo cross-repo da decisão**, porque generative UI não é uma escolha local de `@guardia/design-system`.
+
+## Decision 1 — Adoptar AG-UI como protocolo e CopilotKit como implementação de referência
+
+**Adotado:** o protocolo oficial de generative UI da Guardia sobre Bedrock é o **AG-UI** ([github.com/ag-ui-protocol/ag-ui](https://github.com/ag-ui-protocol/ag-ui)), com **CopilotKit** como a implementação cliente de referência (`@copilotkit/react-core` + `@copilotkit/react-ui`). O backend agêntico expõe um endpoint AG-UI hospedado no **AWS Bedrock AgentCore Runtime** (endpoint nativo anunciado em 2026 pelo FAST template da AWS), conversando com Claude na própria conta Bedrock.
+
+A escolha de AG-UI repousa em três propriedades que nenhuma alternativa entrega ao mesmo tempo:
+
+1. **É protocolo, não lib.** Permite que `@guardia/design-system` exponha um catálogo neutro (descritor por componente) que qualquer cliente que fale AG-UI consome — incluindo, no futuro, implementações que não sejam CopilotKit (Mastra também fala AG-UI; novos clientes podem surgir). Reduz o lock-in real ao protocolo aberto, não ao framework cliente.
+2. **Cobre os dois modos de generative UI numa stack única.** O modo 1 (seleção: agente escolhe uma primitiva pré-registrada via `useCopilotAction`) é o caso de uso seguro e majoritário. O modo 2 (composição em árvore, **A2UI**: agente emite `{ component, props, children }` e o renderer caminha a árvore) é o caso de uso aberto, equivalente conceitual a "o agente desenha um Notion-block-tree dentro da resposta". Sem AG-UI/A2UI, o modo 2 precisa ser construído à mão.
+3. **Endorsement direto da AWS no nosso runtime.** O endpoint AG-UI nativo no Bedrock AgentCore Runtime e o FAST template anunciados em 2026 significam que o ciclo de manutenção do protocolo está alinhado com o ciclo de manutenção do nosso provedor de modelo. Reduz o risco de divergência entre o que o protocolo permite e o que o runtime entrega.
+
+### O que esta decisão **não** prescreve
+
+- **Não escolhe o framework backend do agente.** Bedrock AgentCore Runtime hospeda agentes de várias origens (Mastra-on-AgentCore, LangGraph-on-AgentCore, ou um agente "naked" sobre o Converse API). Esta ADR só exige que o backend exponha um endpoint AG-UI conforme; a escolha do framework agêntico é uma decisão separada.
+- **Não congela CopilotKit como única lib cliente.** CopilotKit é a referência hoje; se um cliente AG-UI alternativo surgir e for mais alinhado com o stack, a substituição é permitida desde que respeite o mesmo protocolo (o catálogo do DS continua funcionando).
+
+## Decision 2 — A decisão é cross-repo: DS + Isac + demais widget exporters
+
+**Adotado:** a adoção de AG-UI/CopilotKit é uma decisão de **arquitetura horizontal**, não de uma biblioteca local. Tem três superfícies de execução simultâneas, com responsabilidades distintas:
+
+| Repo | Papel na arquitetura | Responsabilidade canônica |
+|---|---|---|
+| **`guardiatechnology/design-system`** (este repo) | **Catálogo agêntico (single source of truth)** | Expor cada primitiva consumível por agente como um **descritor AG-UI** — `{ name, propsSchema (Zod), render }` — através de um entry-point dedicado (proposta: `@guardia/design-system/agent`). Os schemas Zod codificam o allowlist de props (intent, variant, tone, size) que respeita `lex-design-system-library` e `lex-brand-colors`. Nenhuma primitiva agêntica é definida fora deste repo. |
+| **`guardiatechnology/isac`** (consumidor primário) | **Surface conversacional principal** | Importa os descritores do DS, conecta ao endpoint AG-UI no Bedrock AgentCore Runtime via `@copilotkit/react-core`, e renderiza widgets como parte do thread Isac. É a primeira validação end-to-end do contrato — o que funciona aqui valida o catálogo do DS. |
+| **Demais projetos que exportam widgets** (qualquer surface além de Isac que renderize saída agêntica — dashboards internos, fluxos auditados, embeds, futuras superfícies AI-First) | **Consumidores secundários** | Adotam o **mesmo padrão** que Isac: importam descritores do DS, conectam ao runtime AG-UI, registram a sessão. Não definem primitivas próprias — se uma primitiva faltar, ela vira issue no DS, não no consumer. |
+
+O inventário definitivo de "demais projetos que exportam widgets" é **out of scope deste ADR** e será produzido durante o PoC de Isac (primeira superfície a usar de verdade revela quais outras superfícies precisam do mesmo padrão).
+
+### Por que a decisão precisa ser declarada cross-repo aqui
+
+Se essa ADR fosse só "o DS expõe descritores", os consumidores ficariam livres pra inventar outro protocolo cliente. Resultado previsível: dois caminhos divergentes em produção, dobro de manutenção, e violação prática de `lex-design-system-library` (porque cada consumer reinventaria a integração). Declarar o escopo aqui — neste ADR neste repo — fixa a expectativa pra todos os consumidores **antes** da divergência acontecer.
+
+### Coordenação de versionamento (esboço, decisão pós-PoC)
+
+A primeira versão do entry-point `@guardia/design-system/agent` será publicada sob a faixa `0.x.y` (mesma do DS). Mudanças no formato do descritor têm impacto cross-repo — Isac e demais consumidores precisam atualizar simultaneamente. A política definitiva (semver coordenado vs. independente; janela de deprecação) sai do PoC, não desta ADR.
+
+## Decision 3 — Salvaguardas obrigatórias contra free-authoring do LLM
+
+**Adotado:** a stack AG-UI/CopilotKit **deve** ser entregue com quatro guard-rails que rodam **antes** de qualquer widget gerado pelo agente chegar ao DOM. Sem essas salvaguardas, a adoção do protocolo violaria Lexis existentes na prática.
+
+| Salvaguarda | Por quê | Onde mora |
+|---|---|---|
+| **Validação Zod estrita no dispatcher** | Bedrock **não suporta strict tool mode** — o Claude pode emitir `<Button intent="awesome">` ou `<Alert tone="orange">`. Sem validação, o widget renderiza com prop inválida e quebra `lex-design-system-library` + `lex-brand-colors`. Dispatcher deve rejeitar e degradar pra `<Alert tone="warning">` (mensagem padrão Brand) explicando que o agente emitiu props inválidas. | `@guardia/design-system/agent` (este repo) |
+| **A11y runtime gate** | A11y das primitivas isoladas já é coberta pelo gate `jest-axe` light+dark de cada componente. Mas a **composição** que o agente cria é nova a cada conversa — não está no Storybook, não passa pelo gate de baseline. Em dev mode, axe-core deve rodar sobre cada widget gerado e logar violações; em prod, pelo menos validações estruturais (roles ARIA conflitantes, labels ausentes) bloqueiam o render. Implementa `lex-frontend-accessibility`. | `@guardia/design-system/agent` (utility) + Isac (integration) |
+| **Brand-voice filter server-side** | `lex-brand-voice` proíbe buzzwords ("disruptive", "transformative", "fintech", etc.). O agente Claude **vai** emitir essas palavras sem filtro — sai do treino. Filtro server-side aplica regex de buzzwords em todo string-field dentro do payload do widget (Alert message, Badge label, Button children) antes do payload chegar ao cliente AG-UI. Match → bloqueio do field + log pra correção do prompt do agente. | Backend agêntico (não vive no DS) |
+| **Confirmação explícita pra ações irreversíveis** | `lex-ai-first-experience` é categórica: ações irreversíveis exigem confirmação. Um widget `<Button intent="primary">Aprovar</Button>` gerado pelo agente **não pode** auto-executar a aprovação no `onClick`. O catálogo agêntico só permite registrar o **descritor visual** da ação; a execução é wrap'd numa primitiva de confirmação (`<ConfirmAction>`) que o consumer plumbiza. | `@guardia/design-system/agent` (forma do descritor) + Isac (plumbing) |
+
+Essas salvaguardas são parte do PoC, não trabalho pós-PoC. Sem elas a stack não é Lex-compliant.
+
+## Consequences
+
+### Positivas
+
+- **Single source of truth.** O catálogo agêntico vive em um lugar (`@guardia/design-system/agent`); consumidores deixam de ter incentivo pra reinventar primitivas.
+- **Caminho da AWS.** Roadmap de runtime alinhado com o protocolo reduz risco de divergência runtime↔protocolo.
+- **Ad-hoc estrutural coberto.** A2UI dá o vocabulário pra "agente compõe árvore de DS components" sem que cada combinação precise ser pré-registrada como tool.
+- **Catálogo é asset Brand.** Forçar os widgets agênticos a passar por descritores tipados é o ponto natural pra aplicar `lex-brand-colors` / `lex-brand-typography` / `lex-brand-voice` programaticamente — algo que hoje vive em PR review.
+
+### Negativas / a mitigar
+
+- **Lock-in protocolar.** Substituir AG-UI por outro protocolo (assistant-ui message protocol, A2A, outro) é migração não-trivial — afeta DS + Isac + demais consumers simultaneamente. Mitigação: o lock-in é no protocolo *aberto*, não num vendor; CopilotKit pode ser substituído por outro cliente AG-UI sem mexer no DS.
+- **Bedrock AgentCore + AG-UI são recentes (2026).** Há features em preview (prompt caching, Guardrails no provider AG-UI). Custo/latência precisam de validação empírica no PoC, não dá pra extrapolar de benchmarks externos.
+- **Strict tool mode ausente no Bedrock.** Mitigado por **Decision 3**: Zod no dispatcher. Sem isso, a stack quebra Lex em produção.
+- **Coordenação multi-repo é custo recorrente.** Cada mudança no formato do descritor exige bump coordenado DS → Isac → outros. Mitigação: a política de versionamento (saída do PoC) trata disso explicitamente; até lá, mudanças de schema são raras e anunciadas.
+- **A11y/Brand runtime gates são novas superfícies de teste.** Adicionar axe-core runtime e brand-voice filter não é trivial — são responsabilidades novas tanto pro DS quanto pro backend agêntico. Mitigação: tratadas como Tech Tasks separadas, paralelas ao PoC.
+- **PoC do AG-UI exige cooperação de pelo menos 2 repos (DS + Isac).** Esta ADR fica **proposed** até que a squad-theros confirme o plano cross-repo; aceitação prematura sem essa coordenação cria expectativa que o DS não cumpre sozinho.
+
+## Alternativas consideradas
+
+| Alternativa | Por que rejeitada |
+|---|---|
+| **`assistant-ui` + Vercel AI SDK 5 + `@ai-sdk/amazon-bedrock`** | Maturidade alta, lock-in baixo, CSR puro — caminho excelente pra **modo 1** (seleção). Rejeitado porque (a) não há protocolo padronizado pra modo 2 (ad-hoc estrutural / A2UI) — teríamos que construir; (b) é uma lib React, não um protocolo, então o catálogo do DS fica acoplado à API do assistant-ui; outros consumidores que não sejam React-first ficam sem caminho. **Mantido como fallback documentado** caso o PoC do AG-UI revele bloqueador estrutural. |
+| **Bedrock SDK direto (`@aws-sdk/client-bedrock-runtime`) + dispatcher próprio** | Zero lock-in. Rejeitado porque seria reconstruir do zero o que AG-UI/A2UI já entrega: streaming de tool calls, render incremental, composição em árvore, sessões com state. Custo alto pra paridade, sem ganho compatível. Mantido como **baseline mental** (referência pra estimar se a abstração adicionada por AG-UI vale a complexidade). |
+| **Mastra** | Backend-only — não resolve a camada UI. Combinaria com CopilotKit ou assistant-ui no front. Decisão sobre Mastra é independente desta ADR (é uma escolha de framework do agente, não de protocolo UI). Pode ser adotada *em adição* a AG-UI no backend. |
+| **LangChain.js + `@langchain/aws`** | Backend-only — mesma observação que Mastra. Decisão independente. |
+| **CopilotKit standalone (sem AG-UI explícito)** | CopilotKit *é* a implementação de referência de AG-UI; usar "CopilotKit sem AG-UI" só faz sentido se o backend não falar o protocolo, e nesse caso perdemos o endpoint nativo do Bedrock AgentCore. Não é uma alternativa real, é uma versão diluída da decisão escolhida. |
+| **Thesys C1** | Força adoção do design system deles (Crayon). **Viola `lex-design-system-library`** diretamente — todo consumer Guardia tem que consumir `@guardia/design-system`. Eliminada por Lex, não por trade-off. |
+| **Tambo** | Não tem suporte documentado a Bedrock (provider list cobre Anthropic-direto, OpenAI-compatíveis, Gemini, Mistral). Adicionalmente, lock-in alto no runtime hospedado. Quando/se Bedrock virar provider suportado, reabrir. |
+| **Vercel `streamUI` (RSC, do AI SDK)** | Marcado pela própria Vercel como **experimental e não-recomendado pra produção**; RSC-only conflita com o stack CSR + Storybook-first do DS. Posts antigos ainda recomendam — descartar a recomendação. |
+
+## Out of scope (decidido separadamente ou não decidido aqui)
+
+- **Inventário definitivo de "demais projetos que exportam widgets"** — produzido durante o PoC de Isac. Esta ADR só declara o padrão que esses projetos seguirão quando entrarem.
+- **Escolha de framework do agente backend** (Mastra-on-AgentCore, LangGraph-on-AgentCore, agente "naked" sobre Converse API) — decisão separada, não bloqueia esta ADR desde que o backend exponha endpoint AG-UI.
+- **Schema completo do catálogo agêntico do DS** (quais primitivas, com quais props expostas, com qual descrição pro LLM) — saída do PoC, input pra ADR sucessor focado em API.
+- **Política de versionamento cross-repo dos descritores** (semver coordenado vs. independente; janela de deprecação) — saída do PoC, decisão pós-aceitação.
+- **Quotas/custo Bedrock pra geração de widgets** — depende de medição empírica no PoC.
+- **Integração com cache de prompt do Bedrock + Guardrails** — features em preview no provider; tratadas em Tech Task separada após o PoC base estabilizar.
+
+## Status transition
+
+- **proposed** — agora (este PR), pendente review da squad-theros pra confirmar o escopo cross-repo (Decision 2). Sem essa confirmação a ADR não promove a `accepted` — o DS sozinho não consegue cumprir o que ela prescreve.
+- **accepted** — quando (a) squad-theros confirmar o plano cross-repo e (b) o PoC inicial (DS expondo 3-5 descritores + Isac renderizando um widget gerado a partir de uma sessão Claude) estiver em execução.
+- **superseded** — apenas se o PoC inviabilizar AG-UI (Bedrock provider regredir, AG-UI mudar de protocolo de forma incompatível, salvaguardas da Decision 3 se mostrarem inviáveis). Nesse cenário, ADR sucessor adota `assistant-ui + AI SDK 5` como fallback documentado.
+
+## References
+
+- [`lex-ai-first-experience`](../../.claude/rules/design/system/lex-ai-first-experience.md) — Isac é conversa, workspace renderiza em resposta
+- [`lex-design-system-library`](../../.claude/rules/design/system/lex-design-system-library.md) — toda UI consome `@guardia/design-system`
+- [`lex-brand-colors`](../../.claude/rules/design/brand/lex-brand-colors.md) — paleta e contrastes que os descritores precisam codificar
+- [`lex-brand-voice`](../../.claude/rules/design/brand/lex-brand-voice.md) — buzzwords que o filtro server-side precisa barrar
+- [`lex-frontend-accessibility`](../../.claude/rules/engineering/frontend/lex-frontend-accessibility.md) — A11y runtime gate
+- [ADR-005 — Popover v0.1.0 API shape and token alignment](ADR-005-popover-api-shape-and-token-alignment.md) (contrato de tokens herdado pelos descritores)
+- [AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui)
+- [CopilotKit — AWS AG-UI endpoint announcement](https://www.copilotkit.ai/blog/aws-announces-dedicated-ag-ui-endpoint-in-agentcore-and-fast-template-for-building-fullstack-agents)
+- [AWS Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-runtime.html)
+- [assistant-ui (fallback documentado)](https://www.assistant-ui.com/)
+- [Vercel AI SDK 5 — Amazon Bedrock provider](https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock)
+- Issue [#246](https://github.com/guardiatechnology/design-system/issues/246)


### PR DESCRIPTION
## Summary

Propõe **ADR-008** formalizando a adoção de **AG-UI** (protocolo) + **CopilotKit** (cliente de referência) como a stack oficial de generative UI da Guardia sobre **AWS Bedrock**.

A decisão é **cross-repo por construção** — não é uma escolha local do design system:

- **`@guardia/design-system` (este repo)** — single source of truth do catálogo agêntico. Expõe cada primitiva consumível por agente como descritor AG-UI (`{ name, propsSchema (Zod), render }`) num entry-point dedicado.
- **Isac** — consumer primário. Conecta ao endpoint AG-UI no Bedrock AgentCore Runtime via `@copilotkit/react-core`, importa os descritores do DS.
- **Demais projetos que exportam widgets** — qualquer outra surface AI-First (dashboards internos, fluxos auditados, embeds futuros) adota o mesmo padrão. Inventário definitivo é out of scope (será produzido durante o PoC de Isac).

## Por que AG-UI sobre as alternativas

- **Protocolo, não lib** — DS expõe catálogo neutro; clientes alternativos (Mastra, novos AG-UI clients) podem consumir sem refazer o DS.
- **Cobre os 2 modos numa stack única** — seleção (1 tool = 1 widget) E composição em árvore (A2UI). Modo 2 é o único caminho padronizado pra "agente compõe `<Card>` aninhando `<Card>`" sem cada combinação ser pré-registrada.
- **Endorsement AWS** — endpoint AG-UI nativo no Bedrock AgentCore Runtime (FAST template, 2026).

Alternativas avaliadas e rejeitadas: assistant-ui+AI SDK (mantido como **fallback documentado**), Bedrock SDK direto, Mastra, LangChain.js, Thesys C1 (viola `lex-design-system-library`), Tambo (sem Bedrock), Vercel `streamUI` (Vercel marca como não-recomendado pra produção).

## Salvaguardas obrigatórias (Decision 3 do ADR)

A stack só é Lex-compliant com 4 guard-rails antes do widget chegar ao DOM:

1. **Validação Zod estrita no dispatcher** — Bedrock não suporta strict tool mode; Zod degrada graciosamente pra `<Alert tone=\"warning\">` em vez de quebrar
2. **A11y runtime gate** — axe-core sobre cada widget gerado (composições novas não passam pelo gate de baseline)
3. **Brand-voice filter server-side** — barra buzzwords proibidos por `lex-brand-voice` em todo string-field
4. **Confirmação explícita** — ações irreversíveis (`<Button>Aprovar</Button>` gerado pelo agente) wrap'd em primitiva de confirmação per `lex-ai-first-experience`

## Status proposto

**proposed** — não promove a `accepted` até a squad-theros confirmar o plano cross-repo (Decision 2). O DS sozinho não consegue cumprir o que a ADR prescreve.

## Test plan

- [ ] Squad-theros revisa Decision 2 (escopo cross-repo) e confirma viabilidade de coordenação DS + Isac + demais consumers
- [ ] Squad-theros valida a lista de alternativas rejeitadas — particularmente o fallback (assistant-ui+AI SDK) e a eliminação de Thesys C1 por Lex
- [ ] Squad-theros confirma que as 4 salvaguardas da Decision 3 entram no escopo do PoC inicial (e não são tratadas como "fast follow")
- [ ] Após aprovação: abrir Tech Task pra PoC inicial (DS expõe 3-5 descritores + Isac renderiza 1 widget de uma sessão Claude real no Bedrock)

Closes #246