### PR TITLE
feat(pagination): migrate Pagination to v0.1.0 DoD

### DIFF
--- a/docs/adr/ADR-018-pagination-v0.1.0-dod-migration.md
+++ b/docs/adr/ADR-018-pagination-v0.1.0-dod-migration.md
@@ -1,0 +1,75 @@
+# ADR-018 — Migrate Pagination to v0.1.0 DoD (Navigation)
+
+- **Status:** accepted
+- **Date:** 2026-05-29
+- **Deciders:** @fernandoseguim (CODEOWNER), `warrior-athena` (Issue-Driven flow orchestrator)
+- **Precedents:** ADR-006 (Menu consolidation), ADR-010 (Dialog), ADR-011 (Alert), ADR-014 (Toast) — recipe shadcn-style multi-parte com tokens semânticos do design-system
+- **Issue:** [#80](https://github.com/guardiatechnology/design-system/issues/80)
+- **Plan:** [#81](https://github.com/guardiatechnology/design-system/issues/81)
+
+## Context
+
+`Pagination` integra o catálogo canônico de 52 componentes do `@guardia/design-system` v0.1.0, categoria **Navigation**. O baseline atual em `ui_kit/components/pagination/index.tsx` já existe como wrapper shadcn-style multi-parte (9 símbolos: Pagination + Content + Item + Link + Previous + Next + First + Last + Ellipsis), porém falha o DoD do v0.1.0 em quatro frentes objetivas:
+
+1. **Ausência de testes.** `Pagination.test.tsx` inexistente; sem cobertura behavioral, sem jest-axe light + dark — viola `lex-frontend-testing` e diretriz Notion Dark Mode.
+2. **Stories minimal.** Apenas `Default` declarada — falta cobertura visual de Active, Disabled, Many pages with ellipsis, Edges (First/Last), Sizes, DarkTheme.
+3. **Documentação Astro ausente.** `docs/src/pages/componentes/pagination.astro` não existe; o Set `MIGRATED` em `docs/src/pages/index.astro` não inclui `Pagination` — o sidebar não rotea para a página migrada.
+4. **A11y lint pendente.** Issue body cita "Corrigir erro de a11y no lint". Embora `PaginationEllipsis` já tenha `aria-hidden` no wrapper, os botões `PaginationPrevious/Next/First/Last` não declaram `aria-label` explícito (depende apenas do `<span>` visível interno), e o handler `onKeyDown` cobre apenas Enter+Space sem `aria-disabled` rigor.
+
+A referência legacy em `ux_references/ui_kits/components/Pagination/` (`Pagination.playground.html` + `index.tsx` + `index.css`) documenta uma **API monolítica controlada** completamente distinta: `<Pagination page={1} pageCount={42} onChange={setP} siblingCount={1} showEdges size="md" />` — componente único que renderiza internamente o range numérico com elipses calculadas.
+
+A decisão arquitetural central é: **mantemos a API multi-parte shadcn-style (composição) ou regredimos para a API monolítica controlada da referência legacy?**
+
+## Decision
+
+Migrar Pagination ao v0.1.0 DoD **mantendo a API multi-parte shadcn-style** (composição), com fixes de a11y explícitos, suíte de testes behavioral completa, stories ampliadas, página Astro publicada, e ADR `accepted` desde o primeiro commit. Decisões cravadas:
+
+1. **Mantemos API multi-parte (9 símbolos).** Composição via `Pagination` + `PaginationContent` + `PaginationItem` + `PaginationLink` + variantes prev/next/first/last + ellipsis. Razão: alinhamento com Breadcrumb, NavigationMenu, Menu (ADR-006) já migrados — o catálogo Navigation inteiro usa composição shadcn-style. Regredir para API monolítica criaria divergência cognitiva no catálogo.
+
+2. **Divergência da referência legacy registrada.** A API controlada `<Pagination page pageCount onChange>` da `ux_references/ui_kits/components/Pagination/` **não é replicada**. Justificativa: composição entrega mais flexibilidade (consumidor decide range, ellipsis, edges) sem custar a a11y. Consumidores que precisam do range calculator constroem a partir das primitivas — futura iteração pode adicionar utility `usePaginationRange()` se a demanda materializar (não está no escopo).
+
+3. **Token contract via `buttonVariants`.** `PaginationLink` ativo usa `outline`; idle usa `ghost`. Zero token novo. Reuso direto do chassis Button — o investimento de Button paga aqui sem mais expansão.
+
+4. **A11y wiring explícito (fix do lint pendente):**
+   - `Pagination` root: `<nav role="navigation" aria-label="pagination">` (mantido).
+   - `PaginationPrevious/Next/First/Last`: cada um declara `aria-label` em pt-BR (`"Página anterior"`, `"Próxima página"`, `"Primeira página"`, `"Última página"`). O `<span>` visível continua presente para affordance visual; o `aria-label` garante anúncio correto em screen reader.
+   - `PaginationEllipsis`: `<span aria-hidden="true">` envolve o ícone `MoreHorizontal`; um `<span className="sr-only">Mais páginas</span>` sibling anuncia para screen reader.
+   - `PaginationLink` sem `href` usa `role="button"` + `tabIndex={0}` + handler Enter+Space (já existente, ratificado).
+   - `PaginationLink` com `disabled` usa `aria-disabled="true"` + `tabIndex={-1}` + `e.preventDefault()` no `onClick` (já existente, ratificado).
+
+5. **Suíte de testes behavioral.** `Pagination.test.tsx` exercita ≥ 20 asserts cobrindo AC-1..AC-10 com queries acessíveis (`getByRole`, `getByLabelText`), sem mockar colaboradores internos. jest-axe em light + dark sobre Default, Active, Disabled — mínimo de **6 asserts axe** (3 estados × 2 temas) garantidos via `axeInThemes()` de `@/test-utils/a11y`.
+
+6. **Stories ≥ 7.** Default + Active + Disabled + ManyPagesWithEllipsis + Edges + Sizes + DarkTheme. Light + dark cobertos pela story DarkTheme + visual regression baseline regenerada.
+
+7. **Astro page + previews.** `docs/src/pages/componentes/pagination.astro` segue o recipe canônico (kicker, group, sourcePath, storybookId, lede, sections). `docs/src/previews/pagination.tsx` exporta `BasicRow`, `ActiveRow`, `DisabledRow`, `EllipsisRow`, `EdgesRow`. `MIGRATED.add("Pagination")` em `index.astro`.
+
+8. **Single atomic commit + ADR `accepted` desde o primeiro commit.** Commit `feat(pagination): migrate to v0.1.0 DoD — ...` carrega código + testes + stories + Astro + ADR + edits do MIGRATED set. Sem pattern `proposed → accepted` (Argos sinalizou 🟡 em PR #237 quando esse pattern foi seguido).
+
+9. **Visual regression baselines regeneradas via CI.** As baselines existentes em `__image_snapshots__/components/pagination/{light,dark}/` foram geradas contra a story `Default` única. As 7+ stories novas invalidarão essas baselines. Estratégia documentada: abrir PR, deixar `visual-regression` CI falhar, aplicar label `regenerate-baselines` (autorizado por Fernando até 2026-05-29 ~22:30 UTC) — Ubuntu/CI rendered baselines são fonte da verdade; macOS local nunca commitado.
+
+## Consequences
+
+### Positive
+
+- Pagination alcança paridade DoD com Alert / Dialog / Drawer / ConfidenceIndicator / Toast (mesmo recipe shadcn-style multi-parte, mesmo token contract via `buttonVariants`, mesmo rigor de teste com `axeInThemes`).
+- A11y lint pendente resolvido — `aria-label` explícito em todos os botões prev/next/first/last + sr-only sibling no ellipsis.
+- Catálogo Navigation avança 1 componente em direção ao 52 do v0.1.0.
+- Zero novas dependências; zero expansão de token; zero churn em consumidores.
+
+### Negative
+
+- **Divergência da API legacy mantida.** Consumidores que viram o playground legacy esperando `<Pagination page pageCount onChange>` precisam compor a partir das primitivas. Mitigado pela Astro page com exemplo de composição.
+- Baselines visuais antigas precisam ser regeneradas (CI rerun + label `regenerate-baselines`) — operacional, não bloqueante.
+
+### Neutral
+
+- Tamanho do arquivo `index.tsx` cresce de ~170 linhas para ~200 (adição de `aria-label` explícitos + comentário canônico do componente). Sem impacto em bundle (Tree-shaking preservado).
+- 1 novo arquivo de teste, 1 nova Astro page, 1 novo preview, 1 ADR. Total: ~5 arquivos novos + 3 modificados (index.tsx, stories, MIGRATED set).
+
+## References
+
+- `ux_references/ui_kits/components/Pagination/` — referência visual + API legacy (divergência justificada acima).
+- ADR-006 (Menu consolidation), ADR-014 (Toast) — precedentes do recipe shadcn-style multi-parte.
+- `lex-frontend-accessibility` Rules 1, 2, 6 — landmarks, keyboard, dynamic content.
+- `lex-frontend-testing` Rules 1, 2 — behavioral tests, accessible queries.
+- `lex-design-system-library` — composição sobre primitivas existentes (`buttonVariants`).

--- a/docs/issues/issue-80/01-brief.md
+++ b/docs/issues/issue-80/01-brief.md
@@ -1,0 +1,32 @@
+# Issue Brief — #80 feat(pagination): migrate Pagination to v0.1.0 DoD
+
+- **Author:** @fernandoseguim
+- **Type:** Feature (migration)
+- **Plan sub-issue:** [#81](https://github.com/guardiatechnology/design-system/issues/81)
+- **Category:** Navigation
+- **Repository:** guardiatechnology/design-system
+
+## Context
+
+`Pagination` integra o catálogo canônico de 52 componentes do `@guardia/design-system` v0.1.0. Hoje vive em `ui_kit/components/pagination/index.tsx` como wrapper shadcn-style multi-parte (Pagination + PaginationContent + PaginationItem + PaginationLink + PaginationPrevious + PaginationNext + PaginationFirst + PaginationLast + PaginationEllipsis) — funcional, mas abaixo do DoD em quatro frentes:
+
+1. **Sem testes.** Não existe `Pagination.test.tsx`; sem cobertura behavioral, sem jest-axe light + dark.
+2. **Stories minimal.** Existe apenas `Default`; faltam variantes (Active, Disabled, Many pages with ellipsis, Edges, Dark, Sizes).
+3. **Sem Astro page.** `docs/src/pages/componentes/pagination.astro` ausente; `MIGRATED` set sem `Pagination`.
+4. **A11y lint pendente.** Issue body cita "Corrigir erro de a11y no lint" — `PaginationEllipsis` tem `aria-hidden` no wrapper + `sr-only` filha, mas vale revisar `PaginationPrevious/Next/First/Last` (anchors com `<span>` label visível) e o handler `onKeyDown` (`role="button"` quando ausente href).
+
+## Referência legacy
+
+`ux_references/ui_kits/components/Pagination/` documenta API monolítica controlada `<Pagination page pageCount onChange siblingCount showEdges size>` que **diverge** intencionalmente da API atual multi-parte (escolha do design-system: composição shadcn-style alinhada com Breadcrumb, NavigationMenu, Menu). A migração v0.1.0 DoD mantém a API multi-parte estabelecida — divergência justificada na ADR-018.
+
+## Unknowns resolved (no clarification needed)
+
+- API shape: multi-parte permanece (ADR-018).
+- Token migration: `buttonVariants` chain (já em uso).
+- Lint fix: explicit `aria-label` em todos os botões prev/next/first/last (mesmo com `<span>` visível, ratifica anúncio screen reader).
+
+## Pre-allocated artifacts
+
+- ADR: [ADR-018](../../adr/ADR-018-pagination-v0.1.0-dod-migration.md) (slot pré-alocado por Fernando).
+- Branch: `feat/80-pagination-v0.1.0-dod`.
+- Worktree: `.claude/worktrees/agent-a51c9623176952d82/`.

--- a/docs/issues/issue-80/02-requirements.md
+++ b/docs/issues/issue-80/02-requirements.md
@@ -1,0 +1,37 @@
+# Requirements — #80 Pagination v0.1.0 DoD
+
+Derived from Plan sub-issue [#81](https://github.com/guardiatechnology/design-system/issues/81) DoD checklist, normalized as numbered ACs for `lex-issue-driven` Rule 3 (bidirectional AC ↔ test traceability).
+
+## Acceptance Criteria
+
+| ID | Criterion |
+|----|-----------|
+| **AC-1** | Public surface exports exactly 9 symbols: `Pagination`, `PaginationContent`, `PaginationItem`, `PaginationLink`, `PaginationPrevious`, `PaginationNext`, `PaginationFirst`, `PaginationLast`, `PaginationEllipsis`. |
+| **AC-2** | The `<Pagination>` root renders `<nav role="navigation" aria-label="pagination">` (semantic HTML, screen-reader navigable). |
+| **AC-3** | `PaginationLink` with `isActive` sets `aria-current="page"` and uses the `outline` visual variant; without `isActive` uses `ghost`. |
+| **AC-4** | `PaginationLink` with `disabled` sets `aria-disabled="true"`, `tabIndex={-1}`, prevents `onClick`, and visually applies the disabled style chain. |
+| **AC-5** | `PaginationLink` without `href` is keyboard-operable via Enter and Space (per `lex-frontend-accessibility` Rule 2.2). |
+| **AC-6** | Only semantic tokens are used — visual chain comes from `buttonVariants`. No hardcoded colors. |
+| **AC-7** | `PaginationEllipsis` renders `<span aria-hidden="true">` wrapping the icon with a visually-hidden sibling text "Mais páginas" (screen-reader-only announcement). |
+| **AC-8** | `PaginationPrevious`, `PaginationNext`, `PaginationFirst`, `PaginationLast` each declare an explicit `aria-label` in Portuguese (`"Página anterior"`, `"Próxima página"`, `"Primeira página"`, `"Última página"`) — ensures correct screen-reader announcement even when the visible text label is present. |
+| **AC-9** | jest-axe asserts `toHaveNoViolations()` in **light AND dark** across at least: Default composition, Active state, Disabled state. |
+| **AC-10** | Behavioral test suite ≥ 20 tests OR ≥ 80% file coverage using accessible queries (`getByRole`, `getByLabelText`); no internal-collaborator mocks. |
+| **AC-11** | Storybook `Pagination.stories.tsx` covers Default + Active + Disabled + ManyPagesWithEllipsis + Edges + Sizes + DarkTheme (≥ 7 stories) and renders correctly in both themes. |
+| **AC-12** | `docs/src/pages/componentes/pagination.astro` + `docs/src/previews/pagination.tsx` published; `Pagination` added to the `MIGRATED` Set in `docs/src/pages/index.astro`. |
+| **AC-13** | `npm run typecheck && npm run lint && npm run test && npm run build && npm run docs:build` all green. |
+| **AC-14** | Single atomic commit `feat(pagination): migrate to v0.1.0 DoD — ...` per `lex-small-commits`. PR body closes both `#80` (parent) and `#81` (plan). |
+
+## Definition of Done (mirrors Plan #81)
+
+- Storybook variants in light + dark — covered by AC-11.
+- Playground side-by-side recorded in PR — handled at PR creation.
+- Behavioral tests + jest-axe — AC-9, AC-10.
+- Brand: tokens semânticos via `buttonVariants` — AC-6.
+- Build pipeline green — AC-13.
+- Single atomic commit — AC-14.
+
+## Out of scope
+
+- Monolithic controlled `<Pagination page pageCount>` API from the legacy reference (`ux_references/`). Divergência ratificada em ADR-018 — multi-parte shadcn-style permanece.
+- Sonner-style deprecation of any existing API surface (não há).
+- Refactor de consumidores externos (não há fora do design-system).

--- a/docs/issues/issue-80/03-architecture.md
+++ b/docs/issues/issue-80/03-architecture.md
@@ -1,0 +1,52 @@
+# Architecture — #80 Pagination v0.1.0 DoD
+
+## Component layout
+
+```
+ui_kit/components/pagination/
+├── index.tsx                  # rewrite — 9 symbols + paginationLinkVariants
+├── Pagination.test.tsx        # new — ≥ 20 behavioral tests + jest-axe light+dark
+└── Pagination.stories.tsx     # rewrite — Default + Active + Disabled + Many + Edges + Sizes + Dark
+```
+
+## Public surface
+
+| Symbol | Role | A11y notes |
+|--------|------|------------|
+| `Pagination` | `<nav role="navigation" aria-label="pagination">` wrapper | Landmark |
+| `PaginationContent` | `<ul>` flex container | Lista semântica |
+| `PaginationItem` | `<li>` slot | Item de lista |
+| `PaginationLink` | `<a>` ou `<button>` (via `role`) | `aria-current="page"` quando `isActive`; `aria-disabled` quando `disabled`; Enter+Space quando sem href |
+| `PaginationPrevious` | `PaginationLink` + chevron + texto "Anterior" | `aria-label="Página anterior"` |
+| `PaginationNext` | `PaginationLink` + chevron + texto "Próxima" | `aria-label="Próxima página"` |
+| `PaginationFirst` | `PaginationLink` + chevrons + texto "Início" | `aria-label="Primeira página"` |
+| `PaginationLast` | `PaginationLink` + chevrons + texto "Final" | `aria-label="Última página"` |
+| `PaginationEllipsis` | `<span aria-hidden="true">` + `<span className="sr-only">Mais páginas</span>` | Decorativo + sr-only siblings |
+
+## Design decisions cravadas em ADR-018
+
+1. **API multi-parte permanece** — não regredir para a API monolítica controlada do legacy reference. Composição shadcn-style está alinhada com Breadcrumb, NavigationMenu, Menu já migrados.
+2. **Token contract via `buttonVariants`** — `PaginationLink` reusa `outline` (active) e `ghost` (idle); zero token novo expansion.
+3. **A11y wiring explícito** — labels em pt-BR; ellipsis com sr-only sibling; Enter+Space handler quando `<a>` sem href atua como botão.
+4. **lucide-react chevrons** — já dep `^0.542.0`.
+
+## Affected components (scope)
+
+| Path | Action | Reason |
+|------|--------|--------|
+| `ui_kit/components/pagination/index.tsx` | rewrite | DoD compliance + a11y fixes |
+| `ui_kit/components/pagination/Pagination.test.tsx` | new | AC-1..AC-10 traceability |
+| `ui_kit/components/pagination/Pagination.stories.tsx` | rewrite | AC-11 — 7+ stories light+dark |
+| `docs/src/pages/componentes/pagination.astro` | new | AC-12 — Astro page |
+| `docs/src/previews/pagination.tsx` | new | AC-12 — Astro previews |
+| `docs/src/pages/index.astro` | edit (1 line) | AC-12 — `MIGRATED.add("Pagination")` |
+| `docs/adr/ADR-018-pagination-v0.1.0-dod-migration.md` | new | architectural decision record |
+| `__image_snapshots__/components/pagination/{light,dark}/*.png` | regenerate via CI | new stories invalidate old baselines |
+
+## Visual regression strategy
+
+Old baselines in `__image_snapshots__/components/pagination/{light,dark}/` were generated against the previous stories (Default only). New 7+ stories will invalidate them. Strategy: open the PR, let CI fail visual-regression, apply `regenerate-baselines` label (authorized by Fernando until 2026-05-29 ~22:30 UTC, no macOS local baselines).
+
+## Out-of-scope confirmation
+
+Nenhuma modificação em consumidores externos. Nenhum token novo. Sonner / Toast intocados. Nenhuma deprecation.

--- a/docs/src/pages/componentes/pagination.astro
+++ b/docs/src/pages/componentes/pagination.astro
@@ -1,0 +1,234 @@
+---
+import ComponentPreview from "../../layouts/ComponentPreview.astro";
+import HighlightedCode from "../../components/HighlightedCode.astro";
+import {
+  BasicRow,
+  ActiveRow,
+  DisabledRow,
+  EllipsisRow,
+  EdgesRow,
+} from "../../previews/pagination";
+import paginationSource from "@ds/components/pagination/index.tsx?raw";
+---
+
+<ComponentPreview
+  kicker="COMPONENTES · NAVEGAÇÃO"
+  title="Pagination"
+  group="Navegação"
+  storybookId="components-pagination--default"
+  sourcePath="ui_kit/components/pagination"
+  lede='Navegação numérica composta para listas paginadas. Composição shadcn-style multi-parte (<code class="inline">Pagination</code> + <code class="inline">Content</code> + <code class="inline">Item</code> + <code class="inline">Link</code> + variantes <code class="inline">Previous</code> · <code class="inline">Next</code> · <code class="inline">First</code> · <code class="inline">Last</code> + <code class="inline">Ellipsis</code>) alinhada com Breadcrumb, NavigationMenu e Menu. O consumidor monta o range e decide quando exibir reticências, edges e qual página marcar como ativa.'
+>
+  <!-- ============ BASIC ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Padrão</h2>
+      <small>composição: Pagination · Content · Item · Link · Previous · Next</small>
+    </div>
+    <div class="preview">
+      <BasicRow client:load />
+    </div>
+    <p class="preview-caption">
+      Render como <code class="inline">&lt;nav role="navigation" aria-label="pagination"&gt;</code> contendo
+      <code class="inline">&lt;ul&gt;</code> + <code class="inline">&lt;li&gt;</code> semânticos.
+      Cada <code class="inline">PaginationLink</code> recebe <code class="inline">href</code> para
+      navegação SPA / SSR e <code class="inline">isActive</code> para a página atual.
+    </p>
+  </section>
+
+  <!-- ============ ACTIVE ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Estado ativo</h2>
+      <small>aria-current="page" · variante outline</small>
+    </div>
+    <div class="preview">
+      <ActiveRow client:load />
+    </div>
+    <p class="preview-caption">
+      <code class="inline">isActive</code> aplica
+      <code class="inline">aria-current="page"</code> e troca a variante visual
+      para <code class="inline">outline</code> (idle usa <code class="inline">ghost</code>).
+      Screen readers anunciam a página atual sem reapresentar o número.
+    </p>
+  </section>
+
+  <!-- ============ DISABLED ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Desabilitado</h2>
+      <small>fronteiras · aria-disabled · tabIndex=-1</small>
+    </div>
+    <div class="preview">
+      <DisabledRow client:load />
+    </div>
+    <p class="preview-caption">
+      <code class="inline">disabled</code> aplica
+      <code class="inline">aria-disabled="true"</code>,
+      <code class="inline">tabIndex={-1}</code>, suprime
+      <code class="inline">onClick</code> e marca o chain visual desabilitado
+      (<code class="inline">cursor-not-allowed</code> +
+      <code class="inline">opacity-50</code>).
+    </p>
+  </section>
+
+  <!-- ============ ELLIPSIS ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Reticências</h2>
+      <small>composição comprimida em torno da página atual</small>
+    </div>
+    <div class="preview">
+      <EllipsisRow client:load />
+    </div>
+    <p class="preview-caption">
+      <code class="inline">PaginationEllipsis</code> renderiza o ícone
+      <code class="inline">MoreHorizontal</code> com
+      <code class="inline">aria-hidden="true"</code> e um sibling
+      <code class="inline">.sr-only</code> "Mais páginas" para anúncio em SR.
+      O range visível (1 · … · 11 · 12 · 13 · … · 42) é decidido pelo consumidor.
+    </p>
+  </section>
+
+  <!-- ============ EDGES ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Edges</h2>
+      <small>First / Last em composição com Prev / Next</small>
+    </div>
+    <div class="preview">
+      <EdgesRow client:load />
+    </div>
+    <p class="preview-caption">
+      <code class="inline">PaginationFirst</code> e
+      <code class="inline">PaginationLast</code> oferecem saltos diretos
+      para início e fim. Use quando a paginação cobre &gt; ~20 páginas.
+    </p>
+  </section>
+
+  <!-- ============ PROPS ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Props</h2>
+      <small>API pública</small>
+    </div>
+    <div class="props">
+      <table>
+        <thead>
+          <tr><th>Componente · Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="name">Pagination · ...nav</td>
+            <td class="type">React.ComponentProps&lt;"nav"&gt;</td>
+            <td class="default">—</td>
+            <td class="desc">Atributos HTML padrão do <code class="inline">&lt;nav&gt;</code>. <code class="inline">role</code> e <code class="inline">aria-label</code> já vêm preenchidos.</td>
+          </tr>
+          <tr>
+            <td class="name">PaginationLink · isActive</td>
+            <td class="type">boolean</td>
+            <td class="default">false</td>
+            <td class="desc"><code class="inline">true</code> aplica <code class="inline">aria-current="page"</code> e variante <code class="inline">outline</code>; <code class="inline">false</code> usa <code class="inline">ghost</code>.</td>
+          </tr>
+          <tr>
+            <td class="name">PaginationLink · disabled</td>
+            <td class="type">boolean</td>
+            <td class="default">false</td>
+            <td class="desc"><code class="inline">aria-disabled="true"</code> + <code class="inline">tabIndex={-1}</code> + <code class="inline">onClick</code> suprimido + visual desabilitado.</td>
+          </tr>
+          <tr>
+            <td class="name">PaginationLink · size</td>
+            <td class="type">"xs" | "sm" | "default" | "lg" | "icon"</td>
+            <td class="default">"default"</td>
+            <td class="desc">Propagada para <code class="inline">buttonVariants</code> — ladder de altura idêntico ao Button.</td>
+          </tr>
+          <tr>
+            <td class="name">PaginationLink · href</td>
+            <td class="type">string</td>
+            <td class="default">—</td>
+            <td class="desc">Sem <code class="inline">href</code>, o link assume <code class="inline">role="button"</code> com handler Enter/Space.</td>
+          </tr>
+          <tr>
+            <td class="name">PaginationPrevious · aria-label</td>
+            <td class="type">string</td>
+            <td class="default">"Página anterior"</td>
+            <td class="desc">Rótulo acessível em pt-BR; sobrescreva para i18n.</td>
+          </tr>
+          <tr>
+            <td class="name">PaginationNext · aria-label</td>
+            <td class="type">string</td>
+            <td class="default">"Próxima página"</td>
+            <td class="desc">Rótulo acessível em pt-BR; sobrescreva para i18n.</td>
+          </tr>
+          <tr>
+            <td class="name">PaginationFirst · aria-label</td>
+            <td class="type">string</td>
+            <td class="default">"Primeira página"</td>
+            <td class="desc">Rótulo acessível em pt-BR; sobrescreva para i18n.</td>
+          </tr>
+          <tr>
+            <td class="name">PaginationLast · aria-label</td>
+            <td class="type">string</td>
+            <td class="default">"Última página"</td>
+            <td class="desc">Rótulo acessível em pt-BR; sobrescreva para i18n.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ============ KEYBOARD ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Teclado</h2>
+      <small>navegação e ativação</small>
+    </div>
+    <div class="props">
+      <table>
+        <thead>
+          <tr><th>Tecla</th><th>Ação</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="name">Tab</td><td class="desc">Avança o foco através dos links em ordem do DOM.</td></tr>
+          <tr><td class="name">Shift + Tab</td><td class="desc">Retrocede o foco.</td></tr>
+          <tr><td class="name">Enter</td><td class="desc">Ativa o link em foco — comportamento nativo de <code class="inline">&lt;a&gt;</code> com <code class="inline">href</code>; equivalente a <code class="inline">onClick</code> quando <code class="inline">role="button"</code>.</td></tr>
+          <tr><td class="name">Space</td><td class="desc">Ativa o link quando atua como botão (sem <code class="inline">href</code>).</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ============ SOURCE ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Código-fonte</h2>
+      <small>ui_kit/components/pagination/index.tsx</small>
+    </div>
+    <HighlightedCode
+      code={paginationSource}
+      language="tsx"
+      filename="ui_kit/components/pagination/index.tsx"
+      maxHeight="520px"
+      showLineNumbers
+    />
+  </section>
+
+  <!-- ============ A11Y ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Acessibilidade</h2>
+      <small>WCAG 2.1 AA · landmark · keyboard</small>
+    </div>
+    <div class="a11y">
+      <ul>
+        <li><span><b>Landmark</b>: <code class="inline">&lt;nav role="navigation" aria-label="pagination"&gt;</code> — identificado por SR como landmark dedicado.</span></li>
+        <li><span><b>Estado ativo</b>: <code class="inline">aria-current="page"</code> aplicado por <code class="inline">isActive</code>; sem ambiguidade entre "está aqui" e "ir para".</span></li>
+        <li><span><b>Estado desabilitado</b>: <code class="inline">aria-disabled="true"</code> + <code class="inline">tabIndex={-1}</code> + <code class="inline">onClick</code> suprimido — SR anuncia como indisponível.</span></li>
+        <li><span><b>Labels pt-BR</b>: <code class="inline">PaginationPrevious</code>, <code class="inline">Next</code>, <code class="inline">First</code> e <code class="inline">Last</code> declaram <code class="inline">aria-label</code> explícito mesmo com texto visível interno — ratifica anúncio correto em SR.</span></li>
+        <li><span><b>Reticências</b>: <code class="inline">PaginationEllipsis</code> com wrapper <code class="inline">aria-hidden="true"</code> + sibling <code class="inline">.sr-only</code> "Mais páginas".</span></li>
+        <li><span><b>Teclado</b>: <code class="inline">Enter</code> sempre ativa; <code class="inline">Space</code> ativa quando o link atua como botão (sem <code class="inline">href</code>).</span></li>
+        <li><span><b>jest-axe</b> em light + dark cobre Default + ManyPagesWithEllipsis + Edges + Disabled (ver <code class="inline">Pagination.test.tsx</code>).</span></li>
+      </ul>
+    </div>
+  </section>
+</ComponentPreview>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -697,6 +697,7 @@ const storybookUrl = import.meta.env.DEV
         "Input",
         "Label",
         "Menu",
+        "Pagination",
         "Popover",
         "Radio",
         "Select",

--- a/docs/src/previews/pagination.tsx
+++ b/docs/src/previews/pagination.tsx
@@ -1,0 +1,183 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationFirst,
+  PaginationLast,
+} from "@ds/components/pagination";
+
+// ──────────────────────────────────────────────────────────────────
+// Padrão
+// ──────────────────────────────────────────────────────────────────
+
+export function BasicRow() {
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">2</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">3</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Estado ativo — destaque via aria-current
+// ──────────────────────────────────────────────────────────────────
+
+export function ActiveRow() {
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              2
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">3</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Desabilitado — fronteiras (página 1 sem Anterior)
+// ──────────────────────────────────────────────────────────────────
+
+export function DisabledRow() {
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" disabled />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">2</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">3</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Muitas páginas com reticências em torno da atual
+// ──────────────────────────────────────────────────────────────────
+
+export function EllipsisRow() {
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">11</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              12
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">13</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">42</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Edges — First / Last em composição com Prev / Next
+// ──────────────────────────────────────────────────────────────────
+
+export function EdgesRow() {
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationFirst href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              5
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLast href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}

--- a/ui_kit/components/pagination/Pagination.stories.tsx
+++ b/ui_kit/components/pagination/Pagination.stories.tsx
@@ -2,21 +2,36 @@ import type { Meta, StoryObj } from "@storybook/react";
 import {
   Pagination,
   PaginationContent,
+  PaginationEllipsis,
   PaginationItem,
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
+  PaginationFirst,
+  PaginationLast,
 } from "./index";
 
-const meta = {
+const meta: Meta<typeof Pagination> = {
   title: "Components/Pagination",
   component: Pagination,
   tags: ["autodocs"],
-} satisfies Meta<typeof Pagination>;
-
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Navegação numérica composta para listas paginadas. Composição shadcn-style multi-parte (`Pagination` + `Content` + `Item` + `Link` + variantes `Previous` / `Next` / `First` / `Last` + `Ellipsis`). Landmark `<nav>` com `aria-label`, estado ativo via `aria-current=\"page\"`, estado desabilitado via `aria-disabled`, operação por teclado quando o link atua como botão. Tokens semânticos via `buttonVariants`.",
+      },
+    },
+  },
+};
 export default meta;
 
 type Story = StoryObj<typeof meta>;
+
+// ──────────────────────────────────────────────────────────────────
+// Default — composição padrão
+// ──────────────────────────────────────────────────────────────────
 
 export const Default: Story = {
   render: () => (
@@ -26,13 +41,254 @@ export const Default: Story = {
           <PaginationPrevious href="#" />
         </PaginationItem>
         <PaginationItem>
-          <PaginationLink href="#" isActive>1</PaginationLink>
+          <PaginationLink href="#" isActive>
+            1
+          </PaginationLink>
         </PaginationItem>
         <PaginationItem>
           <PaginationLink href="#">2</PaginationLink>
         </PaginationItem>
         <PaginationItem>
           <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Active — destaque da página atual via aria-current
+// ──────────────────────────────────────────────────────────────────
+
+export const Active: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            2
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Disabled — fronteiras desabilitadas (página 1 = sem prev)
+// ──────────────────────────────────────────────────────────────────
+
+export const Disabled: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" disabled />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};
+
+// ──────────────────────────────────────────────────────────────────
+// ManyPagesWithEllipsis — composição comprimida em torno da página atual
+// ──────────────────────────────────────────────────────────────────
+
+export const ManyPagesWithEllipsis: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">11</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            12
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">13</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">42</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Edges — saltos First / Last em composição com Prev / Next
+// ──────────────────────────────────────────────────────────────────
+
+export const Edges: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationFirst href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            5
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLast href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Sizes — ladder sm / default propagada via PaginationLink.size
+// ──────────────────────────────────────────────────────────────────
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" size="sm" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive size="sm">
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" size="sm">
+              2
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" size="sm">
+              3
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" size="sm" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">2</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">3</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  ),
+};
+
+// ──────────────────────────────────────────────────────────────────
+// DarkTheme — mesma composição sob data-theme="dark"
+// ──────────────────────────────────────────────────────────────────
+
+export const DarkTheme: Story = {
+  parameters: { backgrounds: { default: "dark" } },
+  decorators: [
+    (Story) => (
+      <div data-theme="dark" className="rounded-md bg-background p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">11</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            12
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">13</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">42</PaginationLink>
         </PaginationItem>
         <PaginationItem>
           <PaginationNext href="#" />

--- a/ui_kit/components/pagination/Pagination.test.tsx
+++ b/ui_kit/components/pagination/Pagination.test.tsx
@@ -1,0 +1,455 @@
+import * as React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { axeInThemes } from "@/test-utils/a11y";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationFirst,
+  PaginationLast,
+} from "./index";
+
+/**
+ * Tests for Plan #81 (parent feature Issue #80) — Pagination v0.1.0 DoD.
+ *
+ * Each `it(...)` carries `AC-N:` so that `lex-issue-driven` Rule 3
+ * (bidirectional AC ↔ test traceability) passes at Gate 2. ACs come
+ * from `docs/issues/issue-80/02-requirements.md`.
+ */
+
+// ──────────────────────────────────────────────────────────────────
+// Helpers — composition harnesses
+// ──────────────────────────────────────────────────────────────────
+
+function BasicPagination(
+  props: Partial<React.ComponentProps<typeof PaginationLink>> = {},
+): React.ReactElement {
+  return (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive {...props}>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}
+
+function ManyPagesWithEllipsis(): React.ReactElement {
+  return (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">11</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            12
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">13</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">42</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}
+
+function EdgesPagination(): React.ReactElement {
+  return (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationFirst href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            5
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLast href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}
+
+function DisabledBoundaries(): React.ReactElement {
+  return (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" disabled />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}
+
+describe("Pagination", () => {
+  // ────────────────────────────────────────────────────────────────
+  // Public API surface (AC-1)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-1: exports the canonical 9-symbol public surface", () => {
+    expect(Pagination).toBeDefined();
+    expect(PaginationContent).toBeDefined();
+    expect(PaginationItem).toBeDefined();
+    expect(PaginationLink).toBeDefined();
+    expect(PaginationPrevious).toBeDefined();
+    expect(PaginationNext).toBeDefined();
+    expect(PaginationFirst).toBeDefined();
+    expect(PaginationLast).toBeDefined();
+    expect(PaginationEllipsis).toBeDefined();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Landmark + semantic HTML (AC-2)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-2: renders the root as a <nav> with role=navigation and aria-label", () => {
+    render(<BasicPagination />);
+    const nav = screen.getByRole("navigation", { name: /pagination/i });
+    expect(nav.tagName).toBe("NAV");
+    expect(nav).toHaveAttribute("aria-label", "pagination");
+  });
+
+  it("AC-2: PaginationContent renders as a <ul>", () => {
+    render(<BasicPagination />);
+    const list = screen.getByRole("list");
+    expect(list.tagName).toBe("UL");
+  });
+
+  it("AC-2: PaginationItem renders as a <li>", () => {
+    render(<BasicPagination />);
+    const items = screen.getAllByRole("listitem");
+    expect(items.length).toBeGreaterThanOrEqual(5);
+    items.forEach((item) => expect(item.tagName).toBe("LI"));
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Active state (AC-3)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-3: PaginationLink with isActive sets aria-current=page", () => {
+    render(<BasicPagination />);
+    const activeLink = screen.getByRole("link", { name: "1" });
+    expect(activeLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("AC-3: PaginationLink without isActive does not set aria-current", () => {
+    render(<BasicPagination />);
+    const inactiveLink = screen.getByRole("link", { name: "2" });
+    expect(inactiveLink).not.toHaveAttribute("aria-current");
+  });
+
+  it("AC-3: PaginationLink with isActive uses outline variant class chain", () => {
+    render(<BasicPagination />);
+    const activeLink = screen.getByRole("link", { name: "1" });
+    // outline variant exposes border-input class via buttonVariants
+    expect(activeLink.className).toContain("border");
+  });
+
+  it("AC-3: PaginationLink without isActive uses ghost variant (no border-input)", () => {
+    render(<BasicPagination />);
+    const inactiveLink = screen.getByRole("link", { name: "2" });
+    // ghost variant does not apply the outline border-input class
+    expect(inactiveLink.className).not.toContain("border-input");
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Disabled state (AC-4)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-4: disabled PaginationLink sets aria-disabled=true and tabIndex=-1", () => {
+    render(<DisabledBoundaries />);
+    const prev = screen.getByRole("link", { name: /página anterior/i });
+    expect(prev).toHaveAttribute("aria-disabled", "true");
+    expect(prev).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("AC-4: disabled PaginationLink applies the disabled visual chain", () => {
+    render(<DisabledBoundaries />);
+    const prev = screen.getByRole("link", { name: /página anterior/i });
+    expect(prev.className).toContain("cursor-not-allowed");
+    expect(prev.className).toContain("opacity-50");
+  });
+
+  it("AC-4: disabled PaginationLink suppresses onClick", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="#" disabled onClick={onClick}>
+              Click me
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    await user.click(screen.getByRole("link", { name: /click me/i }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Keyboard activation (AC-5)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-5: PaginationLink without href is keyboard-operable via Enter", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink onClick={onClick}>Activate me</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByRole("button", { name: /activate me/i });
+    link.focus();
+    await user.keyboard("{Enter}");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC-5: PaginationLink without href is keyboard-operable via Space", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink onClick={onClick}>Press space</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByRole("button", { name: /press space/i });
+    link.focus();
+    await user.keyboard(" ");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC-5: PaginationLink without href takes role=button (semantic intent)", () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink onClick={() => {}}>Action</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByRole("button", { name: /action/i })).toBeInTheDocument();
+  });
+
+  it("AC-5: PaginationLink with href keeps native <a> role (no role override)", () => {
+    render(<BasicPagination />);
+    const link = screen.getByRole("link", { name: "2" });
+    expect(link.tagName).toBe("A");
+    expect(link).not.toHaveAttribute("role");
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Token contract (AC-6)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-6: PaginationLink consumes buttonVariants class chain (no hardcoded color)", () => {
+    render(<BasicPagination />);
+    const link = screen.getByRole("link", { name: "2" });
+    // buttonVariants emits common base utilities — focus-visible:ring tokens, etc.
+    expect(link.className).toContain("focus-visible:ring");
+    expect(link.className).toContain("rounded-md");
+    // Sanity: nenhum hex literal entrou no className.
+    expect(link.className).not.toMatch(/#[0-9a-fA-F]{3,6}/);
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Ellipsis (AC-7)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-7: PaginationEllipsis wrapper has aria-hidden=true", () => {
+    const { container } = render(<ManyPagesWithEllipsis />);
+    const ellipses = container.querySelectorAll('[aria-hidden="true"]');
+    // PaginationEllipsis wrappers + chevron icons; ensure at least the 2 ellipsis spans exist
+    const ellipsisWrappers = Array.from(ellipses).filter(
+      (el) => el.tagName === "SPAN" && el.querySelector(".sr-only"),
+    );
+    expect(ellipsisWrappers.length).toBe(2);
+  });
+
+  it("AC-7: PaginationEllipsis announces 'Mais páginas' via sr-only sibling", () => {
+    render(<ManyPagesWithEllipsis />);
+    const srOnlyTexts = screen.getAllByText(/mais páginas/i);
+    expect(srOnlyTexts).toHaveLength(2);
+    srOnlyTexts.forEach((el) => {
+      expect(el.className).toContain("sr-only");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Explicit pt-BR aria-labels on prev/next/first/last (AC-8)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-8: PaginationPrevious exposes aria-label 'Página anterior'", () => {
+    render(<BasicPagination />);
+    expect(
+      screen.getByRole("link", { name: /página anterior/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("AC-8: PaginationNext exposes aria-label 'Próxima página'", () => {
+    render(<BasicPagination />);
+    expect(
+      screen.getByRole("link", { name: /próxima página/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("AC-8: PaginationFirst exposes aria-label 'Primeira página'", () => {
+    render(<EdgesPagination />);
+    expect(
+      screen.getByRole("link", { name: /primeira página/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("AC-8: PaginationLast exposes aria-label 'Última página'", () => {
+    render(<EdgesPagination />);
+    expect(
+      screen.getByRole("link", { name: /última página/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("AC-8: chevron icons inside prev/next/first/last carry aria-hidden", () => {
+    const { container } = render(<EdgesPagination />);
+    // Each navigation control renders an SVG chevron with aria-hidden — at
+    // minimum 4 (First, Previous, Next, Last). Selector pulls hidden SVGs.
+    const hiddenSvgs = container.querySelectorAll('svg[aria-hidden="true"]');
+    expect(hiddenSvgs.length).toBeGreaterThanOrEqual(4);
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // jest-axe — Default, Active state, Disabled state × light + dark (AC-9)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-9: Default composition has no a11y violations in light + dark", async () => {
+    const { container } = render(<BasicPagination />);
+    await axeInThemes(container);
+  });
+
+  it("AC-9: ManyPagesWithEllipsis composition has no a11y violations in light + dark", async () => {
+    const { container } = render(<ManyPagesWithEllipsis />);
+    await axeInThemes(container);
+  });
+
+  it("AC-9: EdgesPagination composition (First/Last) has no a11y violations in light + dark", async () => {
+    const { container } = render(<EdgesPagination />);
+    await axeInThemes(container);
+  });
+
+  it("AC-9: DisabledBoundaries composition has no a11y violations in light + dark", async () => {
+    const { container } = render(<DisabledBoundaries />);
+    await axeInThemes(container);
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Behavioral — click handler wiring (AC-10)
+  // ────────────────────────────────────────────────────────────────
+
+  it("AC-10: PaginationLink fires onClick when clicked (enabled)", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="#" onClick={onClick}>
+              Click
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    await user.click(screen.getByRole("link", { name: /click/i }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC-10: composition exposes all numbered pages as discoverable links", () => {
+    render(<BasicPagination />);
+    const numberedLinks = ["1", "2", "3"].map((n) =>
+      screen.getByRole("link", { name: n }),
+    );
+    expect(numberedLinks).toHaveLength(3);
+  });
+
+  it("AC-10: composition with ellipsis exposes the correct count of numbered pages", () => {
+    render(<ManyPagesWithEllipsis />);
+    const list = screen.getByRole("list");
+    // 5 numbered pages (1, 11, 12, 13, 42) + 2 ellipses + prev + next = 9 items
+    expect(within(list).getAllByRole("listitem")).toHaveLength(9);
+  });
+
+  it("AC-10: edges composition routes First → Last via accessible labels", () => {
+    render(<EdgesPagination />);
+    const first = screen.getByRole("link", { name: /primeira página/i });
+    const last = screen.getByRole("link", { name: /última página/i });
+    expect(first).toBeInTheDocument();
+    expect(last).toBeInTheDocument();
+  });
+});

--- a/ui_kit/components/pagination/index.tsx
+++ b/ui_kit/components/pagination/index.tsx
@@ -1,8 +1,46 @@
-import * as React from "react"
-import { ChevronLeft, ChevronRight, MoreHorizontal, ChevronsLeft, ChevronsRight } from "lucide-react"
+import * as React from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  MoreHorizontal,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
 
-import { cn } from "../../lib/utils"
-import { type ButtonProps, buttonVariants } from "../button"
+import { cn } from "../../lib/utils";
+import { type ButtonProps, buttonVariants } from "../button";
+
+/**
+ * Pagination — navegação numérica composta para listas paginadas.
+ *
+ * Composição shadcn-style multi-parte alinhada com Breadcrumb,
+ * NavigationMenu e Menu (ADR-006). O consumidor monta o range,
+ * decide quando exibir reticências, quando ativar edges (First/Last)
+ * e qual página marcar como ativa. As primitivas resolvem:
+ *
+ *   - Landmark semântico (`<nav role="navigation" aria-label>`).
+ *   - Estado ativo (`aria-current="page"`) e desabilitado (`aria-disabled`).
+ *   - Operação por teclado (Enter / Space) quando o link atua como
+ *     botão (sem `href`).
+ *   - Token contract via `buttonVariants` (zero hardcoded color).
+ *   - Labels pt-BR explícitos nos botões prev / next / first / last
+ *     mesmo na presença de texto visível, garantindo anúncio correto
+ *     em screen reader.
+ *   - Ellipsis com `aria-hidden` no decorativo + texto visualmente
+ *     escondido ("Mais páginas") como sibling para SR.
+ *
+ * Decisões registradas em
+ * `docs/adr/ADR-018-pagination-v0.1.0-dod-migration.md`.
+ *
+ * Public surface (9 componentes):
+ *   Pagination, PaginationContent, PaginationItem, PaginationLink,
+ *   PaginationPrevious, PaginationNext, PaginationFirst,
+ *   PaginationLast, PaginationEllipsis
+ */
+
+// ──────────────────────────────────────────────────────────────────
+// Pagination — landmark <nav>
+// ──────────────────────────────────────────────────────────────────
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
@@ -11,34 +49,42 @@ const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
     className={cn("mx-auto flex w-full", className)}
     {...props}
   />
-)
-Pagination.displayName = "Pagination"
+);
+Pagination.displayName = "Pagination";
+
+// ──────────────────────────────────────────────────────────────────
+// PaginationContent — <ul> container
+// ──────────────────────────────────────────────────────────────────
 
 const PaginationContent = React.forwardRef<
   HTMLUListElement,
   React.ComponentProps<"ul">
 >(({ className, ...props }, ref) => (
-  <ul
-    ref={ref}
-    className={cn("flex flex-row gap-2", className)}
-    {...props}
-  />
-))
-PaginationContent.displayName = "PaginationContent"
+  <ul ref={ref} className={cn("flex flex-row gap-2", className)} {...props} />
+));
+PaginationContent.displayName = "PaginationContent";
+
+// ──────────────────────────────────────────────────────────────────
+// PaginationItem — <li> slot
+// ──────────────────────────────────────────────────────────────────
 
 const PaginationItem = React.forwardRef<
   HTMLLIElement,
   React.ComponentProps<"li">
 >(({ className, ...props }, ref) => (
   <li ref={ref} className={cn("", className)} {...props} />
-))
-PaginationItem.displayName = "PaginationItem"
+));
+PaginationItem.displayName = "PaginationItem";
+
+// ──────────────────────────────────────────────────────────────────
+// PaginationLink — <a> ou <button> via role; central a11y wiring
+// ──────────────────────────────────────────────────────────────────
 
 type PaginationLinkProps = {
-  isActive?: boolean
-  disabled?: boolean
+  isActive?: boolean;
+  disabled?: boolean;
 } & Pick<ButtonProps, "size"> &
-  React.ComponentProps<"a">
+  React.ComponentProps<"a">;
 
 const PaginationLink = ({
   className,
@@ -47,16 +93,17 @@ const PaginationLink = ({
   size = "default",
   children,
   onClick,
+  onKeyDown,
   href,
   ...props
 }: PaginationLinkProps) => (
   <a
     aria-current={isActive ? "page" : undefined}
-    aria-disabled={disabled}
+    aria-disabled={disabled ? "true" : undefined}
     href={href}
-    /* role="button" quando o consumidor nao passa href — o componente vira
-       interativo apenas via onClick. Quando ha href, <a> e interativo
-       nativamente. */
+    // Sem href, o <a> não é interativo nativamente — sobe role="button"
+    // e tabIndex para participar da navegação por teclado. Com href, o
+    // browser cuida.
     role={!href ? "button" : undefined}
     tabIndex={disabled ? -1 : 0}
     className={cn(
@@ -65,99 +112,116 @@ const PaginationLink = ({
         size,
       }),
       "min-w-10",
-      disabled
-        ? "cursor-not-allowed opacity-50"
-        : "cursor-pointer",
-      className
+      disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+      className,
     )}
-    onClick={disabled ? (e) => e.preventDefault() : onClick}
+    onClick={(e) => {
+      if (disabled) {
+        e.preventDefault();
+        return;
+      }
+      onClick?.(e);
+    }}
     onKeyDown={(e) => {
-      if ((e.key === "Enter" || e.key === " ") && !disabled && onClick) {
+      // Quando o link atua como botão (sem href), Enter/Space dispara
+      // onClick — paridade com <button> nativo.
+      if ((e.key === "Enter" || e.key === " ") && !disabled && !href && onClick) {
         e.preventDefault();
         onClick(e as unknown as React.MouseEvent<HTMLAnchorElement>);
       }
+      onKeyDown?.(e);
     }}
     {...props}
   >
     {children}
   </a>
-)
-PaginationLink.displayName = "PaginationLink"
+);
+PaginationLink.displayName = "PaginationLink";
+
+// ──────────────────────────────────────────────────────────────────
+// PaginationPrevious / Next / First / Last — chevrons + label
+// pt-BR. `aria-label` explícito ratifica o anúncio em SR mesmo com
+// texto visível interno.
+// ──────────────────────────────────────────────────────────────────
 
 const PaginationPrevious = ({
   className,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to previous page"
+    aria-label="Página anterior"
     className={cn("gap-1 px-2.5", className)}
     {...props}
   >
-    <ChevronLeft className="h-4 w-4" />
+    <ChevronLeft className="h-4 w-4" aria-hidden="true" />
     <span>Anterior</span>
   </PaginationLink>
-)
-PaginationPrevious.displayName = "PaginationPrevious"
+);
+PaginationPrevious.displayName = "PaginationPrevious";
 
 const PaginationNext = ({
   className,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to next page"
+    aria-label="Próxima página"
     className={cn("gap-1 px-2.5", className)}
     {...props}
   >
     <span>Próxima</span>
-    <ChevronRight className="h-4 w-4" />
+    <ChevronRight className="h-4 w-4" aria-hidden="true" />
   </PaginationLink>
-)
-PaginationNext.displayName = "PaginationNext"
+);
+PaginationNext.displayName = "PaginationNext";
 
 const PaginationFirst = ({
   className,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to first page"
+    aria-label="Primeira página"
     className={cn("gap-1 px-2.5", className)}
     {...props}
   >
-    <ChevronsLeft className="h-4 w-4" />
+    <ChevronsLeft className="h-4 w-4" aria-hidden="true" />
     <span>Início</span>
   </PaginationLink>
-)
-PaginationFirst.displayName = "PaginationFirst"
+);
+PaginationFirst.displayName = "PaginationFirst";
 
 const PaginationLast = ({
   className,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to last page"
+    aria-label="Última página"
     className={cn("gap-1 px-2.5", className)}
     {...props}
   >
     <span>Final</span>
-    <ChevronsRight className="h-4 w-4" />
+    <ChevronsRight className="h-4 w-4" aria-hidden="true" />
   </PaginationLink>
-)
-PaginationLast.displayName = "PaginationLast"
+);
+PaginationLast.displayName = "PaginationLast";
+
+// ──────────────────────────────────────────────────────────────────
+// PaginationEllipsis — decorativo + sr-only sibling
+// ──────────────────────────────────────────────────────────────────
 
 const PaginationEllipsis = ({
   className,
   ...props
 }: React.ComponentProps<"span">) => (
   <span
-    aria-hidden
+    aria-hidden="true"
     className={cn("flex h-9 w-9 items-center justify-center", className)}
     {...props}
   >
     <MoreHorizontal className="h-4 w-4" />
     <span className="sr-only">Mais páginas</span>
   </span>
-)
-PaginationEllipsis.displayName = "PaginationEllipsis"
+);
+PaginationEllipsis.displayName = "PaginationEllipsis";
 
 export {
   Pagination,
@@ -169,4 +233,4 @@ export {
   PaginationPrevious,
   PaginationFirst,
   PaginationLast,
-}
+};


### PR DESCRIPTION
## Summary

Migrates `Pagination` (Navigation category) to v0.1.0 DoD keeping the established shadcn-style multi-part composition (9 symbols) and adding explicit a11y wiring, behavioral test suite, Astro docs page, and ADR-018.

- 9 exported parts (`Pagination`, `PaginationContent`, `PaginationItem`, `PaginationLink`, `PaginationPrevious`, `PaginationNext`, `PaginationFirst`, `PaginationLast`, `PaginationEllipsis`) — composition aligned with Breadcrumb, NavigationMenu, Menu (ADR-006)
- Token contract via `buttonVariants` chain (`outline` = active, `ghost` = idle); zero new token, zero hardcoded color
- Explicit pt-BR `aria-label` on Previous/Next/First/Last (`"Página anterior"`, `"Próxima página"`, `"Primeira página"`, `"Última página"`) — ratifies SR announcement even with visible text (resolves the a11y lint pending cited in the parent Issue body)
- `PaginationEllipsis` with `aria-hidden` wrapper + `sr-only` sibling "Mais páginas" for SR
- `PaginationLink` without `href` takes `role="button"` + Enter/Space handler; with `disabled` sets `aria-disabled` + `tabIndex=-1` + `onClick` suppression
- 31 behavioral tests with `AC-N` labels (well above 20 minimum); 8 jest-axe assertions (4 compositions × light + dark) — 0 violations
- 7 stories: Default + Active + Disabled + ManyPagesWithEllipsis + Edges + Sizes + DarkTheme
- Astro docs page (`docs/src/pages/componentes/pagination.astro`) + 5 previews (Basic, Active, Disabled, Ellipsis, Edges)
- `Pagination` added to `MIGRATED` Set in `docs/src/pages/index.astro`
- ADR-018 documents the decision to keep shadcn-style composition over the legacy monolithic controlled API in `ux_references/`

## Architecture decision

`docs/adr/ADR-018-pagination-v0.1.0-dod-migration.md` (status `accepted`) — the legacy reference in `ux_references/ui_kits/components/Pagination/` documents a monolithic `<Pagination page pageCount onChange>` API; we deliberately diverge and keep the multi-part composition that the rest of Navigation already uses. Justification + consequences inside the ADR.

## Local validation (Gate 2)

| Check | Result |
|-------|--------|
| `npm run typecheck` | green |
| `npm run lint` | 0 errors on Pagination (pre-existing warnings in multi-select / navbar / theme-toggle untouched) |
| `npm run test` — pagination only | 31/31 pass |
| `npm run build` | green (403.5 kB ESM total) |
| `npm run docs:build` | green (`pagination/index.html` generated) |

`Tooltip > AC-1` flakes in parallel mode (timeout); passes solo — pre-existing, unrelated to this PR.

## Visual regression

Existing baselines in `__image_snapshots__/components/pagination/{light,dark}/` were generated against the previous single `Default` story. The new 7 stories will invalidate them. Strategy: let `visual-regression` CI fail, then apply `regenerate-baselines` label to capture Ubuntu/CI baselines (no macOS local baselines).

## Test plan

- [ ] CI: `typecheck`, `lint`, `test`, `build`, `docs:build` all green
- [ ] CI: `visual-regression` — expected fail on first run; auto-apply `regenerate-baselines` label
- [ ] Visual review: open Storybook → `Components/Pagination`, verify Default + Active + Disabled + ManyPagesWithEllipsis + Edges + Sizes + DarkTheme render correctly in light and dark
- [ ] Playground side-by-side with `ux_references/ui_kits/components/Pagination/Pagination.playground.html` — confirm parity in visual rhythm despite API divergence (ADR-018)
- [ ] A11y: Tab through `Edges` story, confirm focus order Prev → First → 5 → Next → Last and that `Enter` activates each
- [ ] Docs site: navigate to `/componentes/pagination/`, verify all sections render and source viewer loads

Closes #80
Closes #81