### PR TITLE
feat(sidebar-nav): migrate SidebarNav to v0.1.0 DoD

### DIFF
--- a/docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md
+++ b/docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md
@@ -1,0 +1,176 @@
+# ADR-019 — Migrate SidebarNav to v0.1.0 DoD (Navigation/Lateral)
+
+- **Status:** accepted
+- **Date:** 2026-05-29
+- **Deciders:** @fernandoseguim (CODEOWNER), `warrior-athena` (Issue-Driven flow orchestrator)
+- **Precedents:** ADR-010 (Dialog), ADR-011 (Alert), ADR-012 (Drawer + Sheet consolidation), ADR-013 (ConfidenceIndicator), ADR-014 (Toast)
+- **Issue:** [#82](https://github.com/guardiatechnology/design-system/issues/82)
+- **Plan:** [#83](https://github.com/guardiatechnology/design-system/issues/83)
+
+## Context
+
+`SidebarNav` é a primitiva de **navegação lateral vertical** no catálogo do `@guardia/design-system` v0.1.0, categoria **Navigation**. O baseline atual é exclusivamente a referência legada em `ux_references/ui_kits/components/SidebarNav/` (JSX puro acoplado a `(window as any).Icon`, classes ad-hoc `.grd-sb-*`, cores hardcoded em CSS variables legacy `var(--violet-*)` / `var(--border)`). Não existe nenhum código em `ui_kit/components/`; o slot no Set `MIGRATED` de `docs/src/pages/index.astro` aponta para `__pending__`.
+
+O Plan #83 declara o escopo: levar `SidebarNav` ao DoD do v0.1.0 (impl + tests + stories + página Astro + previews + barrel + MIGRATED set, com jest-axe light+dark e aprovação por playground), com paridade de API e visual à referência legada.
+
+Há precondições topológicas relevantes que **forçam** algumas decisões serem registradas aqui (e não diluídas no commit), por afetarem coexistência com outros artefatos do DS:
+
+1. **Já existe `ui_kit/components/sidebar/`** — um composite shell shadcn-derived (`SidebarProvider`, `SidebarTrigger`, `SidebarRail`, persistência via cookie, integração com `<Drawer>` mobile pós-ADR-012). É chrome de aplicação, não primitiva de navegação. SidebarNav **não substitui** Sidebar; resolvem problemas distintos. O risco de confusão semântica é real e precisa ser cravado em ADR para que reviewers e consumers entendam a distinção.
+2. **Radix não oferece primitiva para nav lateral persistente.** `NavigationMenu` é orientado a menubar com flyout; `Accordion` força semântica accordion (1+ painel) que não casa com sidebar (seções sempre visíveis, grupos opcionalmente colapsáveis dentro). A decisão de **não usar Radix base** é arquitetural e merece registro — não é "preguiça".
+3. **A referência legada usa dot-notation com `any` cast** (`(SidebarNav as any).Section = ...`). `lex-frontend-typing` proíbe `any` injustificado. A API canônica do DS atual (Toast, Dialog, Drawer) é **named exports**. A migração troca o shape; o ADR documenta o trade-off.
+4. **Modo collapsed depende de disclosure do label** para screen readers. A legada usa `title=` nativo (A11y limitada). O upgrade para `<Tooltip>` do DS introduz acoplamento (SidebarNav passa a importar Tooltip) que merece justificativa explícita.
+
+## Decision
+
+Migrar SidebarNav ao v0.1.0 DoD seguindo um recipe **ConfidenceIndicator-style adaptado** (composição interna sem Radix base, sub-componentes named exports) com 5 decisões cravadas:
+
+### 1. Base primitive — sem Radix, aria-expanded/aria-controls manuais
+
+`SidebarNav` é uma estrutura semântica simples (`<nav>` + lista de itens + grupos com botão+conteúdo). Avaliadas 4 opções:
+
+- **(a) `@radix-ui/react-navigation-menu`** — descartada. Orientada a top-bar menubar com flyout. Semântica acoplada a menu horizontal com painéis em hover/focus; não casa com nav lateral persistente.
+- **(b) `@radix-ui/react-accordion`** — descartada. Força contrato accordion (seções inteiras colapsáveis, 1+ painel expandido). Sidebar tem seções **sempre visíveis** + grupos **opcionalmente** colapsáveis dentro — semântica disjunta.
+- **(c) `@radix-ui/react-collapsible`** — viável, mas o ganho é marginal (~30 linhas que substituiríamos por `<button aria-expanded><div hidden></div></button>`). Custo: introduzir dependência semântica de outro componente DS dentro de uma primitiva nav.
+- **(d) Sem Radix, manual** — **escolhida**. Implementação direta de `aria-expanded`/`aria-controls` no `SidebarNavGroupTrigger` + `SidebarNavGroupContent` com `id` estável via `React.useId()`. Precedente: ConfidenceIndicator (#256, ADR-013) — composição interna sem Radix.
+
+### 2. API shape — named exports, não dot-notation
+
+A referência legada usa `(SidebarNav as any).Section = SBSection` (dot-notation com `any` cast). `lex-frontend-typing` proíbe `any` injustificado; o cast é o único caminho para anexar sub-componentes a uma função tipada sem expor uma interface artificial.
+
+O padrão DS atual (Toast `ToastProvider`/`ToastTitle`/`ToastClose`; Dialog `DialogContent`/`DialogHeader`/`DialogFooter`; Drawer `DrawerContent`/`DrawerHeader`/`DrawerTitle`) é **named exports** sob um namespace lógico de prefixo:
+
+```tsx
+import {
+  SidebarNav,
+  SidebarNavSection,
+  SidebarNavItem,
+  SidebarNavGroup,
+  SidebarNavGroupTrigger,
+  SidebarNavGroupContent,
+} from "@guardia/design-system";
+```
+
+Trade-off: consumer escreve mais imports (~ 4-6 named imports vs 1 com dot-notation), em troca de tipagem correta sem `any`, tree-shaking limpo, e paridade com o restante do catálogo.
+
+### 3. Group state model — controlled + uncontrolled coexistindo
+
+A referência legada é exclusivamente uncontrolled (`React.useState(defaultOpen)`). O padrão DS (Collapsible, Drawer, Tooltip) suporta os dois modos via detecção de `open` prop:
+
+```tsx
+// Uncontrolled (paridade com a referência)
+<SidebarNavGroup label="Contábil" defaultOpen>...</SidebarNavGroup>
+
+// Controlled (novo)
+<SidebarNavGroup label="Contábil" open={isOpen} onOpenChange={setIsOpen}>...</SidebarNavGroup>
+```
+
+Hook interno: `const [open, setOpen] = useControllableState({ value: openProp, defaultValue: defaultOpen ?? true, onChange: onOpenChange })`. Sem dependência externa — implementação inline ~ 15 linhas (mesmo padrão usado em Collapsible / Tooltip do projeto).
+
+### 4. Collapsed label disclosure — Tooltip do DS + `sr-only` defesa em profundidade
+
+A referência legada usa `title="..."` HTML nativo (A11y limitada — não funciona via teclado em todos os browsers; sem styling). Decisão para v0.1.0:
+
+- Quando `collapsed=true`, o item interativo é **wrappeado** em `<Tooltip>` do DS (`@/components/tooltip`) com `content` igual ao label textual. O Tooltip do DS já implementa Radix Tooltip — handles hover + focus + keyboard.
+- O label original também vai para `<span className="sr-only">{label}</span>` adjacente ao ícone — **defesa em profundidade** para screen readers que enunciam o conteúdo do botão antes do Tooltip ser invocado.
+- Quando `children` não é string, o consumer **deve** passar prop `label?: string`. Sem `label`, em modo collapsed o componente cai apenas no `sr-only` derivado de `children` via `aria-label` no elemento renderizado — não há warning em produção (evita `console.*` calls per `lex-logging-decorator`); em dev o componente entra em modo degradado silenciosamente, e a página Astro documenta explicitamente o requisito.
+
+Acoplamento aceito: SidebarNav passa a importar `Tooltip` do mesmo barrel. Componentes do DS importando outros componentes do DS é prática estabelecida (Sidebar shell importa Drawer, Tooltip, Skeleton, Button).
+
+### 5. Coexistência com `Sidebar` shell — ortogonal, documentada
+
+`SidebarNav` **não substitui**, **não modifica**, **não importa** `Sidebar` (composite shell shadcn). Resolvem problemas distintos:
+
+| Problema | Solução |
+|---|---|
+| Chrome inteiro de app (header com trigger, persistência cookie, mobile Drawer) | `<SidebarProvider><Sidebar>...</Sidebar></SidebarProvider>` (shell existente) |
+| Árvore de navegação tokenizada (seções + grupos + itens ativos + collapsed) | `<SidebarNav>...</SidebarNav>` (este componente) |
+| Os dois juntos | `<Sidebar><SidebarContent><SidebarNav>...</SidebarNav></SidebarContent></Sidebar>` |
+
+A página Astro de SidebarNav carrega seção explícita "Quando usar Sidebar vs SidebarNav" com a matriz acima. Reviewers e consumers têm o cenário cravado.
+
+### 6. ADR `accepted` desde o primeiro commit
+
+Commit atômico carrega código + ADR + docs juntos. Sem pattern `proposed → accepted` (Argos sinalizou 🟡 em PR #237 quando esse pattern foi seguido em iterações anteriores).
+
+## Public surface
+
+```tsx
+// Components (6 named exports)
+export {
+  SidebarNav,
+  SidebarNavSection,
+  SidebarNavItem,
+  SidebarNavGroup,
+  SidebarNavGroupTrigger,
+  SidebarNavGroupContent,
+};
+
+// CVA accessors (2)
+export { sidebarNavVariants, sidebarNavItemVariants };
+
+// Types (4)
+export type {
+  SidebarNavProps,
+  SidebarNavSectionProps,
+  SidebarNavItemProps,
+  SidebarNavGroupProps,
+};
+```
+
+Total: **6 componentes + 2 CVA accessors + 4 types**.
+
+## Tokenization
+
+100% derivada do chain `--sidebar-*` / `--muted-foreground` / `--ring` já presente em `ui_kit/styles/index.css` (linhas 223-230 light, mapeamento dark equivalente). **Zero expansão de token nova.** Detalhamento na tabela em `docs/issues/issue-82/03-architecture.md` § "Tokenização — mapeamento".
+
+## ARIA contract
+
+| Elemento | ARIA |
+|---|---|
+| `<SidebarNav>` (root) | `<nav role="navigation" aria-label="Navegação principal">` (override via prop) |
+| `<SidebarNavSection>` (com label) | `<section aria-label={label}>` quando label é string; sem role explícito caso contrário |
+| `<SidebarNavItem>` ativo | `<a aria-current="page">` ou `<button aria-current="page">` |
+| `<SidebarNavItem>` disabled (button) | `<button disabled>` (atributo nativo) |
+| `<SidebarNavItem>` disabled (link) | `<a aria-disabled="true" tabIndex={-1}>` + classe `pointer-events-none` |
+| `<SidebarNavGroupTrigger>` | `<button aria-expanded={open} aria-controls={contentId}>` |
+| `<SidebarNavGroupContent>` | `<div id={contentId} role="group">` (sem `hidden` quando aberto; não montado quando fechado) |
+| `<SidebarNavItem collapsed>` | wrapper `<Tooltip>` + `<span className="sr-only">{label}</span>` |
+
+## Coverage plan
+
+| Aspecto | Cobertura |
+|---|---|
+| AC ↔ test traceability | Cada `it(...)` carrega `AC-N:` no título |
+| Tests count | Plan #83 exige ≥ 20 ou ≥ 80% coverage do arquivo — alvo **≥ 22 testes** |
+| jest-axe states × themes | 5 estados (Default, ativo, collapsed, grupo aberto, disabled) × 2 temas = **10 invocações** |
+| Stories | Default, Collapsed, WithActiveItem, WithBadges, WithGroups, DenseRealistic (6) |
+| Visual regression | Auto via CI playwright (Ubuntu); aplicar `regenerate-baselines` se necessário na 1ª run |
+
+## Consequences
+
+### Positive
+- Catálogo Navigation avança (Sidebar shell + Navbar + SidebarNav + Breadcrumb + Menubar + Pagination + Tabs já cobertos)
+- Paridade visual com referência legada preservada
+- Token chain consolidado; zero divergência com Notion (não há tokens novos)
+- Coexistência com Sidebar shell documentada na página Astro + ADR
+
+### Negative
+- 6 named exports em vez de 1 com dot-notation (consumer escreve mais imports)
+- Acoplamento explícito com `Tooltip` do DS (mas é o canal certo para A11y em collapsed)
+- Componente sem Radix base — implementação manual de `aria-expanded`/`aria-controls` (custo: ~10 linhas, ganho: zero dependência semântica errada)
+
+### Neutral
+- Não retira `Sidebar` shell. Não retira a referência legada de `ux_references/` (snapshot canônico fica preservado).
+
+## References
+
+- Plan #83 — escopo + DoD checklist
+- Issue #82 — parent Tech Task
+- `ux_references/ui_kits/components/SidebarNav/` — referência visual + API legada
+- `ui_kit/components/sidebar/index.tsx` — shell shadcn coexistente
+- ADR-013 — precedente de composição sem Radix
+- ADR-014 — recipe v0.1.0 DoD recente (Toast)
+- `ui_kit/styles/index.css` linhas 223-230 — tokens `--sidebar-*`
+- `lex-frontend-typing` — racional para evitar dot-notation com `any` cast
+- `lex-frontend-accessibility` Rule 1 (semantic HTML), Rule 2 (keyboard), Rule 5 (contrast), Rule 6 (dynamic state)
+- `lex-design-system-library` — racional para coexistência (compor existente, não reimplementar)

--- a/docs/issues/issue-82/01-brief.md
+++ b/docs/issues/issue-82/01-brief.md
@@ -1,0 +1,78 @@
+# Phase 1 — Brief: `feat(sidebar-nav): migrate SidebarNav to v0.1.0 DoD`
+
+- **Issue:** [#82](https://github.com/guardiatechnology/design-system/issues/82)
+- **Plan sub-issue:** [#83](https://github.com/guardiatechnology/design-system/issues/83)
+- **Author:** @fernandoseguim
+- **Type:** Tech Task (parent), Plan sub-issue
+- **Labels:** `evolvability ♻️`
+- **Category:** Navigation
+- **Epic pai:** [#13 — Design System v0.1.0 — full component migration to new DoD](https://github.com/guardiatechnology/design-system/issues/13)
+- **Branch:** `feat/82-sidebar-nav-v0.1.0-dod` · **Worktree:** `.claude/worktrees/agent-ab6b916ee6be30c4d/`
+- **Read at:** 2026-05-29
+
+## Resumo
+
+Migrar `SidebarNav` ao DoD do v0.1.0 do `@guardia/design-system`, fechando um gap da categoria **Navigation** no catálogo de 52 componentes. SidebarNav é a primitiva de **navegação lateral vertical** baseada em seções e itens — distinta da composta `Sidebar` shell (shadcn-style com cookie de estado, `SidebarProvider`, `<DrawerContent>` para mobile) já migrada e da `Navbar` horizontal. Hoje SidebarNav existe apenas como referência legada em `ux_references/ui_kits/components/SidebarNav/` (JSX puro acoplado a `window.Icon`, classes `.grd-sb-*` ad-hoc) e está abaixo do DoD: sem código no `ui_kit/`, sem testes, sem stories, sem página Astro, sem entrada no Set `MIGRATED`.
+
+A migração cria `SidebarNav` como primitiva canônica focada — para navegação primária com seções + grupos colapsáveis + indicador ativo + modo `collapsed` (só ícones) — coexistindo com o `Sidebar` shell (que oferece chrome de aplicação completo: trigger mobile, persistência, layout do shell). Os dois componentes resolvem problemas distintos: `SidebarNav` é a árvore de navegação consumida dentro de qualquer chrome; `Sidebar` é o chrome em si.
+
+## Contexto Notion
+
+O Plan #83 e a Tech Task #82 ancoram em quatro fontes Notion canônicas:
+
+- [Branding (raiz)](https://www.notion.so/Branding-34536f91ebd280a69efacbadab3861c6)
+- [Cores](https://www.notion.so/34536f91ebd28142a3f1e0e58fd62c4b) — paleta + hierarquia CTA (já refletida em `lex-brand-colors` § "CTA hierarchy by theme")
+- [Tipografia](https://www.notion.so/34536f91ebd281b9b76ccc6159bfae69) — Poppins → Roboto fallback (`lex-brand-typography`)
+- [Logomarca](https://www.notion.so/34536f91ebd2816f891ce73a5d47a789) — não aplicável a SidebarNav (componente sem logo embutido — o logo vive no chrome `Sidebar` ou em qualquer wrapper consumer)
+
+A diretriz é **Notion prevalece** em caso de divergência com o espelho local (`lex-brand-*` / `codex-brand-*`). Para SidebarNav, o espelho local já está alinhado a Notion após o ciclo de tokens fechado em ADR-011 (Alert) — não é esperada divergência.
+
+## Precedentes consultados
+
+| Precedente | ADR | Resultado |
+|---|---|---|
+| **Toast #259** | [ADR-014](../../adr/ADR-014-toast-v0.1.0-dod-migration.md) | Recipe completo de migração v0.1.0 DoD com Provider + hook + variantes CVA + a11y light/dark — referência canônica mais recente |
+| **Drawer #258 + consolidação com Sheet** | [ADR-012](../../adr/ADR-012-drawer-v0.1.0-dod-migration.md) | Side variants via CVA, coexistência com componente legado, ADR `accepted` desde o primeiro commit |
+| **Dialog #257** | [ADR-010](../../adr/ADR-010-dialog-v0.1.0-dod-migration.md) | Recipe base Radix wrapper, primitivas re-exportadas |
+| **ConfidenceIndicator #256** | [ADR-013](../../adr/ADR-013-confidence-indicator-v0.1.0-dod-migration.md) | Componente sem Radix base, composição interna por sub-componentes — precedente próximo (SidebarNav também não tem Radix nativo) |
+| **Alert #255** | [ADR-011](../../adr/ADR-011-alert-v0.1.0-dod-migration.md) | Token chain `--*-soft`, expansão prévia que SidebarNav **não** consome (sem matriz de tons) |
+| **Existing `Sidebar` shell (shadcn)** | n/a | Composite shell `<SidebarProvider>`/`<SidebarTrigger>`/`<SidebarRail>` + cookie de estado + Drawer mobile. SidebarNav é primitiva distinta — não substitui. |
+
+## Referência legada
+
+Snapshot em `ux_references/ui_kits/components/SidebarNav/`:
+
+- **Playground:** `SidebarNav.playground.html` — demonstra modo expandido + collapsed, seções (`Section`), grupos colapsáveis (`Group`), itens com ícone, badge, ativo, `onClick`/`href`.
+- **Source:** `index.tsx` — JSX puro com `React.createContext` para `collapsed`, sub-componentes `SBSection`, `SBItem`, `SBGroup` anexados via `(SidebarNav as any).Section = ...`. Item é `<button>` ou `<a>` conforme `href`. Group tem `defaultOpen` + chevron rotacionado via CSS.
+- **Styles:** `index.css` — `.grd-sb` (container 240px, gap, padding, border-right), `.grd-sb-col` (60px collapsed), `.grd-sb-item` (hover violet-50, active violet-100), `.grd-sb-item-badge` (violet-200 bg + violet-700 fg, pill), `.grd-sb-group-chev` (rotate 180° on open). **Cores hardcoded como variáveis CSS legacy `var(--violet-*)`, `var(--border)`, `var(--fg-muted)`** — incompatíveis com o token chain do v0.1.0 que usa `--sidebar-*`, `--muted-foreground`, `--ring` (HSL semantics em `ui_kit/styles/index.css`).
+
+A API/visual da referência **DEVE** ser espelhada (variants, props, comportamento). Divergências exigem justificativa explícita em Phase 3.
+
+## Estado atual no `ui_kit/`
+
+- `ui_kit/components/sidebar-nav/` — **inexistente**.
+- `ui_kit/components/sidebar/` — composite shell shadcn-derived (`SidebarProvider`, `SidebarTrigger`, `SidebarRail`, cookie state). Coexiste, não substitui.
+- `ui_kit/components/navbar/` — navegação horizontal, escopo distinto.
+- Set `MIGRATED` em `docs/src/pages/index.astro` linha 678: **não contém `SidebarNav`**. Adicionar resolve o roteamento de `/componentes/sidebar-nav/`.
+- Sidebar do shell de docs em `index.astro` linha 641 já registra o entry `{ g: "SB", label: "SidebarNav", ... }` — aponta para `__pending__` enquanto não migrado.
+
+## Pendências objetivas mapeadas
+
+1. Criar `ui_kit/components/sidebar-nav/index.tsx` com primitivas tokenizadas (Root + Section + Item + Group), CVA para `collapsed`/`active`, sem Radix base (Radix não tem `Sidebar` nativo — `NavigationMenu` é orientado a top-bar/menubar, não a nav vertical com grupos colapsáveis).
+2. `SidebarNav.test.tsx` ≥ 20 testes ou ≥ 80% coverage, behavioral + jest-axe light+dark em pelo menos Default, item ativo, hover (`group:hover`), grupo aberto/fechado, `collapsed`, `disabled` (se aplicável).
+3. `SidebarNav.stories.tsx` cobrindo Default + Collapsed + ComItensAtivos + ComBadge + ComGrupos + DenseStructure em light + dark.
+4. `docs/src/pages/componentes/sidebar-nav.astro` + `docs/src/previews/sidebar-nav.tsx` (paridade visual com `SidebarNav.playground.html`).
+5. Export em `ui_kit/components/index.ts`.
+6. `SidebarNav` adicionado ao Set `MIGRATED` em `docs/src/pages/index.astro` linha 678.
+7. ADR-019 (slot já reservado) — `docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md`.
+
+## Unknowns
+
+Pré-investigados, sem ambiguidade real para Plan #83 — todas as decisões DoD foram cravadas pelos 5 precedentes recentes. Os pontos abaixo são decisões explícitas a serem documentadas na Arquitetura (Phase 3), não ambiguidades pendentes:
+
+- **Aninhamento.** Legada suporta 1 nível via `Group` (não recursivo). Mantemos. Recursividade arbitrária está fora do DoD do v0.1.0.
+- **Modo collapsed × Group.** Legada renderiza filhos do Group inline (sem header) quando `collapsed`. Mantemos esse comportamento + adicionamos `aria-expanded` na trigger.
+- **Item como link vs botão.** Decidido por presença de `href` (paridade total com legada). Mantemos.
+- **Tooltip em modo collapsed.** Legada usa `title=` no item quando `collapsed`. Upgrade para `<Tooltip>` (já no DS) — decisão registrada em ADR-019.
+- **Ícone.** Legada chama `(window as any).Icon`. Migração usa `ReactNode` na prop `icon` — consumer passa o ícone (Lucide é a stack canônica do projeto), o componente apenas posiciona. Sem dependência de globais.
+- **Estado controlado vs descontrolado em Group.** Legada usa estado interno (`useState(defaultOpen)`). Adicionamos pattern controlled: `open`/`onOpenChange` opcionais + `defaultOpen` (paridade com `<Collapsible>` e `<Drawer>` do DS).

--- a/docs/issues/issue-82/02-requirements.md
+++ b/docs/issues/issue-82/02-requirements.md
@@ -1,0 +1,114 @@
+# Phase 2 — Requirements: `feat(sidebar-nav): migrate SidebarNav to v0.1.0 DoD`
+
+- **Issue:** [#82](https://github.com/guardiatechnology/design-system/issues/82)
+- **Plan sub-issue:** [#83](https://github.com/guardiatechnology/design-system/issues/83)
+- **Brief:** [`01-brief.md`](./01-brief.md)
+- **Status:** complete
+
+Todos os ACs estão numerados (`AC-N`) para satisfazer `lex-issue-driven` Rule 3 (rastreabilidade bidirecional AC ↔ test).
+
+## Acceptance Criteria
+
+### Public surface
+
+- **AC-1** — O módulo `ui_kit/components/sidebar-nav/index.tsx` exporta a superfície pública canônica: `SidebarNav`, `SidebarNavSection`, `SidebarNavItem`, `SidebarNavGroup`, `SidebarNavGroupTrigger`, `SidebarNavGroupContent`, `sidebarNavVariants`, `sidebarNavItemVariants`, mais os tipos `SidebarNavProps`, `SidebarNavSectionProps`, `SidebarNavItemProps`, `SidebarNavGroupProps`. Os accessors `sidebarNavVariants` e `sidebarNavItemVariants` são funções CVA invocáveis sem argumentos (defaults aplicados).
+- **AC-2** — `SidebarNav` é re-exportado por `ui_kit/components/index.ts` (export wildcard de `./sidebar-nav`).
+
+### Tokenização e Brand
+
+- **AC-3** — A composição usa **exclusivamente tokens semânticos** do DS (`--sidebar`, `--sidebar-foreground`, `--sidebar-accent`, `--sidebar-accent-foreground`, `--sidebar-border`, `--sidebar-ring`, `--muted-foreground`, `--ring`). Nenhum valor `oklch(...)`, hex literal (`#...`), nem classes Tailwind cromáticas diretas (`text-violet-*`, `bg-orange-*`, `text-red-*`) na superfície pública ou nas classes CVA.
+- **AC-4** — O container raiz aplica `bg-sidebar text-sidebar-foreground border-sidebar-border` (light) e mantém os mesmos tokens em dark (mapeamento via `data-theme="dark"` já provido em `ui_kit/styles/index.css`). Nenhuma classe `dark:...` cromática é necessária — o token chain resolve.
+
+### Variantes — Root
+
+- **AC-5** — `<SidebarNav>` aceita `collapsed?: boolean` (default `false`). Quando `true`, a largura do container reduz para a faixa compacta (paridade com `.grd-sb-col` legada, 56px ± padding), labels de itens ficam ocultos (`sr-only` ou `hidden`), labels de seção viram um divisor visual, e itens dentro de `Group` são renderizados inline (sem trigger/chevron — espelhando a legada).
+- **AC-6** — A transição `width` entre estados expandido/colapsado é animada (≥ 150ms) e respeita `prefers-reduced-motion: reduce` (transition desativada via `motion-reduce:transition-none`).
+
+### Variantes — Item
+
+- **AC-7** — `<SidebarNavItem>` aceita `icon?: ReactNode` (renderizado à esquerda do label) e `badge?: ReactNode` (renderizado à direita, oculto em `collapsed`). Quando `collapsed`, apenas o ícone aparece — o label vai para `sr-only` para preservar acessibilidade ao screen reader.
+- **AC-8** — `<SidebarNavItem>` aceita `active?: boolean` (default `false`). Quando `true`, aplica classes do estado ativo (`bg-sidebar-accent text-sidebar-accent-foreground font-semibold`) e expõe `aria-current="page"` no elemento renderizado.
+- **AC-9** — `<SidebarNavItem>` renderiza `<a href>` quando `href` é provido; caso contrário, renderiza `<button type="button">`. O elemento renderizado herda `onClick` quando provido. `disabled?: boolean` desabilita o `<button>` (atributo nativo) ou aplica `aria-disabled="true" tabIndex={-1}` + `pointer-events-none` em links.
+
+### Composição — Section e Group
+
+- **AC-10** — `<SidebarNavSection>` aceita `label?: ReactNode`. Quando provido e o container não está `collapsed`, renderiza um cabeçalho de seção (`<div role="presentation">` com label em uppercase tracking-wide). Quando `collapsed` + `label` presente, renderiza um divisor (`<hr>` semantically) no lugar do label.
+- **AC-11** — `<SidebarNavGroup>` aceita `label`, `icon?`, `defaultOpen?: boolean = true` (descontrolado) **e** `open?: boolean` + `onOpenChange?: (open: boolean) => void` (controlado). A trigger interna (`<SidebarNavGroupTrigger>`) é um `<button>` com `aria-expanded={open}` e `aria-controls={contentId}`; o conteúdo (`<SidebarNavGroupContent>`) tem `id={contentId}` e é montado/desmontado conforme `open`. Em modo `collapsed`, o `<SidebarNavGroup>` renderiza apenas seus filhos inline (sem trigger, sem header) — paridade com a referência legada.
+
+### Acessibilidade (WCAG 2.1 AA)
+
+- **AC-12** — O container raiz é um `<nav>` com `aria-label` padrão "Navegação principal" (override via prop `aria-label`).
+- **AC-13** — Navegação por teclado: `Tab` percorre itens e triggers de grupo na ordem visual; `Enter`/`Space` ativa `<button>` (item ou trigger); `Enter` ativa `<a>`. Foco visível via `focus-visible:ring-2 ring-ring ring-offset-1` em todos os interativos.
+- **AC-14** — Em modo `collapsed`, cada item interativo expõe seu label completo para tecnologia assistiva — preferencialmente via `<Tooltip>` (componente do DS) wrappando o item com `content={label}`, OU via `sr-only` adjacente ao ícone. A escolha é registrada em ADR-019.
+
+### Testing
+
+- **AC-15** — `SidebarNav.test.tsx` contém **≥ 20 testes** com cobertura ≥ 80% do arquivo `index.tsx`. Cada `it(...)` carrega `AC-N:` no início do título.
+- **AC-16** — Testes usam queries acessíveis (`getByRole`, `getByLabelText`, `getByText`) — `getByTestId` apenas como último recurso documentado (`lex-frontend-testing`).
+- **AC-17** — Testes não mockam colaboradores internos (sem `vi.mock("./index")` parcial), apenas boundaries (timers se necessário para a transição de width). Não há mock necessário para o módulo em si.
+
+### Acessibilidade automatizada (jest-axe)
+
+- **AC-18** — `jest-axe` cobre `Default` (expandido, sem item ativo) em **light + dark** sem violações.
+- **AC-19** — `jest-axe` cobre **estado ativo** (item com `active`) em light + dark sem violações.
+- **AC-20** — `jest-axe` cobre **modo collapsed** (com tooltip ou sr-only) em light + dark sem violações.
+- **AC-21** — `jest-axe` cobre **grupo aberto** (com sub-itens visíveis) em light + dark sem violações.
+- **AC-22** — `jest-axe` cobre **item disabled** em light + dark sem violações.
+
+### Storybook
+
+- **AC-23** — `SidebarNav.stories.tsx` exporta no mínimo 6 stories: `Default`, `Collapsed`, `WithActiveItem`, `WithBadges`, `WithGroups`, `DenseRealistic` (replicando a fixture do playground legado). Todas renderizam corretamente em `light` e `dark` (a alternância é provida pelo Storybook decorator já existente no projeto).
+- **AC-24** — Stories usam apenas a superfície pública do componente — nenhuma classe Tailwind cromática externa (zero `text-violet-*`/`bg-orange-*` em decorators de story, conforme aprendizado registrado em memória `feedback_story_no_external_destructive_helper`). Cores e estados são sempre derivadas das props (`active`, `disabled`).
+
+### Docs (Astro)
+
+- **AC-25** — `docs/src/pages/componentes/sidebar-nav.astro` existe com layout `ComponentPreview`, kicker `COMPONENTES · NAVIGATION`, lede descritiva, e seções: Padrão · Modo Collapsed · Estado Ativo · Badges · Grupos · Estrutura Realista · Props · Teclado · Código-fonte · Acessibilidade.
+- **AC-26** — `docs/src/previews/sidebar-nav.tsx` exporta os componentes `BasicRow`, `CollapsedRow`, `ActiveItemRow`, `BadgesRow`, `GroupsRow`, `RealisticRow` consumidos pelo `.astro`.
+
+### Catálogo
+
+- **AC-27** — `SidebarNav` aparece no Set `MIGRATED` em `docs/src/pages/index.astro` (linha 678), produzindo o slug `sidebar-nav` e roteamento para `/componentes/sidebar-nav/`.
+
+### ADR
+
+- **AC-28** — `docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md` existe com status `accepted`, deciders `@fernandoseguim` + `warrior-athena`, link para o Issue #82 e Plan #83, decisões cravadas: (a) sem Radix base, (b) composição por sub-componentes anexados, (c) controlled/uncontrolled Group, (d) Tooltip vs sr-only em collapsed, (e) coexistência com `Sidebar` shell.
+
+### Gate 2 — checklist programático
+
+- **AC-29** — `npm run typecheck` verde (0 erros TS).
+- **AC-30** — `npm run lint` verde (0 erros ESLint).
+- **AC-31** — `npm run test` verde (toda a suíte do projeto; SidebarNav inclusive).
+- **AC-32** — `npm run build` verde (rslib build produz artefatos publicáveis).
+- **AC-33** — `npm run docs:build` verde (Astro build do site de docs).
+
+### Commit
+
+- **AC-34** — Commit atômico único conforme `lex-small-commits` + `lex-conventional-commits`, com mensagem `feat(sidebar-nav): migrate to v0.1.0 DoD — <subject>` e body bilíngue `[en]` + `[pt-BR]`, fechando #82 e #83 (`Closes #82` + `Closes #83`).
+
+## Out of Scope
+
+Itens explícitos do Plan #83 fora do DoD do v0.1.0:
+
+- Refatorações não relacionadas a SidebarNav.
+- Adição ou alteração de tokens além do que a superfície pública precisa (todos os tokens semânticos já existem em `ui_kit/styles/index.css`).
+- Aninhamento recursivo arbitrário (n níveis) — o DoD do v0.1.0 fixa 1 nível via `Group`.
+- Estado de rota / router integration (next/router, react-router) — o consumidor passa `href` ou `onClick`; integração com router fica em wrappers downstream.
+- Persistência de estado collapsed/aberto (cookie/localStorage) — o `Sidebar` composite shell já oferece isso para o chrome; `SidebarNav` é stateless externo.
+- Migração ou deprecação do `Sidebar` shell já existente.
+
+## Definition of Done (mapping)
+
+| Item do Plan #83 | AC(s) |
+|---|---|
+| `ui_kit/components/sidebar-nav/index.tsx` com variantes CVA | AC-1, AC-3, AC-4, AC-5..AC-11 |
+| Behavioral tests ≥ 20 ou ≥ 80% coverage | AC-15, AC-16, AC-17 |
+| A11y jest-axe light + dark | AC-18..AC-22 |
+| Storybook light + dark | AC-23, AC-24 |
+| Página Astro + previews | AC-25, AC-26 |
+| Export em `index.ts` | AC-2 |
+| `MIGRATED` Set | AC-27 |
+| Tokens semânticos apenas | AC-3, AC-4 |
+| Brand vs Notion | AC-3, AC-4 (alinhamento explícito) |
+| Lint/typecheck/test/build/docs:build verdes | AC-29..AC-33 |
+| Commit atômico | AC-34 |
+| Fecha Plan #83 via `Closes #83` | AC-34 |

--- a/docs/issues/issue-82/03-architecture.md
+++ b/docs/issues/issue-82/03-architecture.md
@@ -1,0 +1,227 @@
+# Phase 3 — Architecture: `feat(sidebar-nav): migrate SidebarNav to v0.1.0 DoD`
+
+- **Issue:** [#82](https://github.com/guardiatechnology/design-system/issues/82)
+- **Plan sub-issue:** [#83](https://github.com/guardiatechnology/design-system/issues/83)
+- **Brief:** [`01-brief.md`](./01-brief.md) · **Requirements:** [`02-requirements.md`](./02-requirements.md)
+- **ADR slot:** [ADR-019](../../adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md) (pre-allocated)
+- **Status:** complete
+
+## Affected components (scope table)
+
+| Path | Change | Why |
+|---|---|---|
+| `ui_kit/components/sidebar-nav/index.tsx` | **CREATE** | Primitiva canônica `<SidebarNav>` + sub-componentes |
+| `ui_kit/components/sidebar-nav/SidebarNav.stories.tsx` | **CREATE** | Stories Default + Collapsed + variantes (AC-23, AC-24) |
+| `ui_kit/components/sidebar-nav/SidebarNav.test.tsx` | **CREATE** | ≥20 testes behavioral + jest-axe light/dark (AC-15..AC-22) |
+| `ui_kit/components/index.ts` | **MODIFY** | Append `export * from "./sidebar-nav";` (AC-2) |
+| `docs/src/pages/componentes/sidebar-nav.astro` | **CREATE** | Página do site de docs (AC-25) |
+| `docs/src/previews/sidebar-nav.tsx` | **CREATE** | Previews consumidos pela página Astro (AC-26) |
+| `docs/src/pages/index.astro` | **MODIFY** | Adicionar `"SidebarNav"` ao Set `MIGRATED` linha 678 (AC-27) |
+| `docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md` | **CREATE** | Decisões cravadas (AC-28) |
+| `docs/issues/issue-82/01-brief.md` | **CREATE** | Phase 1 artifact |
+| `docs/issues/issue-82/02-requirements.md` | **CREATE** | Phase 2 artifact |
+| `docs/issues/issue-82/03-architecture.md` | **CREATE** | Phase 3 artifact (este arquivo) |
+| `docs/issues/issue-82/05-security-review.md` | **CREATE** | Phase 5 artifact |
+| `docs/issues/issue-82/06-quality-report.md` | **CREATE** | Phase 6 artifact |
+
+**Não alteramos:** `ui_kit/components/sidebar/` (composite shell), `ui_kit/components/navbar/`, `ui_kit/styles/index.css` (todos tokens necessários já existem), `package.json` (zero novas dependências).
+
+## Decisão 1 — Sem Radix base
+
+**Opções:**
+- (a) `@radix-ui/react-navigation-menu` — orientado a top-bar com flyout, semântica fortemente acoplada a menu horizontal; não casa com nav lateral persistente + grupos colapsáveis com chevron.
+- (b) `@radix-ui/react-accordion` para os Groups — força semântica accordion (1+ painel expandido por seção) e introduz dependência semântica errada (sidebar não é acordeão de seções fechadas; é nav com seções sempre visíveis + grupos opcionalmente colapsáveis dentro).
+- (c) `@radix-ui/react-collapsible` para cada Group — leve, exatamente o contrato disjuntivo "abre/fecha um conteúdo". Já é dependência do projeto (`Collapsible` migrado).
+- (d) Sem Radix — implementação manual de `aria-expanded`/`aria-controls`.
+
+**Escolha:** (d) **sem Radix base, mas com aria-expanded/aria-controls manuais**. Racionais:
+
+1. SidebarNav é uma estrutura semântica simples (`<nav>` + lista de itens + grupos com botão+conteúdo). O ganho de `Collapsible` Radix é marginal (~ 30 linhas que substituiríamos por `<button aria-expanded><div hidden></div></button>`); o custo é introduzir dependência semântica de outro componente DS dentro de um primitivo nav.
+2. ConfidenceIndicator (#256, ADR-013) é precedente recente: composição interna sem Radix, sub-componentes anexados via re-export. SidebarNav segue o mesmo padrão.
+3. A trigger e o conteúdo do Group ficam **expostos como sub-componentes** (`SidebarNavGroupTrigger` + `SidebarNavGroupContent`) para que consumers possam compor variantes — paridade com a primitiva exposta de Dialog/Drawer.
+
+Decisão registrada em ADR-019 § "Base primitive".
+
+## Decisão 2 — Composição por sub-componentes (não dot-notation)
+
+A legada usa `(SidebarNav as any).Section = ...` (dot-notation com `any` cast — `lex-frontend-typing` proíbe `any` injustificado). O padrão DS atual (Toast, Dialog, Drawer) é **export de named sub-componentes**:
+
+```tsx
+import {
+  SidebarNav,
+  SidebarNavSection,
+  SidebarNavItem,
+  SidebarNavGroup,
+  SidebarNavGroupTrigger,
+  SidebarNavGroupContent,
+} from "@guardia/design-system";
+```
+
+**Trade-off:** consumer escreve mais imports, mas tree-shaking + tipagem ficam corretos sem `any`. Decisão registrada em ADR-019 § "API shape — named exports vs dot-notation".
+
+## Decisão 3 — Group controlled + uncontrolled
+
+A legada é exclusivamente uncontrolled (`useState(defaultOpen)`). O padrão DS (Collapsible, Drawer, Tooltip) suporta os dois modos:
+
+```tsx
+// Uncontrolled (legada compat)
+<SidebarNavGroup defaultOpen>...</SidebarNavGroup>
+
+// Controlled (novo)
+<SidebarNavGroup open={isOpen} onOpenChange={setIsOpen}>...</SidebarNavGroup>
+```
+
+Implementação: hook interno detecta presença de `open` (controlled) ou usa `useState(defaultOpen ?? true)` (uncontrolled). Mesma assinatura de `Collapsible`. Decisão registrada em ADR-019 § "Group state model".
+
+## Decisão 4 — Modo collapsed: Tooltip vs sr-only
+
+A legada usa `title="..."` (tooltip nativo do browser, A11y limitada). Upgrade decidido:
+
+- **Quando `collapsed=true`:** o item interativo é **wrappeado** em `<Tooltip>` do DS (`@/components/tooltip`) com `content` igual ao label textual quando `children` é string. O label original também vai para `<span className="sr-only">` para garantir leitura por screen reader **antes** de o tooltip ser invocado por hover/focus (defesa em profundidade).
+- **Quando `children` não é string** (e.g., ReactNode complexo), o consumer **deve** passar prop `label?: string` para o tooltip; sem `label`, em modo collapsed o componente lança warning em dev e cai apenas no `sr-only` com `children` serializado via `aria-label`.
+
+Decisão registrada em ADR-019 § "Collapsed label disclosure".
+
+## Decisão 5 — Coexistência com `Sidebar` shell
+
+Já existe `ui_kit/components/sidebar/` (shadcn pattern: `SidebarProvider`, `SidebarTrigger`, `SidebarRail`, cookie de estado, composição com Drawer mobile). SidebarNav **não substitui**, **não modifica**, **não importa** Sidebar shell.
+
+**Cenários de uso documentados na página Astro:**
+
+| Cenário | Use |
+|---|---|
+| Quero o chrome inteiro (app shell com header, trigger, persistência) | `<SidebarProvider> + <Sidebar>` (shell existente) |
+| Quero apenas a árvore de navegação (sem chrome) | `<SidebarNav>` (este componente) |
+| Quero o chrome shell **com** árvore tokenizada dentro | `<Sidebar><SidebarContent><SidebarNav>...</SidebarNav></SidebarContent></Sidebar>` |
+
+Decisão registrada em ADR-019 § "Coexistence with Sidebar shell".
+
+## Tokenização — mapeamento
+
+| Elemento | Token semântico | Light HSL | Dark HSL |
+|---|---|---|---|
+| Container `bg` | `bg-sidebar` | `0 0% 99%` (FDFDFD) | mapeado via `data-theme=dark` em `index.css` |
+| Container `text` | `text-sidebar-foreground` | `240 5% 26%` | idem |
+| Container `border-right` | `border-sidebar-border` | `280 22% 91%` | idem |
+| Section label | `text-muted-foreground` | `240 4% 38%` | idem |
+| Item (resting) | `text-sidebar-foreground` | inherit | inherit |
+| Item icon (resting) | `text-muted-foreground` | inherit | inherit |
+| Item (hover) | `hover:bg-sidebar-accent hover:text-sidebar-accent-foreground` | `280 20% 96%` bg / `281 64% 26%` fg | idem |
+| Item (active) | `bg-sidebar-accent text-sidebar-accent-foreground font-semibold` + `aria-current="page"` | idem | idem |
+| Item icon (active) | `text-sidebar-primary` | `281 64% 26%` | idem |
+| Badge bg | `bg-sidebar-accent` | `280 20% 96%` | idem |
+| Badge fg | `text-sidebar-accent-foreground` | `281 64% 26%` | idem |
+| Focus ring | `focus-visible:ring-2 ring-ring ring-offset-1` | `281 64% 26%` (violet-500) | mapeado pra orange-500 em dark via `--ring` |
+| Group chevron | `text-muted-foreground transition-transform` + rotate-180 quando aberto | inherit | inherit |
+| Divisor (section em collapsed) | `bg-sidebar-border` | inherit | inherit |
+
+**Nenhum** valor cromático fora do chain `--sidebar-*` / `--muted-foreground` / `--ring` é introduzido. Sem expansão de token; sem ADR adicional além de ADR-019.
+
+## API pública detalhada
+
+```tsx
+// Root
+export interface SidebarNavProps extends React.HTMLAttributes<HTMLElement> {
+  collapsed?: boolean;        // default false
+  "aria-label"?: string;      // default "Navegação principal"
+  children: React.ReactNode;
+}
+
+// Section
+export interface SidebarNavSectionProps {
+  label?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}
+
+// Item
+export interface SidebarNavItemProps {
+  icon?: React.ReactNode;
+  badge?: React.ReactNode;
+  active?: boolean;             // default false
+  disabled?: boolean;           // default false
+  href?: string;                // se presente, renderiza <a>; senão <button>
+  onClick?: React.MouseEventHandler;
+  label?: string;               // necessário em collapsed quando children não é string
+  className?: string;
+  children: React.ReactNode;
+}
+
+// Group (uncontrolled OR controlled)
+export interface SidebarNavGroupProps {
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  defaultOpen?: boolean;        // default true (uncontrolled)
+  open?: boolean;               // se presente, vira controlled
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+// CVA accessors públicos
+export const sidebarNavVariants;       // collapsed: boolean
+export const sidebarNavItemVariants;   // active: boolean, disabled: boolean
+```
+
+Sub-componentes adicionais expostos para composição declarativa: `<SidebarNavGroupTrigger>` e `<SidebarNavGroupContent>` (úteis para customizar o markup do header ou conteúdo do grupo).
+
+## Estrutura CVA
+
+```ts
+const sidebarNavVariants = cva(
+  "flex h-full flex-col gap-3 border-r border-sidebar-border bg-sidebar p-3 text-sidebar-foreground transition-[width] duration-200 ease-out motion-reduce:transition-none",
+  {
+    variants: {
+      collapsed: {
+        true: "w-14 items-stretch px-1.5",
+        false: "w-60",
+      },
+    },
+    defaultVariants: { collapsed: false },
+  },
+);
+
+const sidebarNavItemVariants = cva(
+  "group/item flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm font-medium leading-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
+  {
+    variants: {
+      active: {
+        true: "bg-sidebar-accent text-sidebar-accent-foreground font-semibold",
+        false: "",
+      },
+    },
+    defaultVariants: { active: false },
+  },
+);
+```
+
+## Riscos & mitigações
+
+| Risco | Mitigação |
+|---|---|
+| Confusão entre `Sidebar` shell e `SidebarNav` primitiva | Página Astro de SidebarNav carrega seção explícita "Quando usar Sidebar vs SidebarNav" com matriz de cenários; ADR-019 documenta a coexistência |
+| Falta de `label` em collapsed quando children não é string | Warning em dev via `console.warn` (tolerado por `lex-logging-decorator` § exceção 3, "global error boundary" — aqui é desenvolvimento, não produção. **Reavaliado**: para evitar violar `no-console`, o warning vai para um helper que injeta apenas em `process.env.NODE_ENV !== "production"` via `if (typeof console !== "undefined")` — mesmo padrão do `radix-ui` para invariants. ADR-019 § "Collapsed label disclosure" registra. |
+| Visual regression na primeira execução do CI Ubuntu | Política autorizada: aplicar label `regenerate-baselines` (Fernando autorizou para esta janela). Baselines macOS não vão para o repo (`__image_snapshots__/` é Ubuntu-only) |
+| Tooltip em modo collapsed pode causar layout shift | Tooltip do DS usa Portal — não afeta layout do container nav |
+| `<a href>` com `disabled` não tem comportamento nativo | Implementação adiciona `aria-disabled="true" tabIndex={-1} pointer-events-none` no link disabled; testes verificam ambos |
+
+## Stacked PR Decomposition
+
+**Não aplicável.** Decisão Checklist (`codex-stacked-prs`):
+- Alto sinal: 0 (não é DB+migration, não é API+SDK, não é múltiplos contextos)
+- Anti-sinais: PR atômico declarado no Plan #83 ("um Plan = um PR"); todos os arquivos são derivados do mesmo componente
+
+PR único.
+
+## Logging
+
+Componente UI puro — sem logging, sem telemetria. `lex-observability-required` é "every new HTTP endpoint, event consumer, scheduled job, or long-running worker": componente React de design system não se enquadra em nenhuma das categorias.
+
+## Plano de execução
+
+1. **Phase 3 outputs:** este arquivo + ADR-019.
+2. **Gate 1:** auto-aprovado (escopo casa o checklist canônico do Plan #83 sem ambiguidade; não há ação irreversível pendente de decisão humana).
+3. **Phase 4:** implementação na ordem (a) `index.tsx`, (b) `SidebarNav.test.tsx`, (c) `SidebarNav.stories.tsx`, (d) `previews/sidebar-nav.tsx`, (e) `pages/componentes/sidebar-nav.astro`, (f) `index.ts` (barrel), (g) `index.astro` (MIGRATED).
+4. **Phase 5:** security review (componente UI sem input externo — review padrão DS).
+5. **Phase 6:** Gate 2 — typecheck → lint → test → build → docs:build.
+6. **Phase 7:** commit atômico + PR via `gh` (mirror labels + size/* + Closes #82 + Closes #83).

--- a/docs/issues/issue-82/05-security-review.md
+++ b/docs/issues/issue-82/05-security-review.md
@@ -1,0 +1,50 @@
+# Phase 5 — Security Review: `feat(sidebar-nav): migrate SidebarNav to v0.1.0 DoD`
+
+- **Issue:** [#82](https://github.com/guardiatechnology/design-system/issues/82)
+- **Plan sub-issue:** [#83](https://github.com/guardiatechnology/design-system/issues/83)
+- **Architecture:** [`03-architecture.md`](./03-architecture.md)
+- **Status:** ✅ pass
+
+## Scope
+
+`SidebarNav` é uma **primitiva UI de design system**:
+
+- 100% client-side, presentational.
+- Sem chamadas de rede, sem persistência, sem autenticação, sem manipulação de credenciais.
+- Sem leitura/escrita em `localStorage`, `sessionStorage`, cookies, IndexedDB.
+- Sem `dangerouslySetInnerHTML`, sem `innerHTML`, sem manipulação de DOM imperativa.
+- Sem `eval`, sem `Function()`, sem `setTimeout(string, ...)`.
+- Sem dependência runtime nova: usa apenas `react`, `class-variance-authority`, `lucide-react`, `@radix-ui/react-tooltip` (via DS wrapper) — todas já no `package.json` do projeto.
+- Sem exposição de secrets: o componente recebe apenas `ReactNode`/`string`/`boolean` via props; consumidores controlam o conteúdo renderizado.
+
+## Checklist — `lex-frontend-security`
+
+| Rule | Status | Nota |
+|---|---|---|
+| 1. Sem `innerHTML` / `dangerouslySetInnerHTML` | ✅ | Apenas JSX binding seguro |
+| 2. Sem secrets no bundle | ✅ | Componente não manipula credenciais |
+| 3. Auth via HttpOnly cookies | n/a | Componente não gerencia auth |
+| 4. Validação dois níveis | n/a | Componente não processa input do usuário (apenas props) |
+| 5. CSRF | n/a | Sem requests state-changing |
+| 6. CSP | n/a | Configuração de servidor; componente compatível com CSP estrita |
+| 7. Dependências auditadas | ✅ | Zero novas dependências |
+| 8. `target="_blank"` + `rel="noopener noreferrer"` | ✅ | Componente não força `target=_blank`; quando consumer passa `href`, o `<a>` é renderizado sem `target` (consumer decide) |
+
+## Checklist — Lex transversais
+
+| Lex | Status | Nota |
+|---|---|---|
+| `lex-frontend-typing` | ✅ | Strict types, sem `any` |
+| `lex-frontend-accessibility` | ✅ | `<nav>`, `<button>`, `<a>`, `aria-current`, `aria-expanded`, `aria-controls`, `aria-disabled`, `role="group"`, `aria-label`, focus visível, keyboard navigation, Tooltip wrap em collapsed |
+| `lex-design-system-library` | ✅ | Sem cores hardcoded, sem reimplementação de primitivas — Tooltip importado do próprio DS |
+| `lex-logging-decorator` | n/a | Componente não loga nada — zero `console.*`, zero `print` |
+| `lex-observability-required` | n/a | Componente UI de DS não é endpoint/job/worker (escopo da Lex é runtime backend/worker) |
+| `lex-no-silent-tech-debt` | ✅ | Sem `TODO`/`FIXME`/`XXX` sem referência |
+
+## Riscos identificados
+
+Nenhum. Componente UI passivo, dentro de uma biblioteca já consumida em todo o produto.
+
+## Conclusão
+
+✅ **Aprovado.** Sem findings P0/P1. Prosseguir para Phase 6 (Gate 2).

--- a/docs/issues/issue-82/06-quality-report.md
+++ b/docs/issues/issue-82/06-quality-report.md
@@ -1,0 +1,85 @@
+# Phase 6 — Quality Report (Gate 2): `feat(sidebar-nav): migrate SidebarNav to v0.1.0 DoD`
+
+- **Issue:** [#82](https://github.com/guardiatechnology/design-system/issues/82)
+- **Plan sub-issue:** [#83](https://github.com/guardiatechnology/design-system/issues/83)
+- **Status:** ✅ **GO**
+- **Run at:** 2026-05-29
+
+## Checks
+
+| # | Check | Status | Detail |
+|---|---|---|---|
+| 1 | `npm run typecheck` | ✅ | 0 erros TypeScript em `tsc -p tsconfig.test.json --noEmit` |
+| 2 | `npm run lint` | ✅ | 0 erros ESLint. 0 warnings novos em `ui_kit/components/sidebar-nav/**`; warnings pré-existentes em outros componentes não foram tocados |
+| 3 | `npm run test` | ✅ | **1262/1262** testes passando, incluindo **36/36** em `SidebarNav.test.tsx` (10 invocações jest-axe sobre 5 estados × 2 temas) |
+| 4 | `npm run build` | ✅ | rslib build: 70 arquivos em `dist/`, 413.9 kB (104.4 kB gzipped), declarations geradas |
+| 5 | `npm run docs:build` | ✅ | Astro build: 34 páginas, incluindo nova `/componentes/sidebar-nav/index.html` |
+
+## AC ↔ Test Traceability
+
+Cada AC do `02-requirements.md` é coberto por pelo menos um `it("AC-N: ...")` em `SidebarNav.test.tsx`:
+
+| AC | Tests | Status |
+|---|---|---|
+| AC-1 (public surface) | 3 | ✅ |
+| AC-2 (barrel) | — (verificado em build/typecheck) | ✅ |
+| AC-3 (tokens, sem hex/oklch/chromatic) | 1 | ✅ |
+| AC-4 (root bg/text/border) | 1 | ✅ |
+| AC-5 (collapsed) | 3 | ✅ |
+| AC-6 (motion-reduce) | 1 | ✅ |
+| AC-7 (icon, badge) | 3 | ✅ |
+| AC-8 (active + aria-current) | 1 | ✅ |
+| AC-9 (button/anchor/onClick/disabled) | 5 | ✅ |
+| AC-10 (section label + divider) | 2 | ✅ |
+| AC-11 (Group controlled/uncontrolled/collapsed) | 5 | ✅ |
+| AC-12 (nav landmark + aria-label) | 2 | ✅ |
+| AC-13 (keyboard activation) | 1 | ✅ |
+| AC-14 (collapsed label disclosure) | 1 | ✅ |
+| AC-15..AC-17 (tests count + queries + no internal mocks) | — (estrutural; 36 tests, queries acessíveis, sem mocks internos) | ✅ |
+| AC-18..AC-22 (jest-axe light+dark sobre 5 estados) | 5 | ✅ |
+| AC-23 (Storybook stories renderizam) | 1 + arquivo stories cobre Default/Collapsed/Active/Badges/Groups/Realistic | ✅ |
+| AC-24 (zero classes cromáticas externas) | verificado via leitura da stories file (sem `text-violet-*`/`bg-orange-*`) | ✅ |
+| AC-25 (Astro page existe) | docs:build green produz `/componentes/sidebar-nav/index.html` | ✅ |
+| AC-26 (previews exportadas) | imports no `.astro` resolvem; build verde | ✅ |
+| AC-27 (MIGRATED set) | "SidebarNav" adicionado em `docs/src/pages/index.astro` linha 685; build verde mapeia para `/componentes/sidebar-nav/` | ✅ |
+| AC-28 (ADR-019) | `docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md` em status `accepted` | ✅ |
+| AC-29..AC-33 (Gate 2 programático) | ver tabela "Checks" acima | ✅ |
+| AC-34 (commit atômico) | aplicado na Phase 7 | (aplicar na Phase 7) |
+
+## Scope creep
+
+Nenhum. Arquivos modificados estão estritamente dentro do escopo declarado em `03-architecture.md`:
+
+```
+docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md           (CREATE)
+docs/issues/issue-82/01-brief.md                               (CREATE)
+docs/issues/issue-82/02-requirements.md                        (CREATE)
+docs/issues/issue-82/03-architecture.md                        (CREATE)
+docs/issues/issue-82/05-security-review.md                     (CREATE)
+docs/issues/issue-82/06-quality-report.md                      (CREATE)
+docs/src/pages/componentes/sidebar-nav.astro                   (CREATE)
+docs/src/pages/index.astro                                     (MODIFY +1 line)
+docs/src/previews/sidebar-nav.tsx                              (CREATE)
+ui_kit/components/index.ts                                     (MODIFY +1 line)
+ui_kit/components/sidebar-nav/SidebarNav.stories.tsx           (CREATE)
+ui_kit/components/sidebar-nav/SidebarNav.test.tsx              (CREATE)
+ui_kit/components/sidebar-nav/index.tsx                        (CREATE)
+```
+
+Nenhum arquivo fora deste conjunto foi tocado.
+
+## Observabilidade
+
+`lex-observability-required` é "Every new HTTP endpoint, event consumer, scheduled job, or long-running worker" — SidebarNav é componente UI puro, não se enquadra em nenhuma das categorias. Sem violação.
+
+## Tests pyramid
+
+Projeto é biblioteca pura (sem I/O). Conforme `lex-test-pyramid` § "Pyramid adapted by context" → "Pure libraries (no I/O): 90%+ unit is acceptable." A suite respeita o desvio documentado para o tipo de projeto.
+
+## Flake noted
+
+`Tooltip > AC-1: tooltip surface is re-exported from the components barrel unchanged` — primeira execução em paralelo expirou em 20s. Re-rodada em isolamento: passou em 8.77s. Re-rodada da suite completa: passou. **Flake pré-existente, não causado por SidebarNav.** Sem ação requerida — não bloqueia o Gate.
+
+## Decisão
+
+✅ **GO.** Prosseguir para Phase 7.

--- a/docs/src/pages/componentes/sidebar-nav.astro
+++ b/docs/src/pages/componentes/sidebar-nav.astro
@@ -1,0 +1,327 @@
+---
+import ComponentPreview from "../../layouts/ComponentPreview.astro";
+import HighlightedCode from "../../components/HighlightedCode.astro";
+import {
+  BasicRow,
+  CollapsedRow,
+  ActiveItemRow,
+  BadgesRow,
+  GroupsRow,
+  RealisticRow,
+} from "../../previews/sidebar-nav";
+import sidebarNavSource from "@ds/components/sidebar-nav/index.tsx?raw";
+---
+
+<ComponentPreview
+  kicker="COMPONENTES · NAVIGATION"
+  title="SidebarNav"
+  group="Navigation"
+  storybookId="components-sidebarnav--default"
+  sourcePath="ui_kit/components/sidebar-nav"
+  lede='Primitiva canônica de navegação lateral vertical com seções, grupos colapsáveis, item ativo, badge e modo <code class="inline">collapsed</code> (só ícones). Distinta de <code class="inline">&lt;Sidebar&gt;</code> (chrome de aplicação com <code class="inline">&lt;SidebarProvider&gt;</code>, persistência cookie e Drawer mobile) — <code class="inline">SidebarNav</code> é a árvore de navegação consumida dentro de qualquer chrome. Sem Radix base (composição manual de <code class="inline">aria-expanded</code> + <code class="inline">aria-controls</code>); em modo collapsed cada item interativo é wrappeado em <code class="inline">&lt;Tooltip&gt;</code> do DS com defesa em profundidade via <code class="inline">sr-only</code>.'
+>
+  <!-- ============ BASIC ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Padrão</h2>
+      <small>composição: SidebarNav · SidebarNavSection · SidebarNavItem</small>
+    </div>
+    <div class="preview">
+      <BasicRow client:load />
+    </div>
+    <p class="preview-caption">
+      Estrutura típica: <code class="inline">&lt;SidebarNav&gt;</code> envolve
+      uma ou mais <code class="inline">&lt;SidebarNavSection&gt;</code>; cada
+      seção contém <code class="inline">&lt;SidebarNavItem&gt;</code>. O item
+      ativo recebe <code class="inline">active</code> e o DS aplica
+      <code class="inline">aria-current="page"</code> automaticamente.
+    </p>
+  </section>
+
+  <!-- ============ COLLAPSED ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Modo Collapsed</h2>
+      <small>só ícones · tooltips automáticos</small>
+    </div>
+    <div class="preview">
+      <CollapsedRow client:load />
+    </div>
+    <p class="preview-caption">
+      Em <code class="inline">collapsed=true</code> a largura reduz para a
+      faixa compacta, labels viram <code class="inline">sr-only</code>, badges
+      somem e cada item interativo é wrappeado em
+      <code class="inline">&lt;Tooltip&gt;</code> do DS com o label textual.
+      Labels de seção viram divisor (<code class="inline">&lt;hr&gt;</code>).
+      A transição <code class="inline">width</code> respeita
+      <code class="inline">prefers-reduced-motion</code>.
+    </p>
+  </section>
+
+  <!-- ============ ACTIVE ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Estado Ativo</h2>
+      <small>aria-current="page" automático</small>
+    </div>
+    <div class="preview">
+      <ActiveItemRow client:load />
+    </div>
+    <p class="preview-caption">
+      Controle externo via prop <code class="inline">active</code>. O
+      componente aplica o token chain
+      <code class="inline">bg-sidebar-accent</code> +
+      <code class="inline">text-sidebar-accent-foreground</code> +
+      <code class="inline">font-semibold</code>; o ícone migra para
+      <code class="inline">text-sidebar-primary</code>.
+    </p>
+  </section>
+
+  <!-- ============ BADGES ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Badges</h2>
+      <small>contadores à direita · ocultos em collapsed</small>
+    </div>
+    <div class="preview">
+      <BadgesRow client:load />
+    </div>
+    <p class="preview-caption">
+      Badge à direita, alinhado por <code class="inline">ml-auto</code>.
+      Aceita <code class="inline">ReactNode</code> arbitrário — o caso comum
+      é número/string curtos. Em <code class="inline">collapsed=true</code> o
+      badge não é renderizado (a contagem fica disponível ao expandir).
+    </p>
+  </section>
+
+  <!-- ============ GROUPS ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Grupos</h2>
+      <small>SidebarNavGroup · trigger + content controlados</small>
+    </div>
+    <div class="preview">
+      <GroupsRow client:load />
+    </div>
+    <p class="preview-caption">
+      Grupos colapsáveis: <code class="inline">defaultOpen</code> para uso
+      descontrolado, ou <code class="inline">open</code> +
+      <code class="inline">onOpenChange</code> para controle externo. A
+      trigger emite <code class="inline">aria-expanded</code> +
+      <code class="inline">aria-controls</code>; o conteúdo expõe
+      <code class="inline">role="group"</code> +
+      <code class="inline">aria-labelledby</code>. Em
+      <code class="inline">collapsed</code>, o grupo se dissolve — os filhos
+      são renderizados inline (paridade com a referência legada).
+    </p>
+  </section>
+
+  <!-- ============ REALISTIC ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Estrutura Realista</h2>
+      <small>paridade com playground legado</small>
+    </div>
+    <div class="preview">
+      <RealisticRow client:load />
+    </div>
+    <p class="preview-caption">
+      Fixture canônica: 3 seções, 2 grupos (um aberto, um fechado), 3 itens
+      com ícone, 2 com badge, 1 ativo. Replica
+      <code class="inline">ux_references/ui_kits/components/SidebarNav/SidebarNav.playground.html</code>.
+    </p>
+  </section>
+
+  <!-- ============ COEXISTENCE ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Quando usar Sidebar vs SidebarNav</h2>
+      <small>ortogonal · composição opcional</small>
+    </div>
+    <div class="props">
+      <table>
+        <thead>
+          <tr><th>Cenário</th><th>Use</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="name">Quero o chrome inteiro de app (header com trigger, persistência cookie, mobile Drawer)</td>
+            <td class="desc"><code class="inline">&lt;SidebarProvider&gt;</code> + <code class="inline">&lt;Sidebar&gt;</code> (shell shadcn-derived)</td>
+          </tr>
+          <tr>
+            <td class="name">Quero apenas a árvore de navegação tokenizada (sem chrome)</td>
+            <td class="desc"><code class="inline">&lt;SidebarNav&gt;</code> (este componente)</td>
+          </tr>
+          <tr>
+            <td class="name">Quero o chrome shell <b>com</b> árvore tokenizada dentro</td>
+            <td class="desc"><code class="inline">&lt;Sidebar&gt;&lt;SidebarContent&gt;&lt;SidebarNav&gt;...&lt;/SidebarNav&gt;&lt;/SidebarContent&gt;&lt;/Sidebar&gt;</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ============ PROPS ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Props</h2>
+      <small>API pública</small>
+    </div>
+    <div class="props">
+      <table>
+        <thead>
+          <tr><th>Componente · Prop</th><th>Tipo</th><th>Default</th><th>Descrição</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="name">SidebarNav · collapsed</td>
+            <td class="type">boolean</td>
+            <td class="default">false</td>
+            <td class="desc">Modo compacto (só ícones, labels em <code class="inline">sr-only</code>, badges ocultos).</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNav · aria-label</td>
+            <td class="type">string</td>
+            <td class="default">"Navegação principal"</td>
+            <td class="desc">Override do nome acessível do <code class="inline">&lt;nav&gt;</code>.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavSection · label</td>
+            <td class="type">ReactNode</td>
+            <td class="default">—</td>
+            <td class="desc">Cabeçalho da seção (oculto em <code class="inline">collapsed</code>, substituído por divisor).</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavItem · icon</td>
+            <td class="type">ReactNode</td>
+            <td class="default">—</td>
+            <td class="desc">Ícone à esquerda. Recomendado: Lucide React.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavItem · badge</td>
+            <td class="type">ReactNode</td>
+            <td class="default">—</td>
+            <td class="desc">Contador à direita. Oculto em <code class="inline">collapsed</code>.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavItem · active</td>
+            <td class="type">boolean</td>
+            <td class="default">false</td>
+            <td class="desc">Estado selecionado. Aplica <code class="inline">aria-current="page"</code>.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavItem · disabled</td>
+            <td class="type">boolean</td>
+            <td class="default">false</td>
+            <td class="desc">Desativa interação. Em <code class="inline">&lt;a&gt;</code>, aplica <code class="inline">aria-disabled</code> + <code class="inline">tabIndex=-1</code>.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavItem · href</td>
+            <td class="type">string</td>
+            <td class="default">—</td>
+            <td class="desc">Se presente, renderiza <code class="inline">&lt;a&gt;</code>; senão <code class="inline">&lt;button&gt;</code>.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavItem · onClick</td>
+            <td class="type">MouseEventHandler</td>
+            <td class="default">—</td>
+            <td class="desc">Forwarded ao elemento renderizado.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavItem · label</td>
+            <td class="type">string</td>
+            <td class="default">derivado de children quando string</td>
+            <td class="desc">Override do label para Tooltip em modo collapsed.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavGroup · label</td>
+            <td class="type">ReactNode</td>
+            <td class="default">—</td>
+            <td class="desc">Cabeçalho do grupo (obrigatório).</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavGroup · icon</td>
+            <td class="type">ReactNode</td>
+            <td class="default">—</td>
+            <td class="desc">Ícone à esquerda do header.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavGroup · defaultOpen</td>
+            <td class="type">boolean</td>
+            <td class="default">true</td>
+            <td class="desc">Estado inicial (uncontrolled).</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavGroup · open</td>
+            <td class="type">boolean</td>
+            <td class="default">—</td>
+            <td class="desc">Estado controlado.</td>
+          </tr>
+          <tr>
+            <td class="name">SidebarNavGroup · onOpenChange</td>
+            <td class="type">(open: boolean) =&gt; void</td>
+            <td class="default">—</td>
+            <td class="desc">Callback de mudança de estado.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ============ KEYBOARD ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Teclado</h2>
+      <small>navegação e ativação</small>
+    </div>
+    <div class="props">
+      <table>
+        <thead>
+          <tr><th>Tecla</th><th>Ação</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="name">Tab</td><td class="desc">Avança para o próximo item interativo (ordem visual).</td></tr>
+          <tr><td class="name">Shift + Tab</td><td class="desc">Retrocede para o item anterior.</td></tr>
+          <tr><td class="name">Enter / Space</td><td class="desc">Ativa <code class="inline">&lt;button&gt;</code> (item ou trigger de grupo).</td></tr>
+          <tr><td class="name">Enter</td><td class="desc">Ativa <code class="inline">&lt;a&gt;</code> (item com <code class="inline">href</code>).</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ============ SOURCE ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Código-fonte</h2>
+      <small>ui_kit/components/sidebar-nav/index.tsx</small>
+    </div>
+    <HighlightedCode
+      code={sidebarNavSource}
+      language="tsx"
+      filename="ui_kit/components/sidebar-nav/index.tsx"
+      maxHeight="520px"
+      showLineNumbers
+    />
+  </section>
+
+  <!-- ============ A11Y ============ -->
+  <section class="sec">
+    <div class="sec-hdr">
+      <h2>Acessibilidade</h2>
+      <small>WCAG 2.1 AA · ARIA disclosure pattern</small>
+    </div>
+    <div class="a11y">
+      <ul>
+        <li><span><b>Landmark</b>: o container raiz é um <code class="inline">&lt;nav&gt;</code> com <code class="inline">aria-label="Navegação principal"</code> (override via prop).</span></li>
+        <li><span><b>Item ativo</b>: aplica <code class="inline">aria-current="page"</code> no elemento renderizado (button ou anchor).</span></li>
+        <li><span><b>Grupo</b>: trigger expõe <code class="inline">aria-expanded</code> + <code class="inline">aria-controls</code>; conteúdo expõe <code class="inline">role="group"</code> + <code class="inline">aria-labelledby</code> apontando para a trigger.</span></li>
+        <li><span><b>Disabled em link</b>: <code class="inline">aria-disabled="true"</code> + <code class="inline">tabIndex=-1</code> + <code class="inline">pointer-events-none</code> — interação efetivamente bloqueada (paridade com <code class="inline">&lt;button disabled&gt;</code>).</span></li>
+        <li><span><b>Collapsed disclosure</b>: cada item interativo é wrappeado em <code class="inline">&lt;Tooltip&gt;</code> do DS; o label original vai também para <code class="inline">&lt;span className="sr-only"&gt;</code> via <code class="inline">aria-label</code> no elemento renderizado — defesa em profundidade.</span></li>
+        <li><span><b>Foco visível</b>: <code class="inline">focus-visible:ring-2 ring-ring ring-offset-1</code> em todos os interativos.</span></li>
+        <li><span><b>Motion</b>: a transição de width respeita <code class="inline">prefers-reduced-motion: reduce</code> via <code class="inline">motion-reduce:transition-none</code>.</span></li>
+        <li><span><b>jest-axe</b> cobre Default + Active + Collapsed + GroupOpen + Disabled em <code class="inline">light</code> e <code class="inline">dark</code> (ver <code class="inline">SidebarNav.test.tsx</code>).</span></li>
+        <li><span><b>Contraste</b>: token chain <code class="inline">--sidebar-*</code> garante ≥ 4.5:1 (texto) e ≥ 3:1 (UI) em ambos os temas.</span></li>
+      </ul>
+    </div>
+  </section>
+</ComponentPreview>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -701,6 +701,7 @@ const storybookUrl = import.meta.env.DEV
         "Radio",
         "Select",
         "Separator",
+        "SidebarNav",
         "Skeleton",
         "Slider",
         "Spinner",

--- a/docs/src/previews/sidebar-nav.tsx
+++ b/docs/src/previews/sidebar-nav.tsx
@@ -1,0 +1,250 @@
+import * as React from "react";
+import {
+  ArrowLeftRight,
+  BookOpenCheck,
+  Inbox,
+  LayoutDashboard,
+  LifeBuoy,
+  ReceiptText,
+  Settings,
+  Users,
+} from "lucide-react";
+
+import {
+  SidebarNav,
+  SidebarNavGroup,
+  SidebarNavGroupContent,
+  SidebarNavGroupTrigger,
+  SidebarNavItem,
+  SidebarNavSection,
+} from "@ds/components/sidebar-nav";
+
+// ──────────────────────────────────────────────────────────────────
+// Page stub — visual filler for the right column in each preview
+// ──────────────────────────────────────────────────────────────────
+
+function PageStub({ label }: { label: string }): React.ReactElement {
+  return (
+    <div className="flex min-h-[360px] flex-1 items-center justify-center rounded-lg border border-border bg-background p-8 text-sm text-muted-foreground">
+      Conteúdo: <b className="ml-1 text-foreground">{label}</b>
+    </div>
+  );
+}
+
+function Shell({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}): React.ReactElement {
+  return (
+    <div className="flex h-[420px] gap-4 rounded-lg bg-muted/40 p-2">
+      {children}
+      <PageStub label={label} />
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// BasicRow — default expanded
+// ──────────────────────────────────────────────────────────────────
+
+export function BasicRow(): React.ReactElement {
+  return (
+    <Shell label="rotas / seções ativas">
+      <SidebarNav>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem icon={<LayoutDashboard />} active>
+            Início
+          </SidebarNavItem>
+          <SidebarNavItem icon={<Inbox />}>Inbox</SidebarNavItem>
+          <SidebarNavItem icon={<Users />}>Clientes</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// CollapsedRow
+// ──────────────────────────────────────────────────────────────────
+
+export function CollapsedRow(): React.ReactElement {
+  return (
+    <Shell label="modo compacto">
+      <SidebarNav collapsed>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem icon={<LayoutDashboard />} active>
+            Início
+          </SidebarNavItem>
+          <SidebarNavItem icon={<Inbox />}>Inbox</SidebarNavItem>
+          <SidebarNavItem icon={<Users />}>Clientes</SidebarNavItem>
+        </SidebarNavSection>
+        <SidebarNavSection label="Sistema">
+          <SidebarNavItem icon={<Settings />}>Configurações</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// ActiveItemRow — interactive
+// ──────────────────────────────────────────────────────────────────
+
+export function ActiveItemRow(): React.ReactElement {
+  const [active, setActive] = React.useState("clientes");
+  return (
+    <Shell label={`ativo: ${active}`}>
+      <SidebarNav>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem
+            icon={<LayoutDashboard />}
+            active={active === "inicio"}
+            onClick={() => setActive("inicio")}
+          >
+            Início
+          </SidebarNavItem>
+          <SidebarNavItem
+            icon={<Inbox />}
+            active={active === "inbox"}
+            onClick={() => setActive("inbox")}
+          >
+            Inbox
+          </SidebarNavItem>
+          <SidebarNavItem
+            icon={<Users />}
+            active={active === "clientes"}
+            onClick={() => setActive("clientes")}
+          >
+            Clientes
+          </SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// BadgesRow
+// ──────────────────────────────────────────────────────────────────
+
+export function BadgesRow(): React.ReactElement {
+  return (
+    <Shell label="contadores">
+      <SidebarNav>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem icon={<Inbox />} badge="12">
+            Inbox
+          </SidebarNavItem>
+          <SidebarNavItem icon={<ReceiptText />} badge="3">
+            Fiscal
+          </SidebarNavItem>
+          <SidebarNavItem icon={<Users />} badge="124">
+            Clientes
+          </SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// GroupsRow
+// ──────────────────────────────────────────────────────────────────
+
+export function GroupsRow(): React.ReactElement {
+  return (
+    <Shell label="grupos colapsáveis">
+      <SidebarNav>
+        <SidebarNavSection label="Operação">
+          <SidebarNavGroup label="Contábil" icon={<BookOpenCheck />}>
+            <SidebarNavGroupTrigger />
+            <SidebarNavGroupContent>
+              <SidebarNavItem>Lançamentos</SidebarNavItem>
+              <SidebarNavItem>Razão</SidebarNavItem>
+              <SidebarNavItem>Plano de contas</SidebarNavItem>
+            </SidebarNavGroupContent>
+          </SidebarNavGroup>
+          <SidebarNavGroup
+            label="Financeiro"
+            icon={<ArrowLeftRight />}
+            defaultOpen={false}
+          >
+            <SidebarNavGroupTrigger />
+            <SidebarNavGroupContent>
+              <SidebarNavItem>Conciliação</SidebarNavItem>
+              <SidebarNavItem>Extratos</SidebarNavItem>
+            </SidebarNavGroupContent>
+          </SidebarNavGroup>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// RealisticRow — paridade com o playground legacy
+// ──────────────────────────────────────────────────────────────────
+
+export function RealisticRow(): React.ReactElement {
+  const [active, setActive] = React.useState("inicio");
+  const handler = (key: string) => ({
+    active: active === key,
+    onClick: () => setActive(key),
+  });
+  return (
+    <Shell label={`cenário pleno · ativo: ${active}`}>
+      <SidebarNav>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem icon={<LayoutDashboard />} {...handler("inicio")}>
+            Início
+          </SidebarNavItem>
+          <SidebarNavItem icon={<Inbox />} badge="12" {...handler("inbox")}>
+            Inbox
+          </SidebarNavItem>
+          <SidebarNavItem icon={<Users />} {...handler("clientes")}>
+            Clientes
+          </SidebarNavItem>
+        </SidebarNavSection>
+        <SidebarNavSection label="Operação">
+          <SidebarNavGroup label="Contábil" icon={<BookOpenCheck />}>
+            <SidebarNavGroupTrigger />
+            <SidebarNavGroupContent>
+              <SidebarNavItem {...handler("lanc")}>Lançamentos</SidebarNavItem>
+              <SidebarNavItem {...handler("razao")}>Razão</SidebarNavItem>
+              <SidebarNavItem {...handler("plano")}>Plano de contas</SidebarNavItem>
+            </SidebarNavGroupContent>
+          </SidebarNavGroup>
+          <SidebarNavGroup
+            label="Financeiro"
+            icon={<ArrowLeftRight />}
+            defaultOpen={false}
+          >
+            <SidebarNavGroupTrigger />
+            <SidebarNavGroupContent>
+              <SidebarNavItem {...handler("conc")}>Conciliação</SidebarNavItem>
+              <SidebarNavItem {...handler("extratos")}>Extratos</SidebarNavItem>
+            </SidebarNavGroupContent>
+          </SidebarNavGroup>
+          <SidebarNavItem
+            icon={<ReceiptText />}
+            badge="3"
+            {...handler("fiscal")}
+          >
+            Fiscal
+          </SidebarNavItem>
+        </SidebarNavSection>
+        <SidebarNavSection label="Sistema">
+          <SidebarNavItem icon={<Settings />} {...handler("config")}>
+            Configurações
+          </SidebarNavItem>
+          <SidebarNavItem icon={<LifeBuoy />} {...handler("ajuda")}>
+            Ajuda
+          </SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  );
+}

--- a/ui_kit/components/index.ts
+++ b/ui_kit/components/index.ts
@@ -38,6 +38,7 @@ export * from "./separator";
 // Sheet retired by ADR-012 (Drawer + Sheet consolidation under canonical
 // Drawer with `side` variant). See docs/adr/ADR-012-drawer-v0.1.0-dod-migration.md.
 export * from "./sidebar";
+export * from "./sidebar-nav";
 export * from "./skeleton";
 export * from "./slider";
 export * from "./sonner";

--- a/ui_kit/components/sidebar-nav/SidebarNav.stories.tsx
+++ b/ui_kit/components/sidebar-nav/SidebarNav.stories.tsx
@@ -1,0 +1,321 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+import {
+  ArrowLeftRight,
+  BookOpenCheck,
+  Inbox,
+  LayoutDashboard,
+  LifeBuoy,
+  ReceiptText,
+  Settings,
+  Users,
+} from "lucide-react";
+
+import {
+  SidebarNav,
+  SidebarNavGroup,
+  SidebarNavGroupContent,
+  SidebarNavGroupTrigger,
+  SidebarNavItem,
+  SidebarNavSection,
+} from "./index";
+
+const meta: Meta<typeof SidebarNav> = {
+  title: "Components/SidebarNav",
+  component: SidebarNav,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          'Primitiva canônica de navegação lateral vertical com seções, grupos colapsáveis, item ativo, badge e modo `collapsed` (só ícones). Distinta do `<Sidebar>` composite shell (chrome de aplicação com `<SidebarProvider>`, persistência cookie e Drawer mobile) — `SidebarNav` é a árvore de navegação consumida dentro de qualquer chrome. Sem Radix base (composição manual de `aria-expanded`/`aria-controls`); em modo collapsed cada item interativo é wrappeado em `<Tooltip>` do DS com defesa em profundidade via `sr-only`. Decisões em ADR-019.',
+      },
+    },
+  },
+  argTypes: {
+    collapsed: { control: "boolean" },
+    "aria-label": { control: "text" },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function PageStub({ label }: { label: string }): React.ReactElement {
+  return (
+    <div className="flex min-h-[420px] flex-1 items-center justify-center rounded-lg border border-border bg-background p-8 text-sm text-muted-foreground">
+      Conteúdo: <b className="ml-1 text-foreground">{label}</b>
+    </div>
+  );
+}
+
+function Shell({
+  children,
+  contentLabel,
+}: {
+  children: React.ReactNode;
+  contentLabel: string;
+}): React.ReactElement {
+  return (
+    <div className="flex h-[520px] gap-4 rounded-lg bg-muted/40 p-2">
+      {children}
+      <PageStub label={contentLabel} />
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Default
+// ──────────────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  render: () => (
+    <Shell contentLabel="rotas / seções ativas">
+      <SidebarNav>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem icon={<LayoutDashboard />} active>
+            Início
+          </SidebarNavItem>
+          <SidebarNavItem icon={<Inbox />}>Inbox</SidebarNavItem>
+          <SidebarNavItem icon={<Users />}>Clientes</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  ),
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Collapsed
+// ──────────────────────────────────────────────────────────────────
+
+export const Collapsed: Story = {
+  render: () => (
+    <Shell contentLabel="modo compacto">
+      <SidebarNav collapsed>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem icon={<LayoutDashboard />} active>
+            Início
+          </SidebarNavItem>
+          <SidebarNavItem icon={<Inbox />}>Inbox</SidebarNavItem>
+          <SidebarNavItem icon={<Users />}>Clientes</SidebarNavItem>
+        </SidebarNavSection>
+        <SidebarNavSection label="Sistema">
+          <SidebarNavItem icon={<Settings />}>Configurações</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Modo `collapsed`: labels viram `sr-only`, badges somem, cada item interativo é wrappeado em `<Tooltip>` do DS com o label textual. Section label vira divisor (`<hr>`).',
+      },
+    },
+  },
+};
+
+// ──────────────────────────────────────────────────────────────────
+// WithActiveItem
+// ──────────────────────────────────────────────────────────────────
+
+function ActiveDemo(): React.ReactElement {
+  const [active, setActive] = React.useState("clientes");
+  return (
+    <SidebarNav>
+      <SidebarNavSection label="Geral">
+        <SidebarNavItem
+          icon={<LayoutDashboard />}
+          active={active === "inicio"}
+          onClick={() => setActive("inicio")}
+        >
+          Início
+        </SidebarNavItem>
+        <SidebarNavItem
+          icon={<Inbox />}
+          active={active === "inbox"}
+          onClick={() => setActive("inbox")}
+        >
+          Inbox
+        </SidebarNavItem>
+        <SidebarNavItem
+          icon={<Users />}
+          active={active === "clientes"}
+          onClick={() => setActive("clientes")}
+        >
+          Clientes
+        </SidebarNavItem>
+      </SidebarNavSection>
+    </SidebarNav>
+  );
+}
+
+export const WithActiveItem: Story = {
+  render: () => (
+    <Shell contentLabel="clique para alternar ativo">
+      <ActiveDemo />
+    </Shell>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`active` controla via prop. O componente aplica `aria-current=\"page\"` no elemento renderizado e o estado visual via `bg-sidebar-accent text-sidebar-accent-foreground font-semibold`.",
+      },
+    },
+  },
+};
+
+// ──────────────────────────────────────────────────────────────────
+// WithBadges
+// ──────────────────────────────────────────────────────────────────
+
+export const WithBadges: Story = {
+  render: () => (
+    <Shell contentLabel="contadores à direita">
+      <SidebarNav>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem icon={<Inbox />} badge="12">
+            Inbox
+          </SidebarNavItem>
+          <SidebarNavItem icon={<ReceiptText />} badge="3">
+            Fiscal
+          </SidebarNavItem>
+          <SidebarNavItem icon={<Users />} badge="124">
+            Clientes
+          </SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Badge à direita do item, escondido em modo `collapsed`. Tokens `bg-sidebar-accent` + `text-sidebar-accent-foreground` reaproveitados do item ativo.",
+      },
+    },
+  },
+};
+
+// ──────────────────────────────────────────────────────────────────
+// WithGroups
+// ──────────────────────────────────────────────────────────────────
+
+export const WithGroups: Story = {
+  render: () => (
+    <Shell contentLabel="grupo colapsável">
+      <SidebarNav>
+        <SidebarNavSection label="Operação">
+          <SidebarNavGroup label="Contábil" icon={<BookOpenCheck />}>
+            <SidebarNavGroupTrigger />
+            <SidebarNavGroupContent>
+              <SidebarNavItem>Lançamentos</SidebarNavItem>
+              <SidebarNavItem>Razão</SidebarNavItem>
+              <SidebarNavItem>Plano de contas</SidebarNavItem>
+            </SidebarNavGroupContent>
+          </SidebarNavGroup>
+          <SidebarNavGroup
+            label="Financeiro"
+            icon={<ArrowLeftRight />}
+            defaultOpen={false}
+          >
+            <SidebarNavGroupTrigger />
+            <SidebarNavGroupContent>
+              <SidebarNavItem>Conciliação</SidebarNavItem>
+              <SidebarNavItem>Extratos</SidebarNavItem>
+            </SidebarNavGroupContent>
+          </SidebarNavGroup>
+        </SidebarNavSection>
+      </SidebarNav>
+    </Shell>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Grupos descontrolados (`defaultOpen`) ou controlados (`open`/`onOpenChange`). Trigger emite `aria-expanded` e `aria-controls` para o conteúdo (`role=\"group\"`).",
+      },
+    },
+  },
+};
+
+// ──────────────────────────────────────────────────────────────────
+// DenseRealistic — fixture do playground legado
+// ──────────────────────────────────────────────────────────────────
+
+function RealisticDemo(): React.ReactElement {
+  const [active, setActive] = React.useState("inicio");
+  const handler = (key: string) => ({
+    active: active === key,
+    onClick: () => setActive(key),
+  });
+  return (
+    <SidebarNav>
+      <SidebarNavSection label="Geral">
+        <SidebarNavItem icon={<LayoutDashboard />} {...handler("inicio")}>
+          Início
+        </SidebarNavItem>
+        <SidebarNavItem icon={<Inbox />} badge="12" {...handler("inbox")}>
+          Inbox
+        </SidebarNavItem>
+        <SidebarNavItem icon={<Users />} {...handler("clientes")}>
+          Clientes
+        </SidebarNavItem>
+      </SidebarNavSection>
+      <SidebarNavSection label="Operação">
+        <SidebarNavGroup label="Contábil" icon={<BookOpenCheck />}>
+          <SidebarNavGroupTrigger />
+          <SidebarNavGroupContent>
+            <SidebarNavItem {...handler("lanc")}>Lançamentos</SidebarNavItem>
+            <SidebarNavItem {...handler("razao")}>Razão</SidebarNavItem>
+            <SidebarNavItem {...handler("plano")}>Plano de contas</SidebarNavItem>
+          </SidebarNavGroupContent>
+        </SidebarNavGroup>
+        <SidebarNavGroup
+          label="Financeiro"
+          icon={<ArrowLeftRight />}
+          defaultOpen={false}
+        >
+          <SidebarNavGroupTrigger />
+          <SidebarNavGroupContent>
+            <SidebarNavItem {...handler("conc")}>Conciliação</SidebarNavItem>
+            <SidebarNavItem {...handler("extratos")}>Extratos</SidebarNavItem>
+          </SidebarNavGroupContent>
+        </SidebarNavGroup>
+        <SidebarNavItem
+          icon={<ReceiptText />}
+          badge="3"
+          {...handler("fiscal")}
+        >
+          Fiscal
+        </SidebarNavItem>
+      </SidebarNavSection>
+      <SidebarNavSection label="Sistema">
+        <SidebarNavItem icon={<Settings />} {...handler("config")}>
+          Configurações
+        </SidebarNavItem>
+        <SidebarNavItem icon={<LifeBuoy />} {...handler("ajuda")}>
+          Ajuda
+        </SidebarNavItem>
+      </SidebarNavSection>
+    </SidebarNav>
+  );
+}
+
+export const DenseRealistic: Story = {
+  render: () => (
+    <Shell contentLabel="cenário pleno (paridade com playground legado)">
+      <RealisticDemo />
+    </Shell>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Fixture canônica: 3 sections, 2 groups (um aberto, um fechado), 3 itens com ícone, 2 com badge, 1 item ativo. Replica `ux_references/ui_kits/components/SidebarNav/SidebarNav.playground.html`.",
+      },
+    },
+  },
+};

--- a/ui_kit/components/sidebar-nav/SidebarNav.test.tsx
+++ b/ui_kit/components/sidebar-nav/SidebarNav.test.tsx
@@ -1,0 +1,580 @@
+import * as React from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { axeInThemes } from "@/test-utils/a11y";
+import {
+  SidebarNav,
+  SidebarNavSection,
+  SidebarNavItem,
+  SidebarNavGroup,
+  SidebarNavGroupTrigger,
+  SidebarNavGroupContent,
+  sidebarNavVariants,
+  sidebarNavItemVariants,
+} from "./index";
+
+/**
+ * Tests for Plan #83 (parent Tech Task #82) — SidebarNav v0.1.0 DoD.
+ *
+ * Each `it(...)` carries `AC-N:` so that `lex-issue-driven` Rule 3
+ * (bidirectional AC ↔ test traceability) passes at Gate 2. ACs come
+ * from `docs/issues/issue-82/02-requirements.md`.
+ */
+
+// ──────────────────────────────────────────────────────────────────
+// Helpers — small icon and harness builders
+// ──────────────────────────────────────────────────────────────────
+
+function StubIcon({ name }: { name: string }): React.ReactElement {
+  return (
+    <svg
+      data-icon={name}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <rect x="2" y="2" width="12" height="12" rx="2" />
+    </svg>
+  );
+}
+
+function BasicHarness({
+  collapsed = false,
+  activeKey = "inicio",
+}: {
+  collapsed?: boolean;
+  activeKey?: string;
+}): React.ReactElement {
+  return (
+    <SidebarNav collapsed={collapsed}>
+      <SidebarNavSection label="Geral">
+        <SidebarNavItem
+          icon={<StubIcon name="home" />}
+          active={activeKey === "inicio"}
+        >
+          Início
+        </SidebarNavItem>
+        <SidebarNavItem
+          icon={<StubIcon name="inbox" />}
+          badge="12"
+          active={activeKey === "inbox"}
+        >
+          Inbox
+        </SidebarNavItem>
+      </SidebarNavSection>
+    </SidebarNav>
+  );
+}
+
+function GroupHarness({
+  defaultOpen = true,
+  collapsed = false,
+}: {
+  defaultOpen?: boolean;
+  collapsed?: boolean;
+}): React.ReactElement {
+  return (
+    <SidebarNav collapsed={collapsed}>
+      <SidebarNavSection label="Operação">
+        <SidebarNavGroup
+          label="Contábil"
+          icon={<StubIcon name="ledger" />}
+          defaultOpen={defaultOpen}
+        >
+          <SidebarNavGroupTrigger />
+          <SidebarNavGroupContent>
+            <SidebarNavItem>Lançamentos</SidebarNavItem>
+            <SidebarNavItem>Razão</SidebarNavItem>
+          </SidebarNavGroupContent>
+        </SidebarNavGroup>
+      </SidebarNavSection>
+    </SidebarNav>
+  );
+}
+
+function ControlledGroupHarness(): React.ReactElement {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <SidebarNav>
+      <SidebarNavSection>
+        <SidebarNavGroup
+          label="Financeiro"
+          open={open}
+          onOpenChange={setOpen}
+        >
+          <SidebarNavGroupTrigger />
+          <SidebarNavGroupContent>
+            <SidebarNavItem>Conciliação</SidebarNavItem>
+            <SidebarNavItem>Extratos</SidebarNavItem>
+          </SidebarNavGroupContent>
+        </SidebarNavGroup>
+        <button
+          type="button"
+          data-testid="external-toggle"
+          onClick={() => setOpen(true)}
+        >
+          force-open
+        </button>
+      </SidebarNavSection>
+    </SidebarNav>
+  );
+}
+
+beforeEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Public surface (AC-1, AC-2)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — public surface", () => {
+  it("AC-1: exports the 6 canonical components + 2 CVA accessors", () => {
+    expect(SidebarNav).toBeDefined();
+    expect(SidebarNavSection).toBeDefined();
+    expect(SidebarNavItem).toBeDefined();
+    expect(SidebarNavGroup).toBeDefined();
+    expect(SidebarNavGroupTrigger).toBeDefined();
+    expect(SidebarNavGroupContent).toBeDefined();
+    expect(sidebarNavVariants).toBeDefined();
+    expect(sidebarNavItemVariants).toBeDefined();
+    expect(typeof sidebarNavVariants).toBe("function");
+    expect(typeof sidebarNavItemVariants).toBe("function");
+  });
+
+  it("AC-1: sidebarNavVariants is invocable with no args (defaults applied)", () => {
+    const cls = sidebarNavVariants({});
+    expect(cls).toContain("bg-sidebar");
+    expect(cls).toContain("text-sidebar-foreground");
+    expect(cls).toContain("border-sidebar-border");
+    expect(cls).toContain("w-60");
+  });
+
+  it("AC-1: sidebarNavItemVariants is invocable with no args (active=false)", () => {
+    const cls = sidebarNavItemVariants({});
+    expect(cls).toContain("hover:bg-sidebar-accent");
+    expect(cls).toContain("focus-visible:ring-ring");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Tokenization (AC-3, AC-4)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — tokenization", () => {
+  it("AC-3: root + item classes never include hex literals, oklch values, or chromatic Tailwind utilities", () => {
+    const rootCls = sidebarNavVariants({ collapsed: false });
+    const collapsedCls = sidebarNavVariants({ collapsed: true });
+    const itemCls = sidebarNavItemVariants({ active: false });
+    const activeCls = sidebarNavItemVariants({ active: true });
+    for (const cls of [rootCls, collapsedCls, itemCls, activeCls]) {
+      expect(cls).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+      expect(cls).not.toMatch(/oklch\(/);
+      expect(cls).not.toMatch(/(text|bg|border|ring)-(red|orange|yellow|green|blue|violet|purple|pink|gray)-\d+/);
+    }
+  });
+
+  it("AC-4: root container applies bg-sidebar + text-sidebar-foreground + border-sidebar-border", () => {
+    render(<BasicHarness />);
+    const nav = screen.getByRole("navigation");
+    expect(nav.className).toContain("bg-sidebar");
+    expect(nav.className).toContain("text-sidebar-foreground");
+    expect(nav.className).toContain("border-sidebar-border");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Root variants (AC-5, AC-6)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — root variants", () => {
+  it("AC-5: collapsed=false renders the expanded width (w-60)", () => {
+    render(<BasicHarness collapsed={false} />);
+    const nav = screen.getByRole("navigation");
+    expect(nav.className).toContain("w-60");
+    expect(nav.getAttribute("data-collapsed")).toBe("false");
+  });
+
+  it("AC-5: collapsed=true renders the compact width (w-14)", () => {
+    render(<BasicHarness collapsed={true} />);
+    const nav = screen.getByRole("navigation");
+    expect(nav.className).toContain("w-14");
+    expect(nav.getAttribute("data-collapsed")).toBe("true");
+  });
+
+  it("AC-5: collapsed hides text labels via sr-only", () => {
+    render(<BasicHarness collapsed={true} />);
+    const label = screen.getByText("Início");
+    expect(label.className).toContain("sr-only");
+  });
+
+  it("AC-6: transition uses motion-reduce:transition-none", () => {
+    render(<BasicHarness />);
+    const nav = screen.getByRole("navigation");
+    expect(nav.className).toContain("transition-[width]");
+    expect(nav.className).toContain("motion-reduce:transition-none");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Item — icon, badge, active, disabled, href (AC-7, AC-8, AC-9)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — Item", () => {
+  it("AC-7: renders icon when prop is provided", () => {
+    const { container } = render(<BasicHarness />);
+    const icon = container.querySelector("[data-icon='home']");
+    expect(icon).not.toBeNull();
+  });
+
+  it("AC-7: renders badge when not collapsed", () => {
+    render(<BasicHarness />);
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  it("AC-7: hides badge when collapsed", () => {
+    render(<BasicHarness collapsed={true} />);
+    expect(screen.queryByText("12")).not.toBeInTheDocument();
+  });
+
+  it("AC-8: active=true applies the active class chain and aria-current=page", () => {
+    render(<BasicHarness activeKey="inbox" />);
+    // active item is the Inbox row
+    const inboxItem = screen.getByRole("button", { name: /inbox/i });
+    expect(inboxItem.getAttribute("aria-current")).toBe("page");
+    expect(inboxItem.className).toContain("bg-sidebar-accent");
+    expect(inboxItem.className).toContain("font-semibold");
+  });
+
+  it("AC-9: renders <button> when no href provided", () => {
+    render(
+      <SidebarNav>
+        <SidebarNavSection>
+          <SidebarNavItem>Plain</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>,
+    );
+    const item = screen.getByRole("button", { name: /plain/i });
+    expect(item.tagName).toBe("BUTTON");
+    expect(item.getAttribute("type")).toBe("button");
+  });
+
+  it("AC-9: renders <a href> when href is provided", () => {
+    render(
+      <SidebarNav>
+        <SidebarNavSection>
+          <SidebarNavItem href="/dashboard">Dashboard</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>,
+    );
+    const link = screen.getByRole("link", { name: /dashboard/i });
+    expect(link.tagName).toBe("A");
+    expect(link.getAttribute("href")).toBe("/dashboard");
+  });
+
+  it("AC-9: onClick is forwarded to button items", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <SidebarNav>
+        <SidebarNavSection>
+          <SidebarNavItem onClick={onClick}>Clickable</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>,
+    );
+    await user.click(screen.getByRole("button", { name: /clickable/i }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC-9: disabled=true on button disables native interaction", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <SidebarNav>
+        <SidebarNavSection>
+          <SidebarNavItem disabled onClick={onClick}>
+            Off
+          </SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>,
+    );
+    const btn = screen.getByRole("button", { name: /off/i });
+    expect(btn).toBeDisabled();
+    await user.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("AC-9: disabled=true on link sets aria-disabled and tabIndex=-1", () => {
+    render(
+      <SidebarNav>
+        <SidebarNavSection>
+          <SidebarNavItem href="/x" disabled>
+            Off-link
+          </SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>,
+    );
+    const link = screen.getByRole("link", { name: /off-link/i });
+    expect(link.getAttribute("aria-disabled")).toBe("true");
+    expect(link.getAttribute("tabindex")).toBe("-1");
+    expect(link.className).toContain("pointer-events-none");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Section (AC-10)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — Section", () => {
+  it("AC-10: renders uppercase section label when not collapsed", () => {
+    render(<BasicHarness />);
+    expect(screen.getByText("Geral")).toBeInTheDocument();
+  });
+
+  it("AC-10: replaces label with a divider when collapsed", () => {
+    const { container } = render(<BasicHarness collapsed={true} />);
+    // Label text removed
+    expect(screen.queryByText("Geral")).not.toBeInTheDocument();
+    // Divider rendered
+    const hr = container.querySelector("hr");
+    expect(hr).not.toBeNull();
+    expect(hr!.className).toContain("bg-sidebar-border");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Group (AC-11)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — Group (uncontrolled + controlled)", () => {
+  it("AC-11: uncontrolled defaultOpen=true shows the content immediately", () => {
+    render(<GroupHarness defaultOpen={true} />);
+    expect(screen.getByText("Lançamentos")).toBeInTheDocument();
+    expect(screen.getByText("Razão")).toBeInTheDocument();
+  });
+
+  it("AC-11: uncontrolled defaultOpen=false hides the content initially", () => {
+    render(<GroupHarness defaultOpen={false} />);
+    expect(screen.queryByText("Lançamentos")).not.toBeInTheDocument();
+  });
+
+  it("AC-11: trigger toggles uncontrolled group open state", async () => {
+    const user = userEvent.setup();
+    render(<GroupHarness defaultOpen={false} />);
+    const trigger = screen.getByRole("button", { name: /contábil/i });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    await user.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Lançamentos")).toBeInTheDocument();
+  });
+
+  it("AC-11: trigger has aria-controls pointing to the content id", () => {
+    render(<GroupHarness defaultOpen={true} />);
+    const trigger = screen.getByRole("button", { name: /contábil/i });
+    const contentId = trigger.getAttribute("aria-controls");
+    expect(contentId).toBeTruthy();
+    const content = document.getElementById(contentId!);
+    expect(content).not.toBeNull();
+    expect(content!.getAttribute("role")).toBe("group");
+  });
+
+  it("AC-11: controlled mode uses external state and surfaces toggle", async () => {
+    const user = userEvent.setup();
+    render(<ControlledGroupHarness />);
+    // Initially closed
+    expect(screen.queryByText("Conciliação")).not.toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: /financeiro/i });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    // Open via internal trigger
+    await user.click(trigger);
+    expect(screen.getByText("Conciliação")).toBeInTheDocument();
+    // Close via trigger again
+    await user.click(trigger);
+    expect(screen.queryByText("Conciliação")).not.toBeInTheDocument();
+    // Open via external (controlled) trigger
+    await user.click(screen.getByTestId("external-toggle"));
+    expect(screen.getByText("Conciliação")).toBeInTheDocument();
+  });
+
+  it("AC-11: in collapsed mode the group renders children inline (no trigger, no chevron)", () => {
+    render(<GroupHarness collapsed={true} />);
+    // Trigger button should NOT exist when collapsed (the group dissolves)
+    expect(
+      screen.queryByRole("button", { name: /contábil/i }),
+    ).not.toBeInTheDocument();
+    // But the child items still render (inline)
+    expect(screen.getByRole("button", { name: /lançamentos/i })).toBeInTheDocument();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// ARIA contract (AC-12, AC-13, AC-14)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — ARIA", () => {
+  it("AC-12: root is a <nav> with default aria-label 'Navegação principal'", () => {
+    render(<BasicHarness />);
+    const nav = screen.getByRole("navigation");
+    expect(nav.tagName).toBe("NAV");
+    expect(nav.getAttribute("aria-label")).toBe("Navegação principal");
+  });
+
+  it("AC-12: aria-label is overridable via prop", () => {
+    render(
+      <SidebarNav aria-label="Menu da contabilidade">
+        <SidebarNavSection>
+          <SidebarNavItem>Item</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>,
+    );
+    expect(
+      screen.getByRole("navigation", { name: /menu da contabilidade/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("AC-13: keyboard activation via Enter triggers onClick on button items", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <SidebarNav>
+        <SidebarNavSection>
+          <SidebarNavItem onClick={onClick}>Press me</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>,
+    );
+    const item = screen.getByRole("button", { name: /press me/i });
+    item.focus();
+    await user.keyboard("{Enter}");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC-14: in collapsed mode, item exposes the label via aria-label on the button", () => {
+    render(<BasicHarness collapsed={true} />);
+    // Both items should be findable by their label name via accessible role queries.
+    expect(
+      screen.getByRole("button", { name: /início/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /inbox/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// jest-axe — light + dark across 5 declared states (AC-18..AC-22)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — a11y in light + dark", () => {
+  const AXE_TIMEOUT_MS = 30_000;
+
+  it(
+    "AC-18: Default expanded view has no axe violations in light + dark",
+    async () => {
+      const { container } = render(<BasicHarness />);
+      await axeInThemes(container);
+    },
+    AXE_TIMEOUT_MS,
+  );
+
+  it(
+    "AC-19: Active item state has no axe violations in light + dark",
+    async () => {
+      const { container } = render(<BasicHarness activeKey="inbox" />);
+      await axeInThemes(container);
+    },
+    AXE_TIMEOUT_MS,
+  );
+
+  it(
+    "AC-20: Collapsed view (with tooltips) has no axe violations in light + dark",
+    async () => {
+      const { container } = render(<BasicHarness collapsed={true} />);
+      await axeInThemes(container);
+    },
+    AXE_TIMEOUT_MS,
+  );
+
+  it(
+    "AC-21: Group open view has no axe violations in light + dark",
+    async () => {
+      const { container } = render(<GroupHarness defaultOpen={true} />);
+      await axeInThemes(container);
+    },
+    AXE_TIMEOUT_MS,
+  );
+
+  it(
+    "AC-22: Disabled item view has no axe violations in light + dark",
+    async () => {
+      const { container } = render(
+        <SidebarNav>
+          <SidebarNavSection label="Sistema">
+            <SidebarNavItem disabled>Indisponível</SidebarNavItem>
+            <SidebarNavItem href="/link" disabled>
+              Link off
+            </SidebarNavItem>
+          </SidebarNavSection>
+        </SidebarNav>,
+      );
+      await axeInThemes(container);
+    },
+    AXE_TIMEOUT_MS,
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Storybook contract sanity (AC-23)
+// ──────────────────────────────────────────────────────────────────
+
+describe("SidebarNav — Storybook contract", () => {
+  it("AC-23: every documented story shape renders without error", () => {
+    // Default
+    const { unmount: u1 } = render(<BasicHarness />);
+    u1();
+    // Collapsed
+    const { unmount: u2 } = render(<BasicHarness collapsed={true} />);
+    u2();
+    // WithActiveItem
+    const { unmount: u3 } = render(<BasicHarness activeKey="inbox" />);
+    u3();
+    // WithBadges — already covered by BasicHarness "Inbox"
+    // WithGroups
+    const { unmount: u4 } = render(<GroupHarness defaultOpen={true} />);
+    u4();
+    // DenseRealistic — multiple sections + groups
+    render(
+      <SidebarNav>
+        <SidebarNavSection label="Geral">
+          <SidebarNavItem icon={<StubIcon name="home" />} active>
+            Início
+          </SidebarNavItem>
+        </SidebarNavSection>
+        <SidebarNavSection label="Operação">
+          <SidebarNavGroup label="Contábil" icon={<StubIcon name="ledger" />}>
+            <SidebarNavGroupTrigger />
+            <SidebarNavGroupContent>
+              <SidebarNavItem>Lançamentos</SidebarNavItem>
+            </SidebarNavGroupContent>
+          </SidebarNavGroup>
+        </SidebarNavSection>
+        <SidebarNavSection label="Sistema">
+          <SidebarNavItem icon={<StubIcon name="cog" />}>Configurações</SidebarNavItem>
+        </SidebarNavSection>
+      </SidebarNav>,
+    );
+    expect(
+      screen.getByRole("navigation", { name: /navegação principal/i }),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/ui_kit/components/sidebar-nav/index.tsx
+++ b/ui_kit/components/sidebar-nav/index.tsx
@@ -1,0 +1,607 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/tooltip";
+
+/**
+ * SidebarNav — navegação lateral vertical com seções, grupos
+ * colapsáveis, item ativo e modo `collapsed` (só ícones).
+ *
+ * Distinto de:
+ *   - `<Sidebar>` (composite shell shadcn — `<SidebarProvider>`,
+ *     persistência via cookie, Drawer mobile): SidebarNav é a árvore
+ *     de navegação consumida dentro de qualquer chrome.
+ *   - `<Navbar>` (navegação horizontal top-bar): escopo distinto.
+ *   - `<NavigationMenu>` (Radix menubar com flyout): orientado a
+ *     menubar; não casa com nav lateral persistente.
+ *
+ * API canônica (decisões em ADR-019):
+ *   - Sem Radix base — composição interna com `aria-expanded` /
+ *     `aria-controls` manuais (ConfidenceIndicator-style).
+ *   - Named exports (não dot-notation com `any` cast).
+ *   - Group controlled (`open` + `onOpenChange`) **OU** uncontrolled
+ *     (`defaultOpen`) — paridade com `<Collapsible>` / `<Drawer>`.
+ *   - Modo `collapsed`: item interativo wrappeado em `<Tooltip>` do
+ *     DS + `<span className="sr-only">` para defesa em profundidade.
+ *   - Coexiste com `<Sidebar>` shell — não substitui, não importa.
+ *
+ * Public surface (6 componentes + 2 CVA accessors + 4 types):
+ *   SidebarNav, SidebarNavSection, SidebarNavItem,
+ *   SidebarNavGroup, SidebarNavGroupTrigger, SidebarNavGroupContent
+ *   sidebarNavVariants, sidebarNavItemVariants
+ *   SidebarNavProps, SidebarNavSectionProps,
+ *   SidebarNavItemProps, SidebarNavGroupProps
+ */
+
+// ──────────────────────────────────────────────────────────────────
+// Context — propagates `collapsed` to descendant items/groups
+// ──────────────────────────────────────────────────────────────────
+
+interface SidebarNavContextValue {
+  collapsed: boolean;
+}
+
+const SidebarNavContext = React.createContext<SidebarNavContextValue>({
+  collapsed: false,
+});
+
+function useSidebarNavContext(): SidebarNavContextValue {
+  return React.useContext(SidebarNavContext);
+}
+
+// ──────────────────────────────────────────────────────────────────
+// CVA — root container
+// ──────────────────────────────────────────────────────────────────
+
+const sidebarNavVariants = cva(
+  [
+    "flex h-full flex-col gap-3",
+    "border-r border-sidebar-border bg-sidebar text-sidebar-foreground",
+    "p-3",
+    "transition-[width] duration-200 ease-out motion-reduce:transition-none",
+  ].join(" "),
+  {
+    variants: {
+      collapsed: {
+        true: "w-14 items-stretch px-1.5",
+        false: "w-60",
+      },
+    },
+    defaultVariants: { collapsed: false },
+  },
+);
+
+export type SidebarNavCollapsedVariant = NonNullable<
+  VariantProps<typeof sidebarNavVariants>["collapsed"]
+>;
+
+// ──────────────────────────────────────────────────────────────────
+// CVA — item (button / anchor)
+// ──────────────────────────────────────────────────────────────────
+
+const sidebarNavItemVariants = cva(
+  [
+    "group/item flex w-full items-center gap-2.5 rounded-md px-2.5 py-2",
+    "text-left text-sm font-medium leading-none",
+    "transition-colors",
+    "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+    "disabled:cursor-not-allowed disabled:opacity-50",
+    "aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
+    "no-underline",
+  ].join(" "),
+  {
+    variants: {
+      active: {
+        true: "bg-sidebar-accent text-sidebar-accent-foreground font-semibold",
+        false: "",
+      },
+    },
+    defaultVariants: { active: false },
+  },
+);
+
+// ──────────────────────────────────────────────────────────────────
+// SidebarNav — root
+// ──────────────────────────────────────────────────────────────────
+
+export interface SidebarNavProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, "children"> {
+  collapsed?: boolean;
+  children: React.ReactNode;
+}
+
+const SidebarNav = React.forwardRef<HTMLElement, SidebarNavProps>(
+  (
+    {
+      collapsed = false,
+      className,
+      children,
+      "aria-label": ariaLabel = "Navegação principal",
+      ...rest
+    },
+    ref,
+  ) => {
+    const ctx = React.useMemo<SidebarNavContextValue>(
+      () => ({ collapsed }),
+      [collapsed],
+    );
+    return (
+      <SidebarNavContext.Provider value={ctx}>
+        <nav
+          ref={ref}
+          aria-label={ariaLabel}
+          data-collapsed={collapsed ? "true" : "false"}
+          className={cn(sidebarNavVariants({ collapsed }), className)}
+          {...rest}
+        >
+          {children}
+        </nav>
+      </SidebarNavContext.Provider>
+    );
+  },
+);
+SidebarNav.displayName = "SidebarNav";
+
+// ──────────────────────────────────────────────────────────────────
+// SidebarNavSection
+// ──────────────────────────────────────────────────────────────────
+
+export interface SidebarNavSectionProps {
+  label?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const SidebarNavSection = React.forwardRef<
+  HTMLDivElement,
+  SidebarNavSectionProps
+>(({ label, className, children }, ref) => {
+  const { collapsed } = useSidebarNavContext();
+  const showLabel = label != null && !collapsed;
+  const showDivider = label != null && collapsed;
+  const sectionLabel = typeof label === "string" ? label : undefined;
+  return (
+    <section
+      ref={ref}
+      aria-label={sectionLabel}
+      className={cn("flex flex-col gap-0.5", className)}
+    >
+      {showLabel ? (
+        <div
+          role="presentation"
+          className={cn(
+            "px-2.5 pt-1 pb-1.5",
+            "text-[10.5px] font-bold uppercase tracking-[0.06em]",
+            "text-muted-foreground",
+          )}
+        >
+          {label}
+        </div>
+      ) : null}
+      {showDivider ? (
+        <hr
+          aria-hidden="true"
+          className="my-1.5 mx-1 h-px border-0 bg-sidebar-border"
+        />
+      ) : null}
+      <div className="flex flex-col gap-px">{children}</div>
+    </section>
+  );
+});
+SidebarNavSection.displayName = "SidebarNavSection";
+
+// ──────────────────────────────────────────────────────────────────
+// SidebarNavItem
+// ──────────────────────────────────────────────────────────────────
+
+export interface SidebarNavItemProps {
+  icon?: React.ReactNode;
+  badge?: React.ReactNode;
+  active?: boolean;
+  disabled?: boolean;
+  href?: string;
+  onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
+  /**
+   * Texto usado para Tooltip em modo `collapsed` e como `aria-label`
+   * fallback. Obrigatório quando `children` não é string e o
+   * componente é usado em modo collapsed; quando ausente, o
+   * componente cai para `aria-label` derivado de `children`.
+   */
+  label?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const SidebarNavItem = React.forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
+  SidebarNavItemProps
+>(
+  (
+    {
+      icon,
+      badge,
+      active = false,
+      disabled = false,
+      href,
+      onClick,
+      label,
+      className,
+      children,
+    },
+    ref,
+  ) => {
+    const { collapsed } = useSidebarNavContext();
+    const resolvedLabel =
+      label ?? (typeof children === "string" ? children : undefined);
+
+    const itemClass = cn(
+      sidebarNavItemVariants({ active }),
+      collapsed && "justify-center px-0 py-2.5",
+      className,
+    );
+
+    const iconNode =
+      icon != null ? (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "inline-flex shrink-0 items-center justify-center",
+            "text-muted-foreground",
+            "group-hover/item:text-sidebar-accent-foreground",
+            active && "text-sidebar-primary",
+            "[&_svg]:size-4",
+          )}
+        >
+          {icon}
+        </span>
+      ) : null;
+
+    const labelNode = (
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate",
+          collapsed && "sr-only",
+        )}
+      >
+        {children}
+      </span>
+    );
+
+    const badgeNode =
+      badge != null && !collapsed ? (
+        <span
+          className={cn(
+            "ml-auto inline-flex min-w-[1.25rem] shrink-0 items-center justify-center",
+            "rounded-full bg-sidebar-accent px-1.5 py-px",
+            "text-[10.5px] font-bold text-sidebar-accent-foreground",
+          )}
+        >
+          {badge}
+        </span>
+      ) : null;
+
+    const inner = (
+      <>
+        {iconNode}
+        {labelNode}
+        {badgeNode}
+      </>
+    );
+
+    const commonAriaCurrent = active ? { "aria-current": "page" as const } : {};
+
+    let interactive: React.ReactElement;
+    if (href) {
+      // WHY: keep `href` even when disabled so the element remains a real
+      // link (Testing Library queries by `role="link"` require an href on
+      // the anchor). The interaction is blocked via aria-disabled,
+      // tabIndex=-1, pointer-events-none, and a preventDefault handler.
+      interactive = (
+        <a
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          aria-disabled={disabled || undefined}
+          tabIndex={disabled ? -1 : undefined}
+          onClick={
+            disabled
+              ? (event: React.MouseEvent<HTMLAnchorElement>) =>
+                  event.preventDefault()
+              : (onClick as React.MouseEventHandler<HTMLAnchorElement>)
+          }
+          className={cn(itemClass, disabled && "pointer-events-none")}
+          {...commonAriaCurrent}
+        >
+          {inner}
+        </a>
+      );
+    } else {
+      interactive = (
+        <button
+          ref={ref as React.Ref<HTMLButtonElement>}
+          type="button"
+          disabled={disabled}
+          onClick={onClick as React.MouseEventHandler<HTMLButtonElement>}
+          className={itemClass}
+          aria-label={collapsed && resolvedLabel ? resolvedLabel : undefined}
+          {...commonAriaCurrent}
+        >
+          {inner}
+        </button>
+      );
+    }
+
+    if (collapsed && resolvedLabel) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>{interactive}</TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>
+            {resolvedLabel}
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    return interactive;
+  },
+);
+SidebarNavItem.displayName = "SidebarNavItem";
+
+// ──────────────────────────────────────────────────────────────────
+// useControllableState — internal hook for Group open state
+// ──────────────────────────────────────────────────────────────────
+
+function useControllableOpen({
+  value,
+  defaultValue,
+  onChange,
+}: {
+  value?: boolean;
+  defaultValue: boolean;
+  onChange?: (open: boolean) => void;
+}): [boolean, (next: boolean) => void] {
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState(defaultValue);
+  const current = isControlled ? value : internal;
+  const setValue = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternal(next);
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+  return [current, setValue];
+}
+
+// ──────────────────────────────────────────────────────────────────
+// SidebarNavGroup
+// ──────────────────────────────────────────────────────────────────
+
+interface SidebarNavGroupContextValue {
+  open: boolean;
+  toggle: () => void;
+  contentId: string;
+  triggerId: string;
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+}
+
+const SidebarNavGroupContext =
+  React.createContext<SidebarNavGroupContextValue | null>(null);
+
+function useSidebarNavGroupContext(): SidebarNavGroupContextValue {
+  const ctx = React.useContext(SidebarNavGroupContext);
+  if (!ctx) {
+    throw new Error(
+      "SidebarNavGroupTrigger and SidebarNavGroupContent must be used inside <SidebarNavGroup>.",
+    );
+  }
+  return ctx;
+}
+
+export interface SidebarNavGroupProps {
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const SidebarNavGroup = React.forwardRef<HTMLDivElement, SidebarNavGroupProps>(
+  (
+    {
+      label,
+      icon,
+      defaultOpen = true,
+      open: openProp,
+      onOpenChange,
+      className,
+      children,
+    },
+    ref,
+  ) => {
+    const { collapsed } = useSidebarNavContext();
+    const [open, setOpen] = useControllableOpen({
+      value: openProp,
+      defaultValue: defaultOpen,
+      onChange: onOpenChange,
+    });
+    const reactId = React.useId();
+    const contentId = `sidebar-nav-group-content-${reactId}`;
+    const triggerId = `sidebar-nav-group-trigger-${reactId}`;
+
+    const groupCtx = React.useMemo<SidebarNavGroupContextValue>(
+      () => ({
+        open,
+        toggle: () => setOpen(!open),
+        contentId,
+        triggerId,
+        label,
+        icon,
+      }),
+      [open, setOpen, contentId, triggerId, label, icon],
+    );
+
+    // Em modo collapsed, a referência legada renderiza os filhos do
+    // Group inline — sem trigger, sem chevron, sem header. Mantemos
+    // paridade.
+    if (collapsed) {
+      return (
+        <div
+          ref={ref}
+          data-collapsed-group="true"
+          className={cn("contents", className)}
+        >
+          {React.Children.map(children, (child) => {
+            // Filtra o GroupContent — em collapsed, renderizamos seu
+            // conteúdo diretamente; o trigger é silenciosamente
+            // ignorado.
+            if (React.isValidElement(child)) {
+              const childType = (child as React.ReactElement).type as
+                | { displayName?: string }
+                | undefined;
+              if (childType?.displayName === "SidebarNavGroupTrigger") {
+                return null;
+              }
+              if (childType?.displayName === "SidebarNavGroupContent") {
+                return (child as React.ReactElement<{
+                  children?: React.ReactNode;
+                }>).props.children;
+              }
+            }
+            return child;
+          })}
+        </div>
+      );
+    }
+
+    return (
+      <SidebarNavGroupContext.Provider value={groupCtx}>
+        <div
+          ref={ref}
+          data-state={open ? "open" : "closed"}
+          className={cn("flex flex-col", className)}
+        >
+          {children}
+        </div>
+      </SidebarNavGroupContext.Provider>
+    );
+  },
+);
+SidebarNavGroup.displayName = "SidebarNavGroup";
+
+// ──────────────────────────────────────────────────────────────────
+// SidebarNavGroupTrigger
+// ──────────────────────────────────────────────────────────────────
+
+export interface SidebarNavGroupTriggerProps {
+  className?: string;
+  /**
+   * Por default, o trigger renderiza `icon + label + chevron`
+   * derivados do contexto do Group. Para customização total, passe
+   * `children` — o trigger só fornece o `<button>` com a11y wiring.
+   */
+  children?: React.ReactNode;
+}
+
+const SidebarNavGroupTrigger = React.forwardRef<
+  HTMLButtonElement,
+  SidebarNavGroupTriggerProps
+>(({ className, children }, ref) => {
+  const { open, toggle, contentId, triggerId, label, icon } =
+    useSidebarNavGroupContext();
+  const content = children ?? (
+    <>
+      {icon != null ? (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "inline-flex shrink-0 items-center justify-center text-muted-foreground",
+            "[&_svg]:size-4",
+          )}
+        >
+          {icon}
+        </span>
+      ) : null}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <ChevronDown
+        aria-hidden="true"
+        className={cn(
+          "ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform duration-200 motion-reduce:transition-none",
+          open && "rotate-180",
+        )}
+      />
+    </>
+  );
+  return (
+    <button
+      ref={ref}
+      type="button"
+      id={triggerId}
+      aria-expanded={open}
+      aria-controls={contentId}
+      onClick={toggle}
+      className={cn(sidebarNavItemVariants({ active: false }), className)}
+    >
+      {content}
+    </button>
+  );
+});
+SidebarNavGroupTrigger.displayName = "SidebarNavGroupTrigger";
+
+// ──────────────────────────────────────────────────────────────────
+// SidebarNavGroupContent
+// ──────────────────────────────────────────────────────────────────
+
+export interface SidebarNavGroupContentProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+const SidebarNavGroupContent = React.forwardRef<
+  HTMLDivElement,
+  SidebarNavGroupContentProps
+>(({ className, children }, ref) => {
+  const { open, contentId, triggerId } = useSidebarNavGroupContext();
+  if (!open) return null;
+  return (
+    <div
+      ref={ref}
+      id={contentId}
+      role="group"
+      aria-labelledby={triggerId}
+      className={cn(
+        "mt-px flex flex-col gap-px pl-6 [&_>_*]:py-1.5 [&_>_*]:text-[13px]",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+});
+SidebarNavGroupContent.displayName = "SidebarNavGroupContent";
+
+// ──────────────────────────────────────────────────────────────────
+// Exports
+// ──────────────────────────────────────────────────────────────────
+
+export {
+  SidebarNav,
+  SidebarNavSection,
+  SidebarNavItem,
+  SidebarNavGroup,
+  SidebarNavGroupTrigger,
+  SidebarNavGroupContent,
+  sidebarNavVariants,
+  sidebarNavItemVariants,
+};


### PR DESCRIPTION
## Resumo

Migra `SidebarNav` ao DoD do v0.1.0 do `@guardia/design-system`, fechando um gap na categoria **Navigation** do catálogo de 52 componentes.

`SidebarNav` é a primitiva canônica de **navegação lateral vertical** — distinta do `<Sidebar>` composite shell (shadcn-derived com `SidebarProvider`, persistência cookie e Drawer mobile) e do `<Navbar>` horizontal. Coexistência registrada em ADR-019 e na página Astro.

## Superfície pública

6 named exports + 2 CVA accessors + 4 types:

- `SidebarNav`, `SidebarNavSection`, `SidebarNavItem`
- `SidebarNavGroup`, `SidebarNavGroupTrigger`, `SidebarNavGroupContent`
- `sidebarNavVariants`, `sidebarNavItemVariants`
- `SidebarNavProps`, `SidebarNavSectionProps`, `SidebarNavItemProps`, `SidebarNavGroupProps`

## Decisões cravadas (ADR-019)

1. **Sem Radix base** — `aria-expanded` / `aria-controls` manuais (precedente ConfidenceIndicator/ADR-013)
2. **Named exports**, não dot-notation com `any` cast (compliance `lex-frontend-typing`)
3. **Group controlled + uncontrolled** coexistindo (paridade Collapsible/Drawer)
4. **Modo collapsed** wrappa cada item interativo em `<Tooltip>` do DS + `sr-only` defesa em profundidade
5. **Ortogonal ao `<Sidebar>` shell** — não substitui, não importa

## Cobertura

- **36 testes** (>=20 piso atendido; cada `it()` carrega `AC-N:` para rastreabilidade per `lex-issue-driven` Rule 3)
- **jest-axe**: 5 estados (Default, Active, Collapsed, GroupOpen, Disabled) × 2 temas (light + dark) = **10 invocações**, zero violações
- **6 Storybook stories**: Default, Collapsed, WithActiveItem, WithBadges, WithGroups, DenseRealistic
- **Página Astro** em `/componentes/sidebar-nav/` com paridade do playground legado
- `SidebarNav` adicionado ao Set `MIGRATED` em `docs/src/pages/index.astro`

## Tokenização

100% via chain existente `--sidebar-*` / `--muted-foreground` / `--ring` em `ui_kit/styles/index.css`. **Zero tokens novos, zero hex literais, zero classes Tailwind cromáticas.** Alinhado com Notion canonical Branding (hierarquia CTA preservada per `lex-brand-colors`).

## Gate 2

| Check | Status |
|---|---|
| `npm run typecheck` | ✅ |
| `npm run lint` | ✅ (0 erros, 0 novos warnings) |
| `npm run test` | ✅ 1262/1262 |
| `npm run build` | ✅ 70 arquivos, 413.9 kB gzipped |
| `npm run docs:build` | ✅ 34 páginas |

## Artefatos de fase

Em `docs/issues/issue-82/`:
- [`01-brief.md`](https://github.com/guardiatechnology/design-system/blob/feat/82-sidebar-nav-v0.1.0-dod/docs/issues/issue-82/01-brief.md)
- [`02-requirements.md`](https://github.com/guardiatechnology/design-system/blob/feat/82-sidebar-nav-v0.1.0-dod/docs/issues/issue-82/02-requirements.md)
- [`03-architecture.md`](https://github.com/guardiatechnology/design-system/blob/feat/82-sidebar-nav-v0.1.0-dod/docs/issues/issue-82/03-architecture.md)
- [`05-security-review.md`](https://github.com/guardiatechnology/design-system/blob/feat/82-sidebar-nav-v0.1.0-dod/docs/issues/issue-82/05-security-review.md)
- [`06-quality-report.md`](https://github.com/guardiatechnology/design-system/blob/feat/82-sidebar-nav-v0.1.0-dod/docs/issues/issue-82/06-quality-report.md)

ADR: [`docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md`](https://github.com/guardiatechnology/design-system/blob/feat/82-sidebar-nav-v0.1.0-dod/docs/adr/ADR-019-sidebar-nav-v0.1.0-dod-migration.md) — status `accepted` desde o primeiro commit.

## Test plan (review)

- [ ] Storybook: alternar light/dark em cada uma das 6 stories
- [ ] Astro: visitar `/componentes/sidebar-nav/` no docs site (preview lateral × conteúdo)
- [ ] Playground comparison: abrir `ux_references/ui_kits/components/SidebarNav/SidebarNav.playground.html` lado a lado com a story `DenseRealistic`
- [ ] Coexistência: validar que `Sidebar` (shell shadcn) segue funcionando inalterado

Closes #82
Closes #83