### PR TITLE
feat(styles): export radius/shadow/tracking/motion tokens as :root custom properties

### DIFF
--- a/ui_kit/styles/index.css
+++ b/ui_kit/styles/index.css
@@ -368,6 +368,58 @@
 }
 
 /* ────────────────────────────────────────────────────────────────────────
+ * @theme (static scales) — exported as :root custom properties.
+ *
+ * Unlike `@theme inline` (below), a non-inline @theme block emits its variables
+ * to :root in the compiled output, so downstream consumers (and their own
+ * Tailwind builds) can read the scale via `var(--radius-*)`, `var(--shadow-*)`,
+ * `var(--tracking-*)`, `var(--ease-*)`, `var(--duration-*)`. These tokens are
+ * theme-independent (no light/dark variants), so a single block covers both.
+ * Previously they lived in `@theme inline`, which inlines values into utilities
+ * but does NOT publish the variables — leaving consumers unable to reference
+ * the canon (e.g. a downstream `rounded-xl` fell back to Tailwind's 12px
+ * default instead of the Guardia 10px).
+ * ──────────────────────────────────────────────────────────────────────── */
+@theme {
+  /* Radii — Guardia canon */
+  --radius-xs: 2px;
+  --radius-sm: 3px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 10px;
+  --radius-2xl: 14px;
+  --radius-full: 9999px;
+
+  /* Shadows — violet-tinted (Guardia canon) */
+  --shadow-xs: 0 1px 2px 0 rgba(47, 14, 64, 0.04);
+  --shadow-sm: 0 1px 3px 0 rgba(47, 14, 64, 0.06), 0 1px 2px -1px rgba(47, 14, 64, 0.06);
+  --shadow-md: 0 4px 6px -1px rgba(47, 14, 64, 0.08), 0 2px 4px -2px rgba(47, 14, 64, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(47, 14, 64, 0.10), 0 4px 6px -4px rgba(47, 14, 64, 0.08);
+  --shadow-xl: 0 20px 25px -5px rgba(47, 14, 64, 0.12), 0 8px 10px -6px rgba(47, 14, 64, 0.08);
+  --shadow-brand: 0 8px 24px -4px rgba(224, 116, 0, 0.30);
+
+  /* Letter spacing */
+  --tracking-tight: -0.02em;
+  --tracking-snug: -0.01em;
+  --tracking-normal: 0;
+  --tracking-wide: 0.02em;
+  --tracking-eyebrow: 0.14em;
+
+  /* Motion — easing */
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-emphasis: cubic-bezier(0.3, 0, 0, 1);
+  --ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+
+  /* Motion — duration */
+  --duration-instant: 80ms;
+  --duration-fast: 160ms;
+  --duration-base: 220ms;
+  --duration-slow: 320ms;
+  --duration-slower: 480ms;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
  * @theme inline — expõe tokens para utility classes (bg-*, text-*, etc.)
  * ──────────────────────────────────────────────────────────────────────── */
 @theme inline {
@@ -420,42 +472,8 @@
   --text-6xl: 3.75rem;
   --text-6xl--line-height: 1;
 
-  /* Letter spacing */
-  --tracking-tight: -0.02em;
-  --tracking-snug: -0.01em;
-  --tracking-normal: 0;
-  --tracking-wide: 0.02em;
-  --tracking-eyebrow: 0.14em;
-
-  /* Radii — Guardia canon */
-  --radius-xs: 2px;
-  --radius-sm: 3px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
-  --radius-xl: 10px;
-  --radius-2xl: 14px;
-  --radius-full: 9999px;
-
-  /* Shadows — violet-tinted (Guardia canon) */
-  --shadow-xs: 0 1px 2px 0 rgba(47, 14, 64, 0.04);
-  --shadow-sm: 0 1px 3px 0 rgba(47, 14, 64, 0.06), 0 1px 2px -1px rgba(47, 14, 64, 0.06);
-  --shadow-md: 0 4px 6px -1px rgba(47, 14, 64, 0.08), 0 2px 4px -2px rgba(47, 14, 64, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(47, 14, 64, 0.10), 0 4px 6px -4px rgba(47, 14, 64, 0.08);
-  --shadow-xl: 0 20px 25px -5px rgba(47, 14, 64, 0.12), 0 8px 10px -6px rgba(47, 14, 64, 0.08);
-  --shadow-brand: 0 8px 24px -4px rgba(224, 116, 0, 0.30);
-
-  /* Motion — easing */
-  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
-  --ease-emphasis: cubic-bezier(0.3, 0, 0, 1);
-  --ease-in: cubic-bezier(0.4, 0, 1, 1);
-  --ease-out: cubic-bezier(0, 0, 0.2, 1);
-
-  /* Motion — duration */
-  --duration-instant: 80ms;
-  --duration-fast: 160ms;
-  --duration-base: 220ms;
-  --duration-slow: 320ms;
-  --duration-slower: 480ms;
+  /* Radii, shadows, letter-spacing, and motion are declared in the non-inline
+   * @theme block above so they are emitted as :root custom properties. */
 
   /* ─── Semantic colors — shadcn-compat (HSL composition) ─── */
   --color-background: hsl(var(--background));


### PR DESCRIPTION
## Why

The kit ships its stylesheet **raw** (`@import "tailwindcss"` + `@theme`), so it is compiled by each consumer's Tailwind v4 build. The static scale tokens — **radius, shadows, letter-spacing, motion (easing/duration)** — were declared inside `@theme inline`.

`@theme inline` inlines values into the kit's *own* utilities but does **not** emit the variables to `:root`. A downstream app that compiles its own Tailwind (scanning our components via `@source`) generates e.g. `.rounded-xl { border-radius: var(--radius-xl) }` — but there is no `--radius-xl` at `:root` to read, so it falls back to **Tailwind's 12px default instead of the Guardia canon 10px**. The same gap affects `--shadow-*`, `--tracking-*`, `--ease-*`, `--duration-*`.

Colors don't have this problem because they already bottom out in published `:root` primitives (`--card`, `--guardia-purple-500`, …).

## What

Move the static, theme-independent scale tokens out of `@theme inline` into a non-inline `@theme {}` block. A non-inline `@theme` block **emits the variables to `:root`** in the compiled output, so:

- the tokens are consumable via `var(--radius-*)`, `var(--shadow-*)`, `var(--tracking-*)`, `var(--ease-*)`, `var(--duration-*)` in any consumer (and raw CSS);
- the kit's own utilities keep **identical computed values** (they now reference the var instead of an inlined literal);
- the base-layer transitions that already referenced `var(--duration-*)` / `var(--ease-*)` now resolve too.

Colors stay in `@theme inline` (unchanged). **Typography (font families + text scale) is intentionally left in `@theme inline`** to avoid clashing with consumer `--font-sans` overrides — can follow in a separate PR if desired.

## Validation

- **Tailwind v4.3 compile** of the stylesheet emits `:root { --radius-xl: 10px; --radius-sm: 3px; --shadow-md: …; --duration-fast: … }` (absent before for consumers).
- **End-to-end** in a downstream app (Next.js 16 + Turbopack): overlaying this change makes the served, compiled CSS emit the full `:root` scale, and a DS `ChatMessage` bubble's `rounded-xl` resolves to **10px** (was 12px) with no app-side override — confirming the fix closes the gap at the source.

## Risk

Computed values are unchanged, so visual snapshots should be stable — flagging for the visual-regression suite to confirm.
