### PR TITLE
chore(release): bump design-system to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardiatechnology/design-system",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardiatechnology/design-system",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "workspaces": [
         "docs"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardiatechnology/design-system",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Bumps `package.json`/`package-lock.json` to **0.2.0** to release the Isac token namespace and corrected marks from #311.

MINOR per SemVer — new `--isac-*` tokens/utilities are additive and backward-compatible.

After merge: signed tag `v0.2.0` → `publish.yml` publishes to GitHub Packages → GitHub Release.

Closes #313. Refs #311.