### PR TITLE
build(exports): enable tree-shaking (sideEffects + per-component subpaths)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Typecheck (docs)
         run: npm run typecheck:docs
 
+      # Garante que o mapa `exports` do package.json continua em sincronia
+      # com ui_kit/ (subpaths por componente/tema/lib gerados pelo
+      # scripts/generate-exports.mjs). Roda sobre a fonte, antes do build.
+      # Issue #315.
+      - name: Check exports map is in sync
+        run: npm run exports:check
+
       - name: Build package
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -2,12 +2,303 @@
   "name": "@guardiatechnology/design-system",
   "version": "0.2.0",
   "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./styles.css": "./dist/styles/index.css"
+    "./styles.css": "./dist/styles/index.css",
+    "./accordion": {
+      "types": "./dist/components/accordion/index.d.ts",
+      "import": "./dist/components/accordion/index.js"
+    },
+    "./agent-card": {
+      "types": "./dist/components/agent-card/index.d.ts",
+      "import": "./dist/components/agent-card/index.js"
+    },
+    "./alert": {
+      "types": "./dist/components/alert/index.d.ts",
+      "import": "./dist/components/alert/index.js"
+    },
+    "./alert-dialog": {
+      "types": "./dist/components/alert-dialog/index.d.ts",
+      "import": "./dist/components/alert-dialog/index.js"
+    },
+    "./avatar": {
+      "types": "./dist/components/avatar/index.d.ts",
+      "import": "./dist/components/avatar/index.js"
+    },
+    "./badge": {
+      "types": "./dist/components/badge/index.d.ts",
+      "import": "./dist/components/badge/index.js"
+    },
+    "./badge-select": {
+      "types": "./dist/components/badge-select/index.d.ts",
+      "import": "./dist/components/badge-select/index.js"
+    },
+    "./breadcrumbs": {
+      "types": "./dist/components/breadcrumbs/index.d.ts",
+      "import": "./dist/components/breadcrumbs/index.js"
+    },
+    "./button": {
+      "types": "./dist/components/button/index.d.ts",
+      "import": "./dist/components/button/index.js"
+    },
+    "./button-group": {
+      "types": "./dist/components/button-group/index.d.ts",
+      "import": "./dist/components/button-group/index.js"
+    },
+    "./calendar": {
+      "types": "./dist/components/calendar/index.d.ts",
+      "import": "./dist/components/calendar/index.js"
+    },
+    "./card": {
+      "types": "./dist/components/card/index.d.ts",
+      "import": "./dist/components/card/index.js"
+    },
+    "./chart": {
+      "types": "./dist/components/chart/index.d.ts",
+      "import": "./dist/components/chart/index.js"
+    },
+    "./chat-message": {
+      "types": "./dist/components/chat-message/index.d.ts",
+      "import": "./dist/components/chat-message/index.js"
+    },
+    "./checkbox": {
+      "types": "./dist/components/checkbox/index.d.ts",
+      "import": "./dist/components/checkbox/index.js"
+    },
+    "./chip": {
+      "types": "./dist/components/chip/index.d.ts",
+      "import": "./dist/components/chip/index.js"
+    },
+    "./code-block": {
+      "types": "./dist/components/code-block/index.d.ts",
+      "import": "./dist/components/code-block/index.js"
+    },
+    "./code-editor": {
+      "types": "./dist/components/code-editor/index.d.ts",
+      "import": "./dist/components/code-editor/index.js"
+    },
+    "./collapsible": {
+      "types": "./dist/components/collapsible/index.d.ts",
+      "import": "./dist/components/collapsible/index.js"
+    },
+    "./combobox": {
+      "types": "./dist/components/combobox/index.d.ts",
+      "import": "./dist/components/combobox/index.js"
+    },
+    "./command": {
+      "types": "./dist/components/command/index.d.ts",
+      "import": "./dist/components/command/index.js"
+    },
+    "./confidence-indicator": {
+      "types": "./dist/components/confidence-indicator/index.d.ts",
+      "import": "./dist/components/confidence-indicator/index.js"
+    },
+    "./custom-icons": {
+      "types": "./dist/components/custom-icons/index.d.ts",
+      "import": "./dist/components/custom-icons/index.js"
+    },
+    "./data-table": {
+      "types": "./dist/components/data-table/index.d.ts",
+      "import": "./dist/components/data-table/index.js"
+    },
+    "./date-picker": {
+      "types": "./dist/components/date-picker/index.d.ts",
+      "import": "./dist/components/date-picker/index.js"
+    },
+    "./dialog": {
+      "types": "./dist/components/dialog/index.d.ts",
+      "import": "./dist/components/dialog/index.js"
+    },
+    "./drawer": {
+      "types": "./dist/components/drawer/index.d.ts",
+      "import": "./dist/components/drawer/index.js"
+    },
+    "./empty-state": {
+      "types": "./dist/components/empty-state/index.d.ts",
+      "import": "./dist/components/empty-state/index.js"
+    },
+    "./file-upload": {
+      "types": "./dist/components/file-upload/index.d.ts",
+      "import": "./dist/components/file-upload/index.js"
+    },
+    "./form": {
+      "types": "./dist/components/form/index.d.ts",
+      "import": "./dist/components/form/index.js"
+    },
+    "./form-layout": {
+      "types": "./dist/components/form-layout/index.d.ts",
+      "import": "./dist/components/form-layout/index.js"
+    },
+    "./icon-button": {
+      "types": "./dist/components/icon-button/index.d.ts",
+      "import": "./dist/components/icon-button/index.js"
+    },
+    "./input": {
+      "types": "./dist/components/input/index.d.ts",
+      "import": "./dist/components/input/index.js"
+    },
+    "./input-opt": {
+      "types": "./dist/components/input-opt/index.d.ts",
+      "import": "./dist/components/input-opt/index.js"
+    },
+    "./kanban": {
+      "types": "./dist/components/kanban/index.d.ts",
+      "import": "./dist/components/kanban/index.js"
+    },
+    "./label": {
+      "types": "./dist/components/label/index.d.ts",
+      "import": "./dist/components/label/index.js"
+    },
+    "./logo": {
+      "types": "./dist/components/logo/index.d.ts",
+      "import": "./dist/components/logo/index.js"
+    },
+    "./menu": {
+      "types": "./dist/components/menu/index.d.ts",
+      "import": "./dist/components/menu/index.js"
+    },
+    "./menubar": {
+      "types": "./dist/components/menubar/index.d.ts",
+      "import": "./dist/components/menubar/index.js"
+    },
+    "./metric-card": {
+      "types": "./dist/components/metric-card/index.d.ts",
+      "import": "./dist/components/metric-card/index.js"
+    },
+    "./multi-select": {
+      "types": "./dist/components/multi-select/index.d.ts",
+      "import": "./dist/components/multi-select/index.js"
+    },
+    "./navbar": {
+      "types": "./dist/components/navbar/index.d.ts",
+      "import": "./dist/components/navbar/index.js"
+    },
+    "./navigation-menu": {
+      "types": "./dist/components/navigation-menu/index.d.ts",
+      "import": "./dist/components/navigation-menu/index.js"
+    },
+    "./pagination": {
+      "types": "./dist/components/pagination/index.d.ts",
+      "import": "./dist/components/pagination/index.js"
+    },
+    "./popover": {
+      "types": "./dist/components/popover/index.d.ts",
+      "import": "./dist/components/popover/index.js"
+    },
+    "./progress": {
+      "types": "./dist/components/progress/index.d.ts",
+      "import": "./dist/components/progress/index.js"
+    },
+    "./radio": {
+      "types": "./dist/components/radio/index.d.ts",
+      "import": "./dist/components/radio/index.js"
+    },
+    "./scroll-area": {
+      "types": "./dist/components/scroll-area/index.d.ts",
+      "import": "./dist/components/scroll-area/index.js"
+    },
+    "./select": {
+      "types": "./dist/components/select/index.d.ts",
+      "import": "./dist/components/select/index.js"
+    },
+    "./separator": {
+      "types": "./dist/components/separator/index.d.ts",
+      "import": "./dist/components/separator/index.js"
+    },
+    "./sidebar": {
+      "types": "./dist/components/sidebar/index.d.ts",
+      "import": "./dist/components/sidebar/index.js"
+    },
+    "./sidebar-nav": {
+      "types": "./dist/components/sidebar-nav/index.d.ts",
+      "import": "./dist/components/sidebar-nav/index.js"
+    },
+    "./skeleton": {
+      "types": "./dist/components/skeleton/index.d.ts",
+      "import": "./dist/components/skeleton/index.js"
+    },
+    "./slider": {
+      "types": "./dist/components/slider/index.d.ts",
+      "import": "./dist/components/slider/index.js"
+    },
+    "./sonner": {
+      "types": "./dist/components/sonner/index.d.ts",
+      "import": "./dist/components/sonner/index.js"
+    },
+    "./spinner": {
+      "types": "./dist/components/spinner/index.d.ts",
+      "import": "./dist/components/spinner/index.js"
+    },
+    "./stepper": {
+      "types": "./dist/components/stepper/index.d.ts",
+      "import": "./dist/components/stepper/index.js"
+    },
+    "./switch": {
+      "types": "./dist/components/switch/index.d.ts",
+      "import": "./dist/components/switch/index.js"
+    },
+    "./table": {
+      "types": "./dist/components/table/index.d.ts",
+      "import": "./dist/components/table/index.js"
+    },
+    "./tabs": {
+      "types": "./dist/components/tabs/index.d.ts",
+      "import": "./dist/components/tabs/index.js"
+    },
+    "./textarea": {
+      "types": "./dist/components/textarea/index.d.ts",
+      "import": "./dist/components/textarea/index.js"
+    },
+    "./timeline": {
+      "types": "./dist/components/timeline/index.d.ts",
+      "import": "./dist/components/timeline/index.js"
+    },
+    "./toast": {
+      "types": "./dist/components/toast/index.d.ts",
+      "import": "./dist/components/toast/index.js"
+    },
+    "./toggle": {
+      "types": "./dist/components/toggle/index.d.ts",
+      "import": "./dist/components/toggle/index.js"
+    },
+    "./toggle-group": {
+      "types": "./dist/components/toggle-group/index.d.ts",
+      "import": "./dist/components/toggle-group/index.js"
+    },
+    "./tooltip": {
+      "types": "./dist/components/tooltip/index.d.ts",
+      "import": "./dist/components/tooltip/index.js"
+    },
+    "./top-bar": {
+      "types": "./dist/components/top-bar/index.d.ts",
+      "import": "./dist/components/top-bar/index.js"
+    },
+    "./tree": {
+      "types": "./dist/components/tree/index.d.ts",
+      "import": "./dist/components/tree/index.js"
+    },
+    "./typography": {
+      "types": "./dist/components/typography/index.d.ts",
+      "import": "./dist/components/typography/index.js"
+    },
+    "./theme/theme-provider": {
+      "types": "./dist/theme/theme-provider.d.ts",
+      "import": "./dist/theme/theme-provider.js"
+    },
+    "./theme/theme-toggle": {
+      "types": "./dist/theme/theme-toggle.d.ts",
+      "import": "./dist/theme/theme-toggle.js"
+    },
+    "./lib/utils": {
+      "types": "./dist/lib/utils.d.ts",
+      "import": "./dist/lib/utils.js"
+    }
   },
   "types": "./dist/index.d.ts",
   "files": [
@@ -27,6 +318,8 @@
     "init:env": "git config core.hooksPath .githooks && chmod -R +x ./.githooks",
     "build": "rslib build",
     "dev": "rslib build --watch",
+    "exports:generate": "node scripts/generate-exports.mjs",
+    "exports:check": "node scripts/generate-exports.mjs --check",
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
     "docs:dev": "npm run dev --prefix docs",

--- a/scripts/generate-exports.mjs
+++ b/scripts/generate-exports.mjs
@@ -38,7 +38,9 @@ function componentEntries() {
 /** Public theme modules under ui_kit/theme (excluding tests and stories). */
 function themeEntries() {
     const dir = join(root, "ui_kit", "theme");
-    return readdirSync(dir)
+    return readdirSync(dir, { withFileTypes: true })
+        .filter((d) => d.isFile())
+        .map((d) => d.name)
         .filter((f) => /\.tsx?$/.test(f) && !/\.(test|stories)\./.test(f))
         .map((f) => f.replace(/\.tsx?$/, ""))
         .sort();
@@ -74,13 +76,32 @@ function buildExports() {
     return exp;
 }
 
+/**
+ * Serializes with recursively sorted keys so the sync check compares the set
+ * of subpaths and their targets, not the serialization order. Key order is
+ * irrelevant to Node's exact-match subpath resolution; the generator still
+ * writes a deterministic order below.
+ */
+function stableStringify(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(stableStringify).join(",")}]`;
+    }
+    if (value && typeof value === "object") {
+        const body = Object.keys(value)
+            .sort()
+            .map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`)
+            .join(",");
+        return `{${body}}`;
+    }
+    return JSON.stringify(value);
+}
+
 const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
 const expected = buildExports();
 const check = process.argv.includes("--check");
 
 if (check) {
-    const current = JSON.stringify(pkg.exports ?? {});
-    if (current !== JSON.stringify(expected)) {
+    if (stableStringify(pkg.exports ?? {}) !== stableStringify(expected)) {
         console.error(
             "package.json `exports` is out of sync with ui_kit/.\n" +
                 "Run `npm run exports:generate` and commit the result.",

--- a/scripts/generate-exports.mjs
+++ b/scripts/generate-exports.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Generates the `exports` map in package.json from the `ui_kit/` source tree,
+ * keeping per-component (and theme/lib) subpath exports in sync with the files
+ * that `rslib` emits into `dist/` (Issue #315).
+ *
+ * Why: with `bundle: false`, the build mirrors `ui_kit/` into `dist/`
+ * (`ui_kit/components/button/index.tsx` -> `dist/components/button/index.js`).
+ * Exposing each component as a subpath lets consumers import narrowly, and
+ * `sideEffects: false` (declared in package.json) lets bundlers drop the
+ * unreferenced barrel members. The `.` barrel export is preserved unchanged
+ * for backward compatibility.
+ *
+ * The map is derived from source (not from `dist/`), so this runs without a
+ * prior build — CI can verify sync before the build step.
+ *
+ * Usage:
+ *   node scripts/generate-exports.mjs           # rewrite package.json exports
+ *   node scripts/generate-exports.mjs --check   # exit 1 if package.json drifts
+ */
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkgPath = join(root, "package.json");
+
+/** Component directories under ui_kit/components that expose an index module. */
+function componentEntries() {
+    const dir = join(root, "ui_kit", "components");
+    return readdirSync(dir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .filter((d) => ["index.ts", "index.tsx"].some((f) => existsSync(join(dir, d.name, f))))
+        .map((d) => d.name)
+        .sort();
+}
+
+/** Public theme modules under ui_kit/theme (excluding tests and stories). */
+function themeEntries() {
+    const dir = join(root, "ui_kit", "theme");
+    return readdirSync(dir)
+        .filter((f) => /\.tsx?$/.test(f) && !/\.(test|stories)\./.test(f))
+        .map((f) => f.replace(/\.tsx?$/, ""))
+        .sort();
+}
+
+/** Builds the canonical `exports` map. Fixed entries first, then subpaths. */
+function buildExports() {
+    const exp = {
+        ".": { types: "./dist/index.d.ts", import: "./dist/index.js" },
+        "./styles.css": "./dist/styles/index.css",
+    };
+
+    for (const name of componentEntries()) {
+        exp[`./${name}`] = {
+            types: `./dist/components/${name}/index.d.ts`,
+            import: `./dist/components/${name}/index.js`,
+        };
+    }
+
+    for (const name of themeEntries()) {
+        exp[`./theme/${name}`] = {
+            types: `./dist/theme/${name}.d.ts`,
+            import: `./dist/theme/${name}.js`,
+        };
+    }
+
+    // `cn` and other helpers re-exported by the `.` barrel from lib/utils.
+    exp["./lib/utils"] = {
+        types: "./dist/lib/utils.d.ts",
+        import: "./dist/lib/utils.js",
+    };
+
+    return exp;
+}
+
+const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+const expected = buildExports();
+const check = process.argv.includes("--check");
+
+if (check) {
+    const current = JSON.stringify(pkg.exports ?? {});
+    if (current !== JSON.stringify(expected)) {
+        console.error(
+            "package.json `exports` is out of sync with ui_kit/.\n" +
+                "Run `npm run exports:generate` and commit the result.",
+        );
+        process.exit(1);
+    }
+    console.log("package.json `exports` in sync with ui_kit/.");
+    process.exit(0);
+}
+
+pkg.exports = expected;
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n", "utf-8");
+console.log(`package.json exports regenerated (${Object.keys(expected).length} entries).`);


### PR DESCRIPTION
## Why

Consumers that import a single component from `@guardiatechnology/design-system` shipped the **entire** library. Downstream evidence (`guardia/landing-pages` #62, growth Admin): the Admin chunk was **714.99 kB (215.52 kB gzip)**, flat whether it imported 3 or 9 components — the whole barrel shipped regardless.

Two properties defeated dead-code elimination:
1. **No `sideEffects` field** — bundlers assumed every barrel module might have side effects and kept it.
2. **Barrel-only entry** — `exports` exposed only `.` and `./styles.css`; there was no narrow import path.

## What

- **`sideEffects: ["**/*.css"]`** — lets bundlers drop unreferenced modules while never stripping the copied stylesheet (no JS module imports CSS; the sheet is consumed only via `./styles.css`).
- **Per-component (and theme/lib) subpath exports** in the `exports` map (`./button`, `./table`, `./theme/theme-provider`, `./lib/utils`, …), generated by `scripts/generate-exports.mjs` from `ui_kit/`, mirroring what `rslib` emits to `dist/` under `bundle: false`.
- **`.` barrel export kept unchanged** — existing `import { Button } from "@guardiatechnology/design-system"` keeps working.
- **CI sync guard** — `npm run exports:check` runs in the PR workflow before build, failing if the `exports` map drifts from `ui_kit/`. Regenerate with `npm run exports:generate`.

## How (definition of done)

- [x] `package.json` declares `sideEffects` (CSS-only allowlist), verified not to strip the stylesheet (`npm pack` includes `dist/styles/index.css`).
- [x] `exports` exposes each component + theme entries + `./lib/utils` as subpaths, in addition to `.` (74 entries).
- [x] A single-component import excludes `recharts`/`react-router`/`cmdk`/`react-day-picker`/`react-select` when unreferenced.
- [x] Existing barrel imports keep working unchanged.

## Verification (esbuild, `Button`-only entry against `dist/index.js`)

| | Bundle | recharts | react-day-picker | react-select | cmdk |
|---|---|---|---|---|---|
| **without** `sideEffects` | **1.59 MB** | present | present | present | present |
| **with** `sideEffects` (this PR) | **98 kB** | excluded | excluded | excluded | excluded |

~16× reduction, proving the `sideEffects` field is what unlocks the DCE — not bundler aggressiveness.

## Notes

- The subpath map is **generated**, not hand-maintained: `exports:check` in CI keeps it in lockstep with `ui_kit/components/*`, `ui_kit/theme/*`, and `ui_kit/lib/utils`. Adding a component and running `exports:generate` picks it up automatically.
- No source/runtime code changed — only packaging metadata, a generator script, and one CI step.

Closes #315
