### PR TITLE
fix(styles): make default border-color survive the consumer preflight

### DIFF
--- a/ui_kit/styles/index.css
+++ b/ui_kit/styles/index.css
@@ -712,9 +712,34 @@ body {
 }
 
 @layer base {
-  *,
-  ::before,
-  ::after {
+  /* Cor padrão de borda.
+   *
+   * O Tailwind v4 mudou o padrão de `border-color` de `gray-200` para
+   * `currentColor`, e o pacote tem dezenas de `border` / `border-b` sem
+   * classe de cor (`TableRow` é `"border-b transition-colors …"`). Esta regra
+   * devolve o comportamento esperado.
+   *
+   * O prefixo `:root` é DE PROPÓSITO. Escrita como `*`, a regra não sobrevivia
+   * num consumidor que roda o próprio Tailwind v4: o preflight do app emite
+   * `@layer base` depois desta folha e, com a mesma especificidade (0,0,0),
+   * a declaração posterior vence. Medido num Next 15 com texto violeta 500 —
+   * `TableRow` saía com `borderBottomColor: rgb(68,24,109)`, ou seja, toda
+   * tabela, cartão e separador riscados na cor do texto, sem erro de build
+   * nem aviso de console. `:root *` é (0,1,0) e vence o `*` do preflight mesmo
+   * sendo emitida antes: dentro da MESMA camada quem decide é a
+   * especificidade, não a ordem.
+   *
+   * Ficar em `@layer base` também é DE PROPÓSITO. Tirar a regra da camada
+   * resolveria o preflight, mas regra sem camada vence QUALQUER regra em
+   * camada — inclusive as utilities de cor de borda, que vivem em
+   * `@layer utilities`. Foi o que aconteceu na primeira tentativa deste fix:
+   * o `Switch` inválido perdeu a borda vermelha e 37 snapshots quebraram.
+   * Em `base`, as utilities continuam vencendo, que é o correto.
+   *
+   * Refs #317. */
+  :root *,
+  :root ::before,
+  :root ::after {
     border-color: hsl(var(--border));
   }
 

--- a/ui_kit/styles/index.css
+++ b/ui_kit/styles/index.css
@@ -213,6 +213,14 @@
   --button-bg: var(--action);
   --button-fg: #ffffff;
   --button-fg-hover: #ffffff;
+
+  /* Texto sobre superfície de ação. Completa o par --action/--action-fg, na
+     mesma convenção de --danger/--danger-fg, --info/--info-fg e
+     --warning/--warning-fg. Sem ele, quem pinta `bg-action` precisa saber
+     alcançar --button-fg, que é nomeado por componente e não por superfície.
+     Mesmo valor de --button-fg de propósito: são a mesma decisão de
+     contraste, e divergir seria bug. Refs #317. */
+  --action-fg: var(--button-fg);
   --button-hover-bg: var(--action-hover);
 
   /* ─── shadcn-compat (HSL triples) ─── */
@@ -338,6 +346,7 @@
   --button-bg: var(--action);
   --button-fg: var(--mono-black);                /* Laranja 500 + Mono Preto = 6.2:1 */
   --button-fg-hover: var(--mono-white);          /* Laranja 700 + Mono White = 5.75:1 (AA); mono-black falharia (3.2:1) */
+  --action-fg: var(--button-fg);                 /* Laranja 500 + Mono Preto = 6.2:1 — ver --button-fg acima */
   --button-hover-bg: var(--action-hover);
 
   /* ─── shadcn-compat (HSL triples) alinhados a Cinza Báltico ─── */
@@ -551,6 +560,7 @@
    * Pair them together when migrating a filled action surface:
    *   bg-action text-button-fg hover:bg-action-hover hover:text-button-fg-hover */
   --color-button-fg: var(--button-fg);
+  --color-action-fg: var(--action-fg);
   --color-button-fg-hover: var(--button-fg-hover);
 
   /* ─── Brand palette exposed as utilities (bg-guardia-orange-500 etc.) ─── */


### PR DESCRIPTION
Closes #317

## O problema

Dois defeitos encontrados ao consumir a `0.2.0` num Next 15 + Tailwind v4 real.

### 1. A cor padrão de borda não sobrevive no consumidor

A regra já existia no pacote. Ela só não funciona onde importa.

O Tailwind v4 mudou o padrão de `border-color` de `gray-200` para `currentColor`, e o pacote tem dezenas de `border` / `border-b` sem classe de cor — `TableRow` é literalmente `"border-b transition-colors …"`. Escrita como `*` dentro de `@layer base`, a regra **empata em especificidade (0,0,0)** com o preflight do app, que é emitido depois desta folha. Mesma camada, declaração posterior vence: a regra do pacote é descartada em silêncio.

No Storybook isso nunca aparece, porque lá a folha do DS é a única.

Medido num app com texto violeta 500 — todo `TableRow`, cartão, separador, input e popover saía com `borderBottomColor: rgb(68, 24, 109)`, a cor do texto. Sem erro de build, sem aviso de console: CSS válido com o valor errado.

**Correção:** prefixar com `:root`, tornando o seletor (0,1,0). Dentro da mesma camada quem decide é a especificidade, não a ordem — então vence o preflight mesmo sendo emitida antes.

### 2. `--action` não tem par de primeiro plano

A folha segue `--danger`/`--danger-fg`, `--info`/`--info-fg`, `--warning`/`--warning-fg` — mas `--action` ficou sem. Quem pinta `bg-action` precisa saber alcançar `--button-fg`, token nomeado por componente e não por superfície. Aditivo; nenhuma declaração existente muda.

## O caminho errado que eu tomei primeiro

A primeira versão deste PR tirava a regra de borda **para fora** de `@layer base`. Resolvia o preflight, e quebrou 37 snapshots visuais.

O motivo: regra sem camada vence **qualquer** regra em camada — inclusive as utilities de cor de borda, que vivem em `@layer utilities`. O `Switch` inválido perdeu a borda vermelha, o `CodeEditor` idem.

Verificado no navegador, isolando a cascata:

| regra do fix | utility `border-color: red` explícita |
|---|---|
| fora de camada | ❌ perde — vira a cor genérica |
| em `base`, com `:root` | ✅ vence, como deve |

A versão atual mantém a regra em `base` de propósito. É o único lugar onde ela vence o preflight **e** perde para as utilities.

## Por que isto não deve mudar snapshot algum

Dentro de `@layer base` esta é a **única** regra que define borda — todas as regras de componente do pacote estão fora de camada e continuam vencendo. E `:root *` casa exatamente o mesmo conjunto que `*` para todo elemento renderizado (a diferença é só o próprio `html`, que não tem borda).

No Storybook, sem um segundo preflight, a renderização é idêntica à do `main`.

## Verificação

- `npm run build` ✓
- `npm run test` ✓ — **1839 testes, 54 arquivos**
- Cascata comprovada por medição no navegador (tabela acima), não por dedução
- **No consumidor**, com este build instalado e o contorno do app removido: **0 bordas** resolvendo para a cor do texto, contra dezenas antes

## O que este PR NÃO resolve

Levantado no mesmo consumidor, fora de escopo aqui porque exige atualizar baselines visuais e decisão de design:

- **23 tokens semânticos sem par `--color-*`** — entre eles `--surface`, `--bg`, `--bg-subtle`, `--accent-brand`, `--button-bg`. Como o `@theme` não os expõe, `bg-surface` e afins **não geram utility alguma**: a classe existe na marcação e não pinta nada. Dois componentes do próprio pacote usam `bg-surface` hoje e renderizam transparente. Issue separada a caminho.
- `GuardiaLogo` é só a variante knockout (wordmark branco), invisível em fundo claro; falta `<Logo variant>` com as quatro versões oficiais
- `--accent` e `--border` guardam trio HSL enquanto os nomes `--color-*` guardam cor — a assimetria é a armadilha que causou o defeito nº 1
- `Table` sem densidade de grade de operação, sem subtexto e sem seleção
- `tw-animate-css` é `devDependency` mas a folha publicada faz `@import` dele em runtime
- 11 classes com sintaxe de valor arbitrário do v3 (`w-[--sidebar-width]`), inválidas no v4

## Nota de processo

O `CODEOWNERS` é `@fernandoseguim`, que é o autor deste PR — o GitHub não solicita review do próprio autor, então o PR fica sem reviewer e o item (h) de `lex-pr-quality` não é satisfeito automaticamente. Precisa de outra pessoa ou de ajuste no `CODEOWNERS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
