### PR TITLE
chore(release): bump design-system to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardiatechnology/design-system",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardiatechnology/design-system",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "workspaces": [
         "docs"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardiatechnology/design-system",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Closes #320

Version bump only. No source changes — the content of this release landed in #318.

## What ships in v0.3.0

**`fix(styles)` — default border-color survives the consumer preflight**

Tailwind v4 changed the default `border-color` from `gray-200` to `currentColor`, and the package has dozens of `border` / `border-b` with no color class. The corrective rule existed, but as `*` inside `@layer base` it tied on specificity (0,0,0) with the consumer's own preflight, emitted after this sheet — later declaration wins, rule discarded in silence.

Measured in a Next 15 consumer with violet-500 text: every `TableRow`, card, separator, input and popover rendered `borderBottomColor: rgb(68, 24, 109)`. Now `:root *` (0,1,0), which beats the preflight on specificity while staying in `base` so border-color utilities still win.

**`feat(tokens)` — `--action-fg` / `--color-action-fg`**

Completes the `--action` pair, matching `--danger`/`--danger-fg`, `--info`/`--info-fg`, `--warning`/`--warning-fg`. Additive.

## Why MINOR

`feat` present → MINOR per SemVer. The border change alters no existing declaration; the full visual suite passed unchanged on #318, which is the evidence that consumers see no unintended shift.

## Verification

- `npm run build` ✓
- `npm run test` ✓ — 1839 tests, 54 files
- Visual regression + a11y ✓ on #318
- Verified in a real consumer with the built package installed: 0 borders resolving to the text color, with the app-side workaround removed

## Not in this release

#319 — 23 semantic tokens with no `--color-*` pair, so `bg-surface` and friends generate no utility at all (two components in this package render transparent today). Held back deliberately: fixing it changes rendering on purpose and needs every visual baseline reviewed one by one.

## Process note

`CODEOWNERS` is `@fernandoseguim`, who authors this PR — GitHub will not request review from the author, so no reviewer is auto-requested and `lex-pr-quality` item (h) needs either another person or a `CODEOWNERS` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
