### PR TITLE
build: enable tree-shaking (sideEffects:false + per-component subpath exports)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,293 @@
   "name": "@guardiatechnology/design-system",
   "version": "0.3.0",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./styles.css": "./dist/styles/index.css"
+    "./styles.css": "./dist/styles/index.css",
+    "./accordion": {
+      "types": "./dist/components/accordion/index.d.ts",
+      "import": "./dist/components/accordion/index.js"
+    },
+    "./agent-card": {
+      "types": "./dist/components/agent-card/index.d.ts",
+      "import": "./dist/components/agent-card/index.js"
+    },
+    "./alert": {
+      "types": "./dist/components/alert/index.d.ts",
+      "import": "./dist/components/alert/index.js"
+    },
+    "./alert-dialog": {
+      "types": "./dist/components/alert-dialog/index.d.ts",
+      "import": "./dist/components/alert-dialog/index.js"
+    },
+    "./avatar": {
+      "types": "./dist/components/avatar/index.d.ts",
+      "import": "./dist/components/avatar/index.js"
+    },
+    "./badge": {
+      "types": "./dist/components/badge/index.d.ts",
+      "import": "./dist/components/badge/index.js"
+    },
+    "./badge-select": {
+      "types": "./dist/components/badge-select/index.d.ts",
+      "import": "./dist/components/badge-select/index.js"
+    },
+    "./breadcrumbs": {
+      "types": "./dist/components/breadcrumbs/index.d.ts",
+      "import": "./dist/components/breadcrumbs/index.js"
+    },
+    "./button": {
+      "types": "./dist/components/button/index.d.ts",
+      "import": "./dist/components/button/index.js"
+    },
+    "./button-group": {
+      "types": "./dist/components/button-group/index.d.ts",
+      "import": "./dist/components/button-group/index.js"
+    },
+    "./calendar": {
+      "types": "./dist/components/calendar/index.d.ts",
+      "import": "./dist/components/calendar/index.js"
+    },
+    "./card": {
+      "types": "./dist/components/card/index.d.ts",
+      "import": "./dist/components/card/index.js"
+    },
+    "./chart": {
+      "types": "./dist/components/chart/index.d.ts",
+      "import": "./dist/components/chart/index.js"
+    },
+    "./chat-message": {
+      "types": "./dist/components/chat-message/index.d.ts",
+      "import": "./dist/components/chat-message/index.js"
+    },
+    "./checkbox": {
+      "types": "./dist/components/checkbox/index.d.ts",
+      "import": "./dist/components/checkbox/index.js"
+    },
+    "./chip": {
+      "types": "./dist/components/chip/index.d.ts",
+      "import": "./dist/components/chip/index.js"
+    },
+    "./code-block": {
+      "types": "./dist/components/code-block/index.d.ts",
+      "import": "./dist/components/code-block/index.js"
+    },
+    "./code-editor": {
+      "types": "./dist/components/code-editor/index.d.ts",
+      "import": "./dist/components/code-editor/index.js"
+    },
+    "./collapsible": {
+      "types": "./dist/components/collapsible/index.d.ts",
+      "import": "./dist/components/collapsible/index.js"
+    },
+    "./combobox": {
+      "types": "./dist/components/combobox/index.d.ts",
+      "import": "./dist/components/combobox/index.js"
+    },
+    "./command": {
+      "types": "./dist/components/command/index.d.ts",
+      "import": "./dist/components/command/index.js"
+    },
+    "./confidence-indicator": {
+      "types": "./dist/components/confidence-indicator/index.d.ts",
+      "import": "./dist/components/confidence-indicator/index.js"
+    },
+    "./custom-icons": {
+      "types": "./dist/components/custom-icons/index.d.ts",
+      "import": "./dist/components/custom-icons/index.js"
+    },
+    "./data-table": {
+      "types": "./dist/components/data-table/index.d.ts",
+      "import": "./dist/components/data-table/index.js"
+    },
+    "./date-picker": {
+      "types": "./dist/components/date-picker/index.d.ts",
+      "import": "./dist/components/date-picker/index.js"
+    },
+    "./dialog": {
+      "types": "./dist/components/dialog/index.d.ts",
+      "import": "./dist/components/dialog/index.js"
+    },
+    "./drawer": {
+      "types": "./dist/components/drawer/index.d.ts",
+      "import": "./dist/components/drawer/index.js"
+    },
+    "./empty-state": {
+      "types": "./dist/components/empty-state/index.d.ts",
+      "import": "./dist/components/empty-state/index.js"
+    },
+    "./file-upload": {
+      "types": "./dist/components/file-upload/index.d.ts",
+      "import": "./dist/components/file-upload/index.js"
+    },
+    "./form": {
+      "types": "./dist/components/form/index.d.ts",
+      "import": "./dist/components/form/index.js"
+    },
+    "./form-layout": {
+      "types": "./dist/components/form-layout/index.d.ts",
+      "import": "./dist/components/form-layout/index.js"
+    },
+    "./icon-button": {
+      "types": "./dist/components/icon-button/index.d.ts",
+      "import": "./dist/components/icon-button/index.js"
+    },
+    "./input": {
+      "types": "./dist/components/input/index.d.ts",
+      "import": "./dist/components/input/index.js"
+    },
+    "./input-opt": {
+      "types": "./dist/components/input-opt/index.d.ts",
+      "import": "./dist/components/input-opt/index.js"
+    },
+    "./kanban": {
+      "types": "./dist/components/kanban/index.d.ts",
+      "import": "./dist/components/kanban/index.js"
+    },
+    "./label": {
+      "types": "./dist/components/label/index.d.ts",
+      "import": "./dist/components/label/index.js"
+    },
+    "./logo": {
+      "types": "./dist/components/logo/index.d.ts",
+      "import": "./dist/components/logo/index.js"
+    },
+    "./menu": {
+      "types": "./dist/components/menu/index.d.ts",
+      "import": "./dist/components/menu/index.js"
+    },
+    "./menubar": {
+      "types": "./dist/components/menubar/index.d.ts",
+      "import": "./dist/components/menubar/index.js"
+    },
+    "./metric-card": {
+      "types": "./dist/components/metric-card/index.d.ts",
+      "import": "./dist/components/metric-card/index.js"
+    },
+    "./multi-select": {
+      "types": "./dist/components/multi-select/index.d.ts",
+      "import": "./dist/components/multi-select/index.js"
+    },
+    "./navbar": {
+      "types": "./dist/components/navbar/index.d.ts",
+      "import": "./dist/components/navbar/index.js"
+    },
+    "./navigation-menu": {
+      "types": "./dist/components/navigation-menu/index.d.ts",
+      "import": "./dist/components/navigation-menu/index.js"
+    },
+    "./pagination": {
+      "types": "./dist/components/pagination/index.d.ts",
+      "import": "./dist/components/pagination/index.js"
+    },
+    "./popover": {
+      "types": "./dist/components/popover/index.d.ts",
+      "import": "./dist/components/popover/index.js"
+    },
+    "./progress": {
+      "types": "./dist/components/progress/index.d.ts",
+      "import": "./dist/components/progress/index.js"
+    },
+    "./radio": {
+      "types": "./dist/components/radio/index.d.ts",
+      "import": "./dist/components/radio/index.js"
+    },
+    "./scroll-area": {
+      "types": "./dist/components/scroll-area/index.d.ts",
+      "import": "./dist/components/scroll-area/index.js"
+    },
+    "./select": {
+      "types": "./dist/components/select/index.d.ts",
+      "import": "./dist/components/select/index.js"
+    },
+    "./separator": {
+      "types": "./dist/components/separator/index.d.ts",
+      "import": "./dist/components/separator/index.js"
+    },
+    "./sidebar": {
+      "types": "./dist/components/sidebar/index.d.ts",
+      "import": "./dist/components/sidebar/index.js"
+    },
+    "./sidebar-nav": {
+      "types": "./dist/components/sidebar-nav/index.d.ts",
+      "import": "./dist/components/sidebar-nav/index.js"
+    },
+    "./skeleton": {
+      "types": "./dist/components/skeleton/index.d.ts",
+      "import": "./dist/components/skeleton/index.js"
+    },
+    "./slider": {
+      "types": "./dist/components/slider/index.d.ts",
+      "import": "./dist/components/slider/index.js"
+    },
+    "./sonner": {
+      "types": "./dist/components/sonner/index.d.ts",
+      "import": "./dist/components/sonner/index.js"
+    },
+    "./spinner": {
+      "types": "./dist/components/spinner/index.d.ts",
+      "import": "./dist/components/spinner/index.js"
+    },
+    "./stepper": {
+      "types": "./dist/components/stepper/index.d.ts",
+      "import": "./dist/components/stepper/index.js"
+    },
+    "./switch": {
+      "types": "./dist/components/switch/index.d.ts",
+      "import": "./dist/components/switch/index.js"
+    },
+    "./table": {
+      "types": "./dist/components/table/index.d.ts",
+      "import": "./dist/components/table/index.js"
+    },
+    "./tabs": {
+      "types": "./dist/components/tabs/index.d.ts",
+      "import": "./dist/components/tabs/index.js"
+    },
+    "./textarea": {
+      "types": "./dist/components/textarea/index.d.ts",
+      "import": "./dist/components/textarea/index.js"
+    },
+    "./theme": {
+      "types": "./dist/theme/index.d.ts",
+      "import": "./dist/theme/index.js"
+    },
+    "./timeline": {
+      "types": "./dist/components/timeline/index.d.ts",
+      "import": "./dist/components/timeline/index.js"
+    },
+    "./toast": {
+      "types": "./dist/components/toast/index.d.ts",
+      "import": "./dist/components/toast/index.js"
+    },
+    "./toggle": {
+      "types": "./dist/components/toggle/index.d.ts",
+      "import": "./dist/components/toggle/index.js"
+    },
+    "./toggle-group": {
+      "types": "./dist/components/toggle-group/index.d.ts",
+      "import": "./dist/components/toggle-group/index.js"
+    },
+    "./tooltip": {
+      "types": "./dist/components/tooltip/index.d.ts",
+      "import": "./dist/components/tooltip/index.js"
+    },
+    "./top-bar": {
+      "types": "./dist/components/top-bar/index.d.ts",
+      "import": "./dist/components/top-bar/index.js"
+    },
+    "./tree": {
+      "types": "./dist/components/tree/index.d.ts",
+      "import": "./dist/components/tree/index.js"
+    },
+    "./typography": {
+      "types": "./dist/components/typography/index.d.ts",
+      "import": "./dist/components/typography/index.js"
+    }
   },
   "types": "./dist/index.d.ts",
   "files": [
@@ -26,6 +307,7 @@
   "scripts": {
     "init:env": "git config core.hooksPath .githooks && chmod -R +x ./.githooks",
     "build": "rslib build",
+    "postbuild": "node scripts/generate-exports.mjs",
     "dev": "rslib build --watch",
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",

--- a/scripts/generate-exports.mjs
+++ b/scripts/generate-exports.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Regenerates the per-subpath entries of package.json `exports` from the
+ * built `dist/components/*` and `dist/theme/` directories, so the map stays
+ * in sync with the actual component set instead of being hand-maintained.
+ *
+ * Fixes #315 (design-system tree-shaking): the barrel-only `exports` map
+ * (only `.` and `./styles.css`) forces bundlers to pull in the whole
+ * library even when a consumer imports a single component. This script
+ * adds one subpath per component (`./button`, `./table`, ...) plus
+ * `./theme`, each pointing at the already-tree-shaken per-file build
+ * output that `rslib build` produces (bundle: false in rslib.config.ts).
+ *
+ * Wired as the `postbuild` script, so it runs automatically after
+ * `npm run build` / `rslib build`. It only rewrites `exports`; every other
+ * package.json field (and key order) is left untouched. The resulting
+ * package.json must be committed — the GitHub Packages publish workflow
+ * (.github/workflows/publish.yml) publishes the package.json already on
+ * disk at tag time, it does not re-run this script.
+ */
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkgPath = join(rootDir, "package.json");
+const distComponentsDir = join(rootDir, "dist", "components");
+const distThemeIndex = join(rootDir, "dist", "theme", "index.js");
+
+function readPkg() {
+  return JSON.parse(readFileSync(pkgPath, "utf8"));
+}
+
+function listComponentNames() {
+  if (!existsSync(distComponentsDir)) {
+    console.error(
+      `[generate-exports] dist/components not found at ${distComponentsDir}. Run "rslib build" before this script (it runs automatically as "postbuild").`,
+    );
+    process.exit(1);
+  }
+
+  return readdirSync(distComponentsDir)
+    .filter((name) => {
+      const full = join(distComponentsDir, name);
+      return statSync(full).isDirectory() && existsSync(join(full, "index.js"));
+    })
+    .sort();
+}
+
+function buildExportsMap(pkg) {
+  const prev = pkg.exports ?? {};
+
+  // "." and "./styles.css" are hand-maintained; every other key is derived.
+  const exportsMap = {
+    ".": prev["."] ?? { types: "./dist/index.d.ts", import: "./dist/index.js" },
+    "./styles.css": prev["./styles.css"] ?? "./dist/styles/index.css",
+  };
+
+  const subpaths = listComponentNames();
+  if (existsSync(distThemeIndex)) {
+    subpaths.push("theme");
+    subpaths.sort();
+  }
+
+  for (const name of subpaths) {
+    const dir = name === "theme" ? "theme" : `components/${name}`;
+    exportsMap[`./${name}`] = {
+      types: `./dist/${dir}/index.d.ts`,
+      import: `./dist/${dir}/index.js`,
+    };
+  }
+
+  return exportsMap;
+}
+
+function main() {
+  const pkg = readPkg();
+  const prevExports = pkg.exports ?? {};
+  const nextExports = buildExportsMap(pkg);
+
+  const changed = JSON.stringify(prevExports) !== JSON.stringify(nextExports);
+  pkg.exports = nextExports;
+
+  const subpathCount = Object.keys(nextExports).length - 2; // minus "." and "./styles.css"
+
+  if (changed) {
+    writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+    console.log(
+      `[generate-exports] package.json exports map updated: ${subpathCount} subpath entries (components + theme) in sync with dist/components/*.`,
+    );
+  } else {
+    console.log(
+      `[generate-exports] package.json exports map already up to date (${subpathCount} subpath entries).`,
+    );
+  }
+}
+
+main();

--- a/ui_kit/theme/index.ts
+++ b/ui_kit/theme/index.ts
@@ -1,0 +1,10 @@
+// Barrel for the `./theme` subpath export (see package.json `exports`).
+// Mirrors the per-component pattern in `ui_kit/components/*` so
+// `scripts/generate-exports.mjs` can derive `./theme` from `dist/theme/index.js`
+// the same way it derives `./button`, `./table`, etc. from `dist/components/*`.
+//
+// The root barrel (`ui_kit/index.tsx`) keeps exporting `theme-provider` and
+// `theme-toggle` directly for backward compatibility; this file does not
+// change that behavior.
+export * from './theme-provider';
+export * from './theme-toggle';


### PR DESCRIPTION
## Summary

Closes #315.

Consumers importing a single component (e.g. `Button`) shipped the entire library — `recharts`, `react-router`, `cmdk`, `react-day-picker`, `react-select`, etc. — because `package.json` had no `sideEffects` field and `exports` only exposed the barrel (`.`) and `./styles.css`. This PR fixes both root causes named in the issue, additively:

- **`"sideEffects": false`** added to `package.json`. Verified (see below) that this does not strip the CSS export — no JS module under `ui_kit/` imports a `.css` file or performs module-scope side effects; the stylesheet is a fully separate `./styles.css` export that consumers import explicitly.
- **Per-component subpath exports** added to `exports` for all 69 components plus a new `./theme` entry (`ThemeProvider` + `ThemeToggle`), generated rather than hand-maintained: `scripts/generate-exports.mjs` runs as `postbuild` (after `npm run build` / `rslib build`) and derives one subpath per `dist/components/*` directory that has an `index.js`, so the map can't drift from the actual build output. A small `ui_kit/theme/index.ts` barrel was added (mirroring the per-component pattern) so `./theme` has something to point at — this is additive and does not change the existing root barrel, which still exports `theme-provider`/`theme-toggle` directly.
- The **`.` barrel export is untouched** — existing consumers (e.g. `guardia/landing-pages`) keep working with zero code changes.

## Why generated instead of hand-written

The issue asked for this "ideally generated so it stays in sync with `dist/components/*`." Hand-maintaining 69 entries would drift the first time a component is added/removed/renamed. `postbuild` regenerates and rewrites the `exports` block in `package.json` deterministically (only that key; every other field and key order is left alone) and is idempotent — running it twice with no component changes makes no further edit.

**Known tradeoff (documented, not silently swept):** the `publish` job in `.github/workflows/publish.yml` does *not* re-run `npm run build` — it downloads the `dist/` artifact from the `build` job and publishes directly from a fresh checkout of `package.json`. That means the generated `exports` map must be committed (as it is in this PR) before tagging a release; the publish job will not regenerate it on its own. This PR intentionally does not touch `publish.yml` to stay scoped to #315 — a follow-up could add a CI check that fails if `package.json`'s `exports` drifts from a fresh `postbuild` run, to catch a forgotten regeneration before it ships.

## Verification (definition of done from #315)

All done against a real build of this branch, not just by inspection.

**1. Build produces the expected output and the exports map matches it**
```
$ npm run build
...
84 files generated in dist (esm)
Total size: 567.9 kB (141.6 kB gzipped)

> postbuild
> node scripts/generate-exports.mjs
[generate-exports] package.json exports map updated: 70 subpath entries (components + theme) in sync with dist/components/*.
```
`dist/components/<name>/index.js` + `index.d.ts` exist for all 69 components; `dist/theme/index.js` + `.d.ts` exist for the new theme barrel. Running `postbuild` again with no changes reports "already up to date" (idempotent).

**2. Typecheck and tests pass**
```
$ npm run typecheck   # tsc -p tsconfig.test.json --noEmit
(clean, no errors)

$ npm run test        # vitest run
Test Files  54 passed (54)
     Tests  1839 passed (1839)
```

**3. Tree-shaking proof — throwaway Vite 6 consumer**

Set up a scratch app (`file:` dependency pointing at this branch's checkout) with three entry points, each built with `vite build`:

| Entry | Import | JS bundle | recharts / react-router / cmdk / react-day-picker / react-select found? |
|---|---|---|---|
| Baseline (issue #315, downstream `guardia/landing-pages` #62, 9 components via barrel, pre-fix) | `import { Button, Input, ... } from "@guardiatechnology/design-system"` | **714.99 kB / 215.52 kB gzip** | yes (dragged in regardless) |
| `subpath-entry.jsx` | `import { Button } from "@guardiatechnology/design-system/button"` | **224.12 kB / 70.48 kB gzip** | **0 occurrences of any of the 5 markers** |
| `barrel-entry.jsx` | `import { Button } from "@guardiatechnology/design-system"` (unchanged existing path) | **224.12 kB / 70.48 kB gzip** — byte-identical to the subpath build (`diff` confirms) | **0 occurrences** |
| `control-entry.jsx` (sanity check) | `import { ChartContainer } from "@guardiatechnology/design-system/chart"` (Chart genuinely uses recharts) | 243.72 kB / 77.77 kB gzip | `recharts` string present (15 occurrences) — confirms the 0-occurrence results above are real elimination, not a broken import |

The ~224 kB remaining in the Button-only build is React + ReactDOM client baseline for this throwaway app, not design-system weight.

Interesting result beyond the letter of the issue: because `sideEffects: false` lets Rollup shake straight through the `export *` barrel chain (not just resolve narrower subpath entry points), **the existing barrel import path also becomes fully tree-shakeable** in a modern Rollup/Vite consumer — existing consumers get the fix without migrating any import statements. The subpath exports remain valuable as an explicit, guaranteed-narrow entry point (useful for tooling that can't shake through barrels, and for clarity of intent).

**4. Stylesheet not stripped by `sideEffects: false`**

A fourth build explicitly importing `@guardiatechnology/design-system/styles.css` alongside the `Button` subpath still emits the full stylesheet:
```
dist-css/assets/index-css-*.css   57.23 kB │ gzip: 11.61 kB
```

**5. Barrel import path unchanged**

Confirmed above (`barrel-entry.jsx`) — `import { Button } from "@guardiatechnology/design-system"` still resolves and renders correctly, no consumer code changes required.

## Scope

Only the tree-shaking fix from #315: `sideEffects`, generated `exports` subpaths, the minimal `./theme` barrel needed to expose it, and the `postbuild` wiring. No component API/behavior changes, no unrelated refactors, lint fixes, or dependency bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)