### PR TITLE
fix(styles): @source glob must match compiled *.js, not just *.tsx

### DIFF
--- a/ui_kit/styles/index.css
+++ b/ui_kit/styles/index.css
@@ -27,9 +27,25 @@
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Poppins:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap");
 
 /* Garante que o Tailwind escaneie todos os componentes do ui_kit
-   (o path é relativo a este arquivo) */
-@source "../components/**/*.{ts,tsx}";
-@source "../theme/**/*.{ts,tsx}";
+   (o path é relativo a este arquivo).
+ *
+ * A extensão `.js` é necessária porque este mesmo arquivo é copiado
+ * verbatim para `dist/styles/index.css` (rslib.config.ts `output.copy`) e
+ * publicado no pacote. No pacote publicado, `../components/` e `../theme/`
+ * resolvem para `dist/components/` e `dist/theme/`, que só contêm `*.js`
+ * (compilado) e `*.d.ts` (apenas tipos, sem os literais de classe usados
+ * pelos `cva()`) — nunca `*.tsx`. Sem `.js` no glob, o scanner automático
+ * do Tailwind v4 não encontra nenhuma string de classe utilitária real em
+ * um consumidor do pacote publicado, e as classes estruturais dos
+ * componentes (ex.: `h-10`, `px-4`, `rounded-md`, `whitespace-nowrap` do
+ * Button) são podadas por purge — o componente renderiza sem essas
+ * classes, silenciosamente, sem erro de build. Refs #323.
+ *
+ * Mantemos `.tsx`/`.ts` porque Storybook e o site de docs (`docs/`) importam
+ * este arquivo diretamente do source (`ui_kit/styles/index.css`), onde
+ * `../components/**` e `../theme/**` ainda são `.tsx`. */
+@source "../components/**/*.{ts,tsx,js}";
+@source "../theme/**/*.{ts,tsx,js}";
 
 /* Dark mode variant — driven by data-theme OR .dark class */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *, .dark, .dark *));


### PR DESCRIPTION
## Why

Closes #323.

`ui_kit/styles/index.css` declared:

```css
@source "../components/**/*.{ts,tsx}";
@source "../theme/**/*.{ts,tsx}";
```

`rslib.config.ts` copies this file verbatim into `dist/styles/index.css` (`output.copy`), so in the **published** package the glob resolves to `dist/components/**/*.{ts,tsx}` / `dist/theme/**/*.{ts,tsx}`. But `dist/` only ever ships compiled `*.js` and declaration-only `*.d.ts` — never `*.tsx`. `.d.ts` files match the glob's `.ts` half but contain only type signatures, not the literal utility-class strings that live in the compiled `.js` body of each `cva()` call.

Result: Tailwind's automatic content scanner in **every consumer of the published package** finds zero real class-name literals via this `@source`, so structural utilities baked into the library's own components (Button's `h-10`, `px-4`, `rounded-md`, `whitespace-nowrap`, etc.) get purged — silently, no build error. Components render with the right `className` output but no matching CSS rule.

## What

```diff
-@source "../components/**/*.{ts,tsx}";
-@source "../theme/**/*.{ts,tsx}";
+@source "../components/**/*.{ts,tsx,js}";
+@source "../theme/**/*.{ts,tsx,js}";
```

Adding `js` to the brace expansion makes the glob also match `dist/**/*.js` in the published package, while the existing `.ts`/`.tsx` pattern keeps matching the local `ui_kit/**/*.tsx` sources that Storybook and the docs Astro site scan directly (they import `ui_kit/styles/index.css`, not the built `dist/` version). Purely additive — no existing consumer behavior changes except that the previously-purged classes now survive.

## Evidence

### Before (production — `guardia/landing-pages`, `apps/growth`, depends on `@guardiatechnology/design-system@^0.2.0`)

```
$ yarn workspace @guardia/growth build
...
$ grep -l "guardia-purple-500" dist/_astro/*.css
dist/_astro/index.CuhtGZAq.css   # 34,331 bytes

$ grep -o '\.rounded-md[,{]\|\.h-10[,{]\|\.whitespace-nowrap[,{]\|\.px-4[,{]\|\.inline-flex[,{]' dist/_astro/index.CuhtGZAq.css
(no output — all missing)

$ grep -o '\.bg-primary[,{]' dist/_astro/index.CuhtGZAq.css
.bg-primary{   # present -- color utility referenced literally by the Admin's OWN source
```

The Admin's real production CSS bundle ships the DS's brand color tokens but is missing every structural utility Button/Card/etc. depend on via `cva()`. Confirmed today, on `main` of this repo, before this PR.

### Before (isolated repro — throwaway Vite + React 19 app, `@tailwindcss/vite`, DS installed via `file:` dependency on a clean clone of `main`, only `import "@guardiatechnology/design-system/styles.css"` + `<Button>Ver transações</Button>`)

```
CSS bundle: dist/assets/index-1WdBhrSH.css (30,345 bytes)
--guardia-purple-500:#552973;
  .rounded-md      -> MISSING
  .h-10            -> MISSING
  .whitespace-nowrap -> MISSING
  .px-4            -> MISSING
  .inline-flex     -> MISSING
  .gap-2           -> MISSING
```

### After (same throwaway consumer, DS rebuilt with this PR's fix)

```
CSS bundle: dist/assets/index-D01n2LYb.css (133,924 bytes)
  .rounded-md        -> .rounded-md{
  .h-10              -> .h-10{
  .whitespace-nowrap -> .whitespace-nowrap{
  .px-4              -> .px-4{
  .inline-flex       -> .inline-flex{
  .gap-2             -> .gap-2{
```

(CSS grew because the barrel-import consumer's Tailwind build can now see class literals across the whole `dist/components/**` tree, not just Button's — expected, and orthogonal to the tree-shaking work in #315/#322.)

## Verification

- [x] `npm run build` — succeeds, `dist/styles/index.css` carries the updated `@source` lines
- [x] `npm run typecheck` — passes, no errors (CSS-only change)
- [x] `npm run test` — 54 test files / 1839 tests pass, unaffected
- [x] Throwaway Vite consumer before/after comparison above
- [x] Confirmed real production impact against `guardia/landing-pages` `apps/growth` before merging this fix

## Relationship to #315 / #322

Independent. #322 (tree-shaking: `sideEffects: false` + per-component subpath exports) is still open, unmerged, and untouched by this PR — this branch is based on `main`, not on `fix/315-tree-shaking-subpath-exports`, so the two can merge in either order without a dependency between them. This PR touches only `ui_kit/styles/index.css`.
