### PR TITLE
chore(release): bump design-system to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardiatechnology/design-system",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardiatechnology/design-system",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "workspaces": [
         "docs"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardiatechnology/design-system",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
Closes #325.

Bumps `package.json`/`package-lock.json` to `0.4.0` (MINOR — #322 adds a
new backward-compatible subpath-export surface; #324 is a pure bug fix).

Next: merge, tag `v0.4.0` (annotated + signed) on the merge commit, push
the tag to trigger `publish.yml`, then create the GitHub Release.